### PR TITLE
WIP: Handle undef

### DIFF
--- a/src/fmu/dataio/_export_item.py
+++ b/src/fmu/dataio/_export_item.py
@@ -25,6 +25,7 @@ ALLOWED_CONTENTS = [
     "undefined",
 ]
 
+
 logger = logging.getLogger(__name__)
 
 
@@ -316,6 +317,8 @@ class _ExportItem:  # pylint disable=too-few-public-methods
         Note that 'format' field will be added in _item_to_file
         """
 
+        logging.info("starting _data_process_object")
+
         if self.subtype == "RegularSurface":
             self._data_process_object_regularsurface()
         elif self.subtype == "Polygons":
@@ -342,7 +345,11 @@ class _ExportItem:  # pylint disable=too-few-public-methods
                 val = float(val)
             newspecs[spec] = val
         meta["spec"] = newspecs
-        meta["spec"]["undef"] = 1.0e30  # irap binary undef
+
+        _undef = self.dataio._undef
+        if _undef is None:
+            _undef = self.dataio.default_undef.get("RegularSurface")
+        meta["spec"]["undef"] = _undef
 
         meta["bbox"] = OrderedDict()
         meta["bbox"]["xmin"] = float(regsurf.xmin)
@@ -364,6 +371,12 @@ class _ExportItem:  # pylint disable=too-few-public-methods
         meta["spec"] = OrderedDict()
         # number of polygons:
         meta["spec"]["npolys"] = np.unique(poly.dataframe[poly.pname].values).size
+
+        _undef = self.dataio._undef
+        if _undef is None:
+            _undef = self.dataio.default_undef.get("Polygons")
+        meta["spec"]["undef"] = _undef
+
         xmin, xmax, ymin, ymax, zmin, zmax = poly.get_boundary()
 
         meta["bbox"] = OrderedDict()
@@ -390,7 +403,11 @@ class _ExportItem:  # pylint disable=too-few-public-methods
         meta["spec"] = OrderedDict()
         meta["spec"]["columns"] = list(dfr.columns)
         meta["spec"]["size"] = int(dfr.size)
-        meta["spec"]["undef"] = "Nan"
+
+        _undef = self.dataio._undef
+        if _undef is None:
+            _undef = self.dataio.default_undef.get("Dataframe")
+        meta["spec"]["undef"] = _undef
 
         meta["bbox"] = None
         logger.info("Process data metadata for DataFrame... done!!")

--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -77,6 +77,12 @@ class ExportData:
     createfolder = True
     meta_format = "yaml"
 
+    default_undef = {
+        "RegularSurface": 1.0e30,  # irap binary undef
+        "Dataframe": -999.25,
+        "Polygons": -999.25,
+    }
+
     def __init__(
         self,
         name: Optional[str] = None,
@@ -92,6 +98,7 @@ class ExportData:
         workflow: Optional[str] = None,
         access_ssdl: Optional[dict] = None,
         runfolder: Optional[str] = None,
+        undef: Optional[float] = None,
         verbosity: Optional[str] = "CRITICAL",
     ) -> None:
         """Instantate ExportData object.
@@ -144,6 +151,8 @@ class ExportData:
         self._workflow = workflow
         self._access_ssdl = access_ssdl
         self._verbosity = verbosity
+
+        self._undef = undef
 
         # keep track if case
         self._case = False

--- a/tests/test_export_item.py
+++ b/tests/test_export_item.py
@@ -180,3 +180,49 @@ def test_data_process_content():
     exportitem._data_process_content()
     assert dataio._meta_data["content"] == "seismic"
     assert dataio._meta_data["seismic"]["attribute"] == "attribute_timeshifted_somehow"
+
+
+def test_data_process_object_regularsurface():
+    """Test the data_process_object for regularsurface function.
+    * Check that subtype is present in dataio.default_undef
+    * spec.undef value is correctly set
+    * bbox present and valid
+    * layout present and == "regular"
+    """
+
+    subtype = "RegularSurface"
+    obj = xtgeo.RegularSurface(name="SomeName")
+
+    # test case 1 - use default undef
+    dataio = fmu.dataio.ExportData()
+    exportitem = ei._ExportItem(dataio, obj, verbosity="INFO")
+    exportitem.subtype = subtype
+    exportitem._data_process_object()
+    _default = dataio.default_undef[subtype]  # also checking presence
+    assert dataio._meta_data["spec"]["undef"] == _default
+
+    assert dataio._meta_data["bbox"]["xmin"] == float(obj.xmin)
+    assert dataio._meta_data["bbox"]["xmax"] == float(obj.xmax)
+    assert dataio._meta_data["bbox"]["ymin"] == float(obj.ymin)
+    assert dataio._meta_data["bbox"]["ymax"] == float(obj.ymax)
+    assert dataio._meta_data["bbox"]["zmin"] == float(obj.values.min())
+    assert dataio._meta_data["bbox"]["zmax"] == float(obj.values.max())
+
+    assert dataio._meta_data["layout"] == "regular"
+
+    # test case 2 - set undef with argument
+    dataio = fmu.dataio.ExportData(undef=1.0)
+    exportitem = ei._ExportItem(dataio, obj, verbosity="INFO")
+    exportitem.subtype = subtype
+    exportitem._data_process_object()
+    assert dataio._meta_data["spec"]["undef"] == 1.0
+
+
+def test_data_process_object_polygons():
+    """Test the data_process_object function for polygons subtype."""
+    # placeholder
+
+
+def test_data_process_object_dataframe():
+    """Test the data_process_object function for dataframe subtype."""
+    # placeholder


### PR DESCRIPTION
Ref #39 
Attempting a better handle of undef by allowing it to be passed as argument.
If not passed by argument, defaults will be used as before.
Defaults moved to class variable.

- [ ] Agree on patterns. Some code repetition now between the different subtype-specific methods. But putting it on the outside makes it unintuitive to read. (Still smells a bit.)
- [ ] Complete tests for `_process_data_object` for remaining datatypes (polygons/tables)