### PR TITLE
Read justified-formatted parameters txt

### DIFF
--- a/src/fmu/dataio/_utils.py
+++ b/src/fmu/dataio/_utils.py
@@ -218,15 +218,15 @@ def read_parameters_txt(pfile):
     logger.debug("Reading parameters.txt from {}".format(pfile))
 
     with open(pfile, "r") as stream:
-        buffer_ = stream.read().splitlines()
+        buffer = stream.read().splitlines()
 
-    logger.debug("buffer_ is of type {}".format(type(buffer_)))
-    logger.debug("buffer_ has {} lines".format(len(buffer_)))
+    logger.debug("buffer is of type {}".format(type(buffer)))
+    logger.debug("buffer has {} lines".format(len(buffer)))
 
-    buffer_ = [":".join(line.split()) for line in buffer_]
+    buffer = [":".join(line.split()) for line in buffer]
 
     param = OrderedDict()
-    for line in buffer_:
+    for line in buffer:
         items = line.split(":")
         if len(items) == 2:
             param[items[0]] = check_if_number(items[1])

--- a/src/fmu/dataio/_utils.py
+++ b/src/fmu/dataio/_utils.py
@@ -191,6 +191,21 @@ def read_parameters_txt(pfile):
       LOG10_MULTREGT:MULT_THERYS_VOLON -3.21365
       LOG10_MULTREGT:MULT_VALYSAR_THERYS -3.2582
 
+    Or the structure::
+                            SENSNAME     rms_seed
+                            SENSCASE     p10_p90
+                            RMS_SEED     1000
+                        KVKH_CHANNEL     0.6
+                       KVKH_CREVASSE     0.3
+      GLOBVAR:VOLON_FLOODPLAIN_VOLFRAC   0.256355
+          GLOBVAR:VOLON_PERMH_CHANNEL    1100
+           GLOBVAR:VOLON_PORO_CHANNEL    0.2
+      LOG10_GLOBVAR:FAULT_SEAL_SCALING   0.685516
+      LOG10_MULTREGT:MULT_THERYS_VOLON   -3.21365
+      LOG10_MULTREGT:MULT_VALYSAR_THERYS -3.2582
+
+    ...where leading whitespace is space, separator is tab
+
     This should be parsed as::
 
         {
@@ -203,11 +218,18 @@ def read_parameters_txt(pfile):
         }
     """
 
+    logger.debug("Reading parameters.txt from {}".format(pfile))
+
     with open(pfile, "r") as stream:
-        buffer = stream.read().replace(" ", ":").splitlines()
+        buffer_ = stream.read().splitlines()
+
+    logger.debug("buffer_ is of type {}".format(type(buffer_)))
+    logger.debug("buffer_ has {} lines".format(len(buffer_)))
+
+    buffer_ = [":".join(line.split()) for line in buffer_]
 
     param = OrderedDict()
-    for line in buffer:
+    for line in buffer_:
         items = line.split(":")
         if len(items) == 2:
             param[items[0]] = check_if_number(items[1])

--- a/src/fmu/dataio/_utils.py
+++ b/src/fmu/dataio/_utils.py
@@ -191,20 +191,17 @@ def read_parameters_txt(pfile):
       LOG10_MULTREGT:MULT_THERYS_VOLON -3.21365
       LOG10_MULTREGT:MULT_VALYSAR_THERYS -3.2582
 
-    Or the structure::
+    ...but may also appear on a justified format, with leading
+    whitespace and tab-justified columns, legacy from earlier
+    versions but kept alive by some users::
+
                             SENSNAME     rms_seed
                             SENSCASE     p10_p90
                             RMS_SEED     1000
                         KVKH_CHANNEL     0.6
-                       KVKH_CREVASSE     0.3
-      GLOBVAR:VOLON_FLOODPLAIN_VOLFRAC   0.256355
           GLOBVAR:VOLON_PERMH_CHANNEL    1100
-           GLOBVAR:VOLON_PORO_CHANNEL    0.2
       LOG10_GLOBVAR:FAULT_SEAL_SCALING   0.685516
       LOG10_MULTREGT:MULT_THERYS_VOLON   -3.21365
-      LOG10_MULTREGT:MULT_VALYSAR_THERYS -3.2582
-
-    ...where leading whitespace is space, separator is tab
 
     This should be parsed as::
 

--- a/src/fmu/dataio/_utils.py
+++ b/src/fmu/dataio/_utils.py
@@ -215,13 +215,13 @@ def read_parameters_txt(pfile):
         }
     """
 
-    logger.debug("Reading parameters.txt from {}".format(pfile))
+    logger.debug("Reading parameters.txt from %s", pfile)
 
     with open(pfile, "r") as stream:
         buffer = stream.read().splitlines()
 
-    logger.debug("buffer is of type {}".format(type(buffer)))
-    logger.debug("buffer has {} lines".format(len(buffer)))
+    logger.debug("buffer is of type %s", type(buffer))
+    logger.debug("buffer has %s lines", str(len(buffer)))
 
     buffer = [":".join(line.split()) for line in buffer]
 

--- a/tests/data/drogon/ertrun1/realization-0/iter-0/parameters_justified.txt
+++ b/tests/data/drogon/ertrun1/realization-0/iter-0/parameters_justified.txt
@@ -1,0 +1,15 @@
+                               SENSNAME    rms_seed
+                               SENSCASE    p10_p90
+                               RMS_SEED    1000
+                           KVKH_CHANNEL    0.6
+                          KVKH_CREVASSE    0.3
+       GLOBVAR:VOLON_FLOODPLAIN_VOLFRAC    0.256355
+            GLOBVAR:VOLON_PERMH_CHANNEL    1100
+             GLOBVAR:VOLON_PORO_CHANNEL    0.2
+       LOG10_GLOBVAR:FAULT_SEAL_SCALING    0.685516
+       LOG10_MULTREGT:MULT_THERYS_VOLON    -3.21365
+     LOG10_MULTREGT:MULT_VALYSAR_THERYS    -3.2582
+      INIT_FILES:AQUA_TRANS_FACTOR_NORM    -0.89905
+        INIT_FILES:AQUA_VOL_FACTOR_NORM    0.823781
+                     INIT_FILES:BW_NORM    -0.0898115
+LONGNAME_LONGNAME_LONGNAME_LONGNAME_LONGN  value

--- a/tests/test_fmu_dataio_utils.py
+++ b/tests/test_fmu_dataio_utils.py
@@ -123,7 +123,7 @@ def test_uuid_from_string():
 
 
 def test_parse_parameters_txt():
-    """Testing parsing of paramaters.txt to JSON"""
+    """Testing parsing of parameters.txt to JSON"""
 
     ptext = "tests/data/drogon/ertrun1/realization-1/iter-0/parameters.txt"
 
@@ -131,3 +131,15 @@ def test_parse_parameters_txt():
 
     assert res["SENSNAME"] == "rms_seed"
     assert res["GLOBVAR"]["VOLON_PERMH_CHANNEL"] == 1100
+
+
+def test_parse_parameters_txt_justified():
+    """Testing parsing of justified parameters.txt to JSON"""
+
+    ptext = "tests/data/drogon/ertrun1/realization-0/iter-0/parameters_justified.txt"
+
+    res = _utils.read_parameters_txt(ptext)
+
+    assert res["SENSNAME"] == "rms_seed"
+    assert res["GLOBVAR"]["VOLON_PERMH_CHANNEL"] == 1100
+    assert res["LOG10_MULTREGT"]["MULT_VALYSAR_THERYS"] == -3.2582


### PR DESCRIPTION
Solving #53 by stripping whitespace from parameters.txt contents before parsing it. Also added testing for a negative float value, and renamed the `buffer` variable to `buffer_` to avoid overwriting the `buffer` type.