### PR TITLE
Add access field to case metadata

### DIFF
--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -510,11 +510,25 @@ class InitializeCase(ExportData):  # pylint: disable=too-few-public-methods
 
         meta = self._meta_dollars.copy()
         meta["class"] = "case"
+
         meta["fmu"] = OrderedDict()
         meta["fmu"]["case"] = c_meta
         meta["fmu"]["model"] = self._meta_fmu["model"]
+
+        # Should not be possible to initialize a case without
+        # the access.asset field be present.
+        # Outgoing case metadata should contain access.asset only
+        if not self._meta_access:
+            logger.debug("self._meta_access is %s", str(self._meta_access))
+            logger.error("Cannot proceed without access information.")
+            raise ValueError("Access information missing.")
+        if not "asset" in self._meta_access.keys():
+            logger.error("the access field in the metadata was missing the asset field")
+        meta["access"] = {"asset": self._meta_access["asset"]}
+
         meta["masterdata"] = self._meta_masterdata
         meta["tracklog"] = list()
+
         track = OrderedDict()
 
         track["datetime"] = datetime.datetime.now().isoformat()

--- a/tests/test_fmu_dataio_case.py
+++ b/tests/test_fmu_dataio_case.py
@@ -18,6 +18,7 @@ CFG["masterdata"] = {
 CFG["stratigraphy"] = {"TopVolantis": {}}
 CFG["access"] = {"someaccess": "jail"}
 CFG["model"] = {"revision": "0.99.0"}
+CFG["access"] = {"asset": "Drogon", "ssdl": "internal"}
 
 RUN = "tests/data/drogon/ertrun1/realization-0/iter-0/rms"
 


### PR DESCRIPTION
Case metadata must contain the access field, but only the "asset". Ref #19 