### PR TITLE
allow fluid_contact.truncated according to schema

### DIFF
--- a/src/fmu/dataio/_export_item.py
+++ b/src/fmu/dataio/_export_item.py
@@ -54,7 +54,7 @@ ALLOWED_CONTENTS = {
         "scaling_factor": float,
         "offset": str,
     },
-    "fluid_contact": {"contact": str},
+    "fluid_contact": {"contact": str, "truncated": bool},
     "field_outline": {"contact": str},
     "regions": None,
     "pinchout": None,

--- a/tests/test_export_item.py
+++ b/tests/test_export_item.py
@@ -257,7 +257,7 @@ def test_data_process_content_shall_fail():
 def test_data_process_content_validate():
     """Test the content validation"""
 
-    # test case 1 - fluid contact, valid
+    # fluid contact, valid without "truncated"
     dataio = fmu.dataio.ExportData(
         name="Valysar",
         config=CFG2,
@@ -269,7 +269,19 @@ def test_data_process_content_validate():
 
     assert "fluid_contact" in dataio.metadata4data
 
-    # test case 2 - fluid contact, not valid, shall fail
+    # fluid contact, valid with "truncated"
+    dataio = fmu.dataio.ExportData(
+        name="Valysar",
+        config=CFG2,
+        content={"fluid_contact": {"contact": "owc", "truncated": True}},
+    )
+    obj = xtgeo.Polygons()
+    exportitem = ei._ExportItem(dataio, obj, verbosity="INFO")
+    exportitem._data_process_content()
+
+    assert "fluid_contact" in dataio.metadata4data
+
+    # fluid contact, not valid, shall fail
     dataio = fmu.dataio.ExportData(
         name="SomeName",
         config=CFG2,


### PR DESCRIPTION
Solving #156 

Ref #150 - `truncated` is a valid field for `fluid_contact` but fmu-dataio did not allow it. This PR allows it.