### PR TITLE
Allow nonstandard folders

### DIFF
--- a/src/fmu/dataio/_export_item.py
+++ b/src/fmu/dataio/_export_item.py
@@ -133,6 +133,7 @@ class _ExportItem:
         dataio,
         obj,
         subfolder=None,
+        forcefolder=None,
         verbosity="WARNING",
         include_index=False,
         name=None,
@@ -153,6 +154,7 @@ class _ExportItem:
         self.display_name = _override_arg(dataio, "display_name", display_name)
         self.unit = _override_arg(dataio, "unit", unit)
         self.subfolder = _override_arg(dataio, "subfolder", subfolder)
+        self.forcefolder = _override_arg(dataio, "forcefolder", forcefolder)
         self.verbosity = _override_arg(dataio, "verbosity", verbosity)
         self.include_index = _override_arg(
             dataio, "include_index", include_index, default=False
@@ -187,13 +189,6 @@ class _ExportItem:
         self.realfolder = dataio.realfolder
         self.iterfolder = dataio.iterfolder
         self.createfolder = dataio.createfolder
-
-        if subfolder is not None:
-            warnings.warn(
-                "Exporting to a subfolder is a deviation from the standard "
-                "and could have consequences for later dependencies",
-                UserWarning,
-            )
 
     def save_to_file(self) -> str:
         """Save (export) an instance to file with rich metadata.
@@ -1000,6 +995,10 @@ class _ExportItem:
 
         dest = outroot / loc
 
+        # override in case of forcefolder!
+        if self.forcefolder:
+            dest = self.forcefolder
+
         if self.subfolder:
             dest = dest / self.subfolder
 
@@ -1037,7 +1036,7 @@ class _ExportItem:
             (Path(filepath) / ("." + filestem.lower())).with_suffix(ext + ".yml")
         ).resolve()
 
-        # get the relative path (relative to runptah if interactive, and to casedir
+        # get the relative path (relative to runpath if interactive, and to casedir
         # if this is an ERT run)
 
         useroot = self.dataio.runpath.resolve()

--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -119,7 +119,8 @@ class ExportData:
         content: Is a string or a dictionary with one key. Example is "depth" or
             {"fluid_contact": {"xxx": "yyy", "zzz": "uuu"}}
         subfolder: It is possible to set one level of subfolders for file output.
-            The input will only accept a single folder name, i.e. no paths
+            The input should only accept a single folder name, i.e. no paths. If
+            paths are present, a deprecation warning will be raised.
         forcefolder: This setting shall only be used as exception, and will make it
             possible to output to a non-standard folder. A ``/`` in front will indicate
             an absolute path; otherwise it will be relative to RUNPATH. Use with care.
@@ -293,9 +294,12 @@ class ExportData:
             return
 
         if "/" in foldername:
-            raise ValueError(
-                "The subfolder input contains '/' which is illegal. Consider using"
-                "the forcefolder key instead if paths are required."
+            warnings.warn(
+                "The subfolder input contains a path reference '/' which is currently "
+                "allowed, but is an antipattern. In future versions only subfolder "
+                "names without path references will be allowed. Consider using "
+                "the 'forcefolder' key instead if special paths are required.",
+                UserWarning,
             )
         else:
             warnings.warn(

--- a/tests/test_fmu_dataio_surface.py
+++ b/tests/test_fmu_dataio_surface.py
@@ -146,8 +146,7 @@ def test_surface_io_with_timedata_shall_fail(tmp_path, dates, errmessage):
 
 
 def test_surface_io_export_subfolder(tmp_path):
-    """Minimal test surface io with export_subfolder set,
-    uses tmp_path."""
+    """Minimal test surface io with export_subfolder set, uses tmp_path."""
 
     srf = xtgeo.RegularSurface(
         ncol=20, nrow=30, xinc=20, yinc=20, values=np.ma.ones((20, 30)), name="test"
@@ -162,6 +161,84 @@ def test_surface_io_export_subfolder(tmp_path):
     assert (
         tmp_path / FMUP1 / "maps" / "mysubfolder" / ".test.gri.yml"
     ).is_file() is True
+
+
+def test_surface_io_export_subfolder_illegal(tmp_path):
+    """Minimal test surface io with sufolder, using illegal path."""
+
+    srf = xtgeo.RegularSurface(
+        ncol=20, nrow=30, xinc=20, yinc=20, values=np.ma.ones((20, 30)), name="test"
+    )
+    fmu.dataio.ExportData.surface_fformat = "irap_binary"
+
+    exp = fmu.dataio.ExportData(content="depth", runpath=tmp_path, config=CFG)
+    with pytest.raises(ValueError):
+        exp.export(srf, subfolder="../mysubfolder")
+
+
+def test_surface_io_export_forcefolder_absolute(tmp_path):
+    """Minimal test surface io with forcefolder set, uses tmp_path."""
+
+    srf = xtgeo.RegularSurface(
+        ncol=20, nrow=30, xinc=20, yinc=20, values=np.ma.ones((20, 30)), name="test234"
+    )
+    fmu.dataio.ExportData.surface_fformat = "irap_binary"
+
+    exp = fmu.dataio.ExportData(content="depth", runpath=tmp_path, config=CFG)
+    with pytest.warns(UserWarning):
+        exp.export(srf, forcefolder=str(tmp_path))
+
+    assert (tmp_path / "test234.gri").is_file() is True
+
+
+def test_surface_io_export_forcefolder_relative(tmp_path):
+    """Minimal test surface io with forcefolder set as relative to runpath"""
+
+    srf = xtgeo.RegularSurface(
+        ncol=20, nrow=30, xinc=20, yinc=20, values=np.ma.ones((20, 30)), name="test235"
+    )
+    fmu.dataio.ExportData.surface_fformat = "irap_binary"
+
+    exp = fmu.dataio.ExportData(content="depth", runpath=tmp_path, config=CFG)
+    with pytest.warns(UserWarning):
+        exp.export(srf, forcefolder="share/results/myfolder")
+
+    assert (tmp_path / "share/results/myfolder" / "test235.gri").is_file() is True
+
+
+def test_surface_io_export_forcefolder_illegal_folder_create(tmp_path):
+    """Test with forcefolder set as absolute to a path with only admin rights."""
+
+    srf = xtgeo.RegularSurface(
+        ncol=20, nrow=30, xinc=20, yinc=20, values=np.ma.ones((20, 30)), name="test235"
+    )
+    fmu.dataio.ExportData.surface_fformat = "irap_binary"
+
+    exp = fmu.dataio.ExportData(
+        content="depth", runpath=tmp_path, config=CFG, verbosity="INFO"
+    )
+
+    # try to make a folder under /usr/bin which is illegal unless root rights
+    with pytest.raises(PermissionError):
+        exp.export(srf, forcefolder="/usr/bin/whatever")
+
+
+def test_surface_io_export_forcefolder_illegal_folder_store(tmp_path):
+    """Test with forcefolder store in folder with admin rights."""
+
+    srf = xtgeo.RegularSurface(
+        ncol=20, nrow=30, xinc=20, yinc=20, values=np.ma.ones((20, 30)), name="test235"
+    )
+    fmu.dataio.ExportData.surface_fformat = "irap_binary"
+
+    exp = fmu.dataio.ExportData(
+        content="depth", runpath=tmp_path, config=CFG, verbosity="INFO"
+    )
+
+    # legal path, but still not allowed to write a file, which returns different
+    # exceptions dependent if xtgeo or Pandas, or ...
+    with pytest.raises((IOError, Exception)):
+        exp.export(srf, forcefolder="/usr/bin")
 
 
 def test_surface_io_larger_case(tmp_path):

--- a/tests/test_fmu_dataio_surface.py
+++ b/tests/test_fmu_dataio_surface.py
@@ -163,7 +163,7 @@ def test_surface_io_export_subfolder(tmp_path):
     ).is_file() is True
 
 
-def test_surface_io_export_subfolder_illegal(tmp_path):
+def test_surface_io_export_subfolder_w_path_warn(tmp_path):
     """Minimal test surface io with sufolder, using illegal path."""
 
     srf = xtgeo.RegularSurface(
@@ -172,8 +172,8 @@ def test_surface_io_export_subfolder_illegal(tmp_path):
     fmu.dataio.ExportData.surface_fformat = "irap_binary"
 
     exp = fmu.dataio.ExportData(content="depth", runpath=tmp_path, config=CFG)
-    with pytest.raises(ValueError):
-        exp.export(srf, subfolder="../mysubfolder")
+    # with pytest.warns(UserWarning):
+    exp.export(srf, subfolder="../mysubfolder")
 
 
 def test_surface_io_export_forcefolder_absolute(tmp_path):


### PR DESCRIPTION
Responding to issue #187 but keep as draft
* Restrict `subfolder` fields so it cannot contain path information
* Add a `forcefolder` key for nonstandards file locations
~~* Rename `runpath` to `basepath` to be more generic~~
