### PR TITLE
Use semeio for parameter parsing, make nesting explicit

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,9 @@
+[mypy]
+
+[mypy-numpy.*]
+# Applies to Python 3.6:
+ignore_missing_imports = True
+
+[mypy-semeio.*]
+ignore_missing_imports = True
+

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,3 +1,4 @@
+semeio
 xtgeo>=2.14
 PyYAML
 # skip pyarrow for RMS 11 and 12.0 which uses python 3.6.1 and too old numpy 1.13.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,8 @@ addopts =
 markers =
     integration: marks a test as an integration test
 
+xfail_strict = true
+
 # [tool:pylint]
 # # Module docstrings are not required, there are other means of documenting at
 # # that level in subscript

--- a/src/fmu/dataio/_utils.py
+++ b/src/fmu/dataio/_utils.py
@@ -3,10 +3,11 @@ import hashlib
 import json
 import logging
 import uuid
-from collections import OrderedDict
 from os.path import join
 from pathlib import Path
+from typing import Dict, List, Union
 
+from semeio.jobs.design_kw.design_kw import extract_key_value
 from . import _oyaml as oyaml
 
 logger = logging.getLogger(__name__)
@@ -207,7 +208,7 @@ def uuid_from_string(string):
     return uuid.UUID(hashlib.md5(string.encode("utf-8")).hexdigest())
 
 
-def read_parameters_txt(pfile):
+def read_parameters_txt(pfile: Union[Path, str]) -> Dict[str, Union[str, float, int]]:
     """Read the parameters.txt file and convert to a dict.
 
     The parameters.txt file has this structure::
@@ -250,30 +251,46 @@ def read_parameters_txt(pfile):
 
     logger.debug("Reading parameters.txt from %s", pfile)
 
-    with open(pfile, "r") as stream:
-        buffer = stream.read().splitlines()
+    parameterlines = Path(pfile).read_text().splitlines()
 
-    logger.debug("buffer is of type %s", type(buffer))
-    logger.debug("buffer has %s lines", str(len(buffer)))
+    dict_str_to_str = extract_key_value(parameterlines)
+    return {key: check_if_number(value) for key, value in dict_str_to_str.items()}
 
-    buffer = [":".join(line.split()) for line in buffer]
 
-    param = OrderedDict()
-    for line in buffer:
-        items = line.split(":")
-        if len(items) == 2:
-            param[items[0]] = check_if_number(items[1])
-        elif len(items) == 3:
-            if items[0] not in param:
-                param[items[0]] = OrderedDict()
+def nested_parameters_dict(
+    paramdict: Dict[str, Union[str, int, float]]
+) -> Dict[str, Union[str, int, float, Dict[str, Union[str, int, float]]]]:
+    """Interpret a flat parameters dictionary into a nested dictionary, based on
+    presence of colons in keys.
 
-            param[items[0]][items[1]] = check_if_number(items[2])
+    This assumes that what comes before a ":" is sort of a namespace identifier.
+
+    In design_kw (semeio) this namespace identifier is actively ignored, meaning that
+    the keys without the namespace must be unique.
+    """
+    nested_dict: Dict[
+        str, Union[str, int, float, Dict[str, Union[str, int, float]]]
+    ] = {}
+    unique_keys: List[str] = []
+    for key, value in paramdict.items():
+        if ":" in key:
+            subdict, newkey = key.split(":", 1)
+            if not newkey:
+                raise ValueError(f"Empty parameter name in {key} after removing prefix")
+            if subdict not in nested_dict:
+                nested_dict[subdict] = {}
+            unique_keys.append(newkey)
+            nested_dict[subdict][newkey] = value  # type: ignore
         else:
-            raise RuntimeError(
-                f"Unexpected structure of parameters.txt, line is: {line}"
-            )
+            unique_keys.append(key)
+            nested_dict[key] = value
 
-    return param
+    if len(unique_keys) > len(set(unique_keys)):
+        raise ValueError(
+            "Keys in parameters dictionary are not unique after removal of namespace"
+        )
+
+    return nested_dict
 
 
 def check_if_number(value):

--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -390,7 +390,8 @@ class ExportData:
                 parameters_file = self._iterfolder / "parameters.txt"
                 if parameters_file.is_file():
                     params = _utils.read_parameters_txt(parameters_file)
-                    ertjob["params"] = params
+                    nested_params = _utils.nested_parameters_dict(params)
+                    ertjob["params"] = nested_params
 
                 jobs_file = self._iterfolder / "jobs.json"
                 if jobs_file.is_file():

--- a/tests/test_fmu_dataio_utils.py
+++ b/tests/test_fmu_dataio_utils.py
@@ -128,22 +128,52 @@ def test_uuid_from_string():
 
 
 def test_parse_parameters_txt():
-    """Testing parsing of parameters.txt to JSON"""
+    """Testing parsing of parameters.txt into a flat dictionary"""
 
     ptext = "tests/data/drogon/ertrun1/realization-1/iter-0/parameters.txt"
 
     res = _utils.read_parameters_txt(ptext)
 
     assert res["SENSNAME"] == "rms_seed"
-    assert res["GLOBVAR"]["VOLON_PERMH_CHANNEL"] == 1100
+
+    # Numbers in strings should be parsed as numbers:
+    assert res["GLOBVAR:VOLON_PERMH_CHANNEL"] == 1100
+
+
+@pytest.mark.parametrize(
+    "flat_dict, nested_dict",
+    [
+        ({}, {}),
+        ({"foo": "bar"}, {"foo": "bar"}),
+        ({"foo:bar": "com"}, {"foo": {"bar": "com"}}),
+        ({"foo:bar:com": "hoi"}, {"foo": {"bar:com": "hoi"}}),
+        (
+            {"fo": "ba", "foo:bar": "com", "fooo:barr:comm": "hoi"},
+            {"fo": "ba", "foo": {"bar": "com"}, "fooo": {"barr:comm": "hoi"}},
+        ),
+        (
+            {"foo:bar": "com", "foo:barr": "comm"},
+            {"foo": {"bar": "com", "barr": "comm"}},
+        ),
+        pytest.param(
+            {"foo:bar": "com1", "hoi:bar": "com2"},
+            None,
+            marks=pytest.mark.xfail(raises=ValueError),
+            id="non-unique_keys",
+        ),
+        pytest.param({"foo:": "com"}, None, marks=pytest.mark.xfail(raises=ValueError)),
+    ],
+)
+def test_nested_parameters(flat_dict, nested_dict):
+    assert _utils.nested_parameters_dict(flat_dict) == nested_dict
 
 
 def test_parse_parameters_txt_justified():
-    """Testing parsing of justified parameters.txt to JSON"""
+    """Testing parsing of justified parameters.txt into nested dictionary"""
 
     ptext = "tests/data/drogon/ertrun1/realization-0/iter-0/parameters_justified.txt"
 
-    res = _utils.read_parameters_txt(ptext)
+    res = _utils.nested_parameters_dict(_utils.read_parameters_txt(ptext))
 
     assert res["SENSNAME"] == "rms_seed"
     assert res["GLOBVAR"]["VOLON_PERMH_CHANNEL"] == 1100


### PR DESCRIPTION
The nesting of parameters dictionary is specific to fmu-dataio. Make it more explicit
by putting it in a different function