### PR TITLE
Pyarrow import granularity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,4 +23,10 @@ exclude = '''
 '''
 
 [build-system]
-requires = ["pip>=19.1.1", "setuptools>=28", "setuptools_scm>=3.2.0", "wheel"]
+requires = [
+  "pip>=19.1.1",
+  "setuptools>=28",
+  "setuptools_scm>=3.2.0",
+  "wheel",
+  'pyarrow; python_version>"3.6.1"',
+]

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,3 +1,4 @@
 xtgeo>=2.14
 PyYAML
-pyarrow
+# skip pyarrow for RMS 11 and 12.0 which uses python 3.6.1 and too old numpy 1.13.3
+pyarrow; python_version > "3.6.1"

--- a/src/fmu/dataio/_export_item.py
+++ b/src/fmu/dataio/_export_item.py
@@ -7,8 +7,14 @@ from datetime import datetime
 
 import numpy as np
 import pandas as pd
-import pyarrow as pa
-from pyarrow import feather
+
+try:
+    import pyarrow as pa
+except ImportError:
+    HAS_PYARROW = False
+else:
+    HAS_PYARROW = True
+    from pyarrow import feather
 
 import xtgeo
 
@@ -134,7 +140,7 @@ class _ExportItem:  # pylint disable=too-few-public-methods
         elif isinstance(self.obj, pd.DataFrame):
             self.subtype = "DataFrame"
             self.classname = "table"
-        elif isinstance(self.obj, pa.Table):
+        elif HAS_PYARROW and isinstance(self.obj, pa.Table):
             self.subtype = "ArrowTable"
             self.classname = "table"
         else:
@@ -962,7 +968,7 @@ class _ExportItem:  # pylint disable=too-few-public-methods
         # Temporary (?) override so that pa.Table in can only become .arrow out for now
         # Perhaps better to make the fmt an input argument rather than a class constant
 
-        if isinstance(obj, pa.Table):
+        if HAS_PYARROW and isinstance(obj, pa.Table):
             logger.info(
                 "Incoming object is pa.Table, so setting outgoing table "
                 "format to 'arrow'"

--- a/tests/test_fmu_dataio_table.py
+++ b/tests/test_fmu_dataio_table.py
@@ -1,13 +1,19 @@
 """Test the surface_io module."""
 import logging
 import shutil
+import sys
 from collections import OrderedDict
 
 import pandas as pd
-import pyarrow as pa
-import yaml
+import pytest
+
+try:
+    import pyarrow as pa
+except ImportError:
+    pass
 
 import fmu.dataio
+import yaml
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -60,6 +66,7 @@ def test_table_io_pandas(tmp_path):
     assert len(header) == 3
 
 
+@pytest.mark.skipif("pyarrow" not in sys.modules, reason="requires pyarrow")
 def test_table_io_arrow(tmp_path):
     """Test the support for PyArrow tables"""
 
@@ -86,6 +93,7 @@ def test_table_io_arrow(tmp_path):
         assert metadata["data"]["spec"]["columns"] == ["STOIIP", "PORO"]
 
 
+@pytest.mark.skipif("pyarrow" not in sys.modules, reason="requires pyarrow")
 def test_tables_io_larger_case_ertrun(tmp_path):
     """Larger test table io as ERTRUN, uses global config from Drogon to tmp_path."""
 


### PR DESCRIPTION
Use of pyarrow requires a higher numpy version than RMS 12.0 (and before) has. Adjust dependency on pyarrow install and adjust code according to this, so it will not be installed for python versions <= 3.6.1 (which is the version RMS 11* and 12.0* uses). Also conditional use in code.