### PR TITLE
remove data.spec.undef from outgoing table metadata

### DIFF
--- a/src/fmu/dataio/_export_item.py
+++ b/src/fmu/dataio/_export_item.py
@@ -390,7 +390,6 @@ class _ExportItem:  # pylint disable=too-few-public-methods
         meta["spec"] = OrderedDict()
         meta["spec"]["columns"] = list(dfr.columns)
         meta["spec"]["size"] = int(dfr.size)
-        meta["spec"]["undef"] = "Nan"
 
         meta["bbox"] = None
         logger.info("Process data metadata for DataFrame... done!!")


### PR DESCRIPTION
I think #40 needs more discussion. Meanwhile, propose to remove the outgoing `data.spec.undef` value for tables to avoid mixed-type in the output `data.spec.undef` for surfaces is a float and make table data validate against current 0.8.0 schema.