### PR TITLE
content fluid contact

### DIFF
--- a/src/fmu/dataio/_export_item.py
+++ b/src/fmu/dataio/_export_item.py
@@ -298,7 +298,7 @@ class _ExportItem:  # pylint disable=too-few-public-methods
             useextra = content[usecontent]
 
         else:
-            raise ValidationError(f"content must be string or dict")
+            raise ValidationError("content must be string or dict")
 
         if usecontent not in ALLOWED_CONTENTS.keys():
             raise ValidationError(

--- a/tests/test_export_item.py
+++ b/tests/test_export_item.py
@@ -246,8 +246,36 @@ def test_data_process_content_shall_fail():
     assert "is not valid for" in str(errmsg)
 
 
+def test_data_process_content_validate():
+    """Test the content validation"""
+
+    # test case 1 - fluid contact, valid
+    dataio = fmu.dataio.ExportData(
+        name="Valysar",
+        config=CFG2,
+        content={"fluid_contact": {"contact": "owc"}},
+    )
+    obj = xtgeo.Polygons()
+    exportitem = ei._ExportItem(dataio, obj, verbosity="INFO")
+    exportitem._data_process_content()
+
+    assert "fluid_contact" in dataio._meta_data
+
+    # test case 2 - fluid contact, not valid, shall fail
+    dataio = fmu.dataio.ExportData(
+        name="SomeName",
+        config=CFG2,
+        content="fluid_contact",
+    )
+    obj = xtgeo.Polygons()
+    exportitem = ei._ExportItem(dataio, obj, verbosity="DEBUG")
+    with pytest.raises(ei.ValidationError):
+        exportitem._data_process_content()
+
+
 def test_data_process_content_fluid_contact():
     """Test the field fluid_contact."""
+
     # test case 1
     dataio = fmu.dataio.ExportData(
         name="Valysar",


### PR DESCRIPTION
Purpose is to fail when required content is not provided. Currently, giving a string will pass through even if that string indicates that this content should have additional required information.

Solving #83, but probably needs a refactoring at some point. I assume this is the idea behind #20. 