### PR TITLE
Use surface as class

### DIFF
--- a/src/fmu/dataio/_export_item.py
+++ b/src/fmu/dataio/_export_item.py
@@ -97,7 +97,7 @@ class _ExportItem:  # pylint disable=too-few-public-methods
         logger.info("Save to file...")
         if isinstance(self.obj, xtgeo.RegularSurface):
             self.subtype = "RegularSurface"
-            self.classname = "regularsurface"
+            self.classname = "surface"
         elif isinstance(self.obj, xtgeo.Polygons):
             self.subtype = "Polygons"
             self.classname = "polygons"

--- a/tests/test_fmu_dataio_surface.py
+++ b/tests/test_fmu_dataio_surface.py
@@ -49,8 +49,6 @@ def test_surface_io(tmp_path):
     assert (tmp_path / "maps" / ".test.gri.yml").is_file() is True
 
 
-
-
 def test_surface_io_larger_case(tmp_path):
     """Larger test surface io, uses global config from Drogon to tmp_path."""
 

--- a/tests/test_fmu_dataio_surface.py
+++ b/tests/test_fmu_dataio_surface.py
@@ -49,6 +49,8 @@ def test_surface_io(tmp_path):
     assert (tmp_path / "maps" / ".test.gri.yml").is_file() is True
 
 
+
+
 def test_surface_io_larger_case(tmp_path):
     """Larger test surface io, uses global config from Drogon to tmp_path."""
 
@@ -137,6 +139,7 @@ def test_surface_io_larger_case_ertrun(tmp_path):
         meta["file"]["relative_path"]
         == "realization-0/iter-0/share/results/maps/topvolantis--what_descr.gri"
     )
+    assert meta["class"] == "surface", meta["class"]
     assert meta["fmu"]["model"]["name"] == "ff"
     assert meta["fmu"]["iteration"]["name"] == "iter-0"
     assert meta["fmu"]["realization"]["name"] == "realization-0"


### PR DESCRIPTION
Solving #57 

For later surface subtypes (e.g. structuredsurface), the classname should also be `surface`.