### PR TITLE
Detect global config from env etc

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -8,3 +8,5 @@ log_cli_format = %(levelname)8s (%(relativeCreated)6.0fms) %(name)37s [%(funcNam
 log_cli_level = INFO
 testpaths =
     tests
+filterwarnings =
+    ignore::UserWarning

--- a/tests/data/drogon/global_config2/not_valid_yaml.yml
+++ b/tests/data/drogon/global_config2/not_valid_yaml.yml
@@ -1,0 +1,6 @@
+key:
+  - This is not a valid YAML file; for use in testing! *KU $$$ \\:
+  -
+  -
+
+&HEI


### PR DESCRIPTION
Either, in case the `config` key is not present or set None:

- Set env variable  ~~`FMU_DATAIO_CONFIG`~~ `FMU_GLOBAL_CONFIG` to point to the YAML file that shall be input to the `config` key
- ~~Look for `../../fmuconfig/output/global_variables.yml`~~

This will simplify for e.g. script running in an ERT forward model
