### PR TITLE
Tagname to metadata

### DIFF
--- a/schema/definitions/0.8.0/examples/surface_depth.yml
+++ b/schema/definitions/0.8.0/examples/surface_depth.yml
@@ -99,8 +99,8 @@ data: # The data block describes the actual data (e.g. surface). Only present in
   # content is white-listed and standardized
   content: depth
 
-  # tag is flexible. The tag is intended primarily for providing uniqueness. The tagname will also be part of the outgoing file name on disk.
-  tag: ds_extract_geogrid
+  # tagname is flexible. The tag is intended primarily for providing uniqueness. The tagname will also be part of the outgoing file name on disk.
+  tagname: ds_extract_geogrid
 
   # no content-specific attribute for "depth" but can come in the future
 

--- a/schema/definitions/0.8.0/examples/surface_depth.yml
+++ b/schema/definitions/0.8.0/examples/surface_depth.yml
@@ -96,8 +96,11 @@ data: # The data block describes the actual data (e.g. surface). Only present in
     - somename_fm_1_top
     - top_somename
 
-  # content is flexible more than standardized for now.
+  # content is white-listed and standardized
   content: depth
+
+  # tag is flexible. The tag is intended primarily for providing uniqueness. The tagname will also be part of the outgoing file name on disk.
+  tag: ds_extract_geogrid
 
   # no content-specific attribute for "depth" but can come in the future
 

--- a/schema/definitions/0.8.0/schema/fmu_results.json
+++ b/schema/definitions/0.8.0/schema/fmu_results.json
@@ -13,6 +13,7 @@
         "data.stratigraphic_alias",
         "data.offset",
         "data.content",
+        "data.tag",
         "data.vertical_domain",
         "data.grid_model",
         "data.bbox",
@@ -159,6 +160,7 @@
             "title": "The data block",
             "required": [
                 "content",
+                "tag",
                 "name",
                 "format",
                 "spec",
@@ -233,6 +235,14 @@
                     "description": "The contents of this data object",
                     "examples": [
                         "depth"
+                    ]
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "A semi-human readable tag for internal usage and uniqueness",
+                    "examples": [
+                        "ds_extract_geogrid",
+                        "ds_post_strucmod"
                     ]
                 },
                 "properties": {

--- a/schema/definitions/0.8.0/schema/fmu_results.json
+++ b/schema/definitions/0.8.0/schema/fmu_results.json
@@ -13,7 +13,7 @@
         "data.stratigraphic_alias",
         "data.offset",
         "data.content",
-        "data.tag",
+        "data.tagname",
         "data.vertical_domain",
         "data.grid_model",
         "data.bbox",
@@ -160,7 +160,6 @@
             "title": "The data block",
             "required": [
                 "content",
-                "tag",
                 "name",
                 "format",
                 "spec",
@@ -237,7 +236,7 @@
                         "depth"
                     ]
                 },
-                "tag": {
+                "tagname": {
                     "type": "string",
                     "description": "A semi-human readable tag for internal usage and uniqueness",
                     "examples": [

--- a/src/fmu/dataio/_export_item.py
+++ b/src/fmu/dataio/_export_item.py
@@ -285,6 +285,7 @@ class _ExportItem:
         self._data_process_parent()
         self._data_process_timedata()
         self._data_process_description()
+        self._data_process_tagname()
         self._data_process_various()
 
     def _data_process_name(self):
@@ -587,6 +588,41 @@ class _ExportItem:
             meta["description"] = [str(item) for item in self.description]
         elif isinstance(self.description, str):
             meta["description"] = [self.description]
+
+    def _data_process_tagname(self):
+        """Process the data.tagname attribute.
+
+        The tagname will be included in outgoing filename if file is exported, and will
+        then be made filename-friendly. The tagname used in the file shall be identical
+        to the one used in data.tagname. Therefore, we will require that incoming
+        tagname is filename friendly.
+
+        For now we will change it with a warning.
+
+        # TODO align this with similar operation in _construct_filename_fmustandard1()
+
+        """
+
+        if self.tagname is None:
+            logger.debug("Incoming tagname is None - returning")
+            return
+
+        meta = self.dataio.metadata4data  # short form
+
+        logger.debug("Incoming tagname is %s", self.tagname)
+
+        tagname = self.tagname.lower().replace(" ", "_").replace(".", "_")
+
+        if tagname != self.tagname:
+            logger.debug("Tagname was changed to %s", tagname)
+            warnings.warn(
+                "'tagname' shall be lowercase and not contain special characters."
+                "The provided tagname will be changed to {tagname}."
+                "In future versions, illegal characters in tagname will not be allowed",
+                UserWarning,
+            )
+
+        meta["tagname"] = tagname
 
     def _data_process_various(self):
         """Process "all the rest" of the generic items.

--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -952,7 +952,7 @@ class ExportData:
                 is "Valysar Top Fm." that latter name will be used.
             unit: Is the unit of the exported item(s), e.g. "m" or "fraction".
             tagname: Override any setting in class initialization. This is a short
-                tag description which be be a part of file name.
+                tag description which will be a part of file name and data.tagname.
             parent: Override any setting in class initialization. This key is
                 required for datatype GridProperty, and refers to the name of the
                 grid geometry.

--- a/tests/test_export_item.py
+++ b/tests/test_export_item.py
@@ -409,6 +409,52 @@ def test_data_process_content_fluid_contact():
     obj = xtgeo.Polygons()
 
 
+def test_data_process_tagname():
+    """Test the data.tagname entry."""
+
+    dataio = fmu.dataio.ExportData(
+        name="Valysar",
+        config=CFG2,
+        content="depth",
+        tagname="what_ever",  # valid tagname
+    )
+    obj = xtgeo.RegularSurface(
+        name="SomeName", ncol=3, nrow=4, xinc=22, yinc=22, values=0
+    )
+    exportitem = ei._ExportItem(dataio, obj, verbosity="INFO")
+    exportitem._data_process_tagname()
+    assert dataio.metadata4data["tagname"] == "what_ever"
+
+    # allow tagname not given, shall then not be in metadata
+    dataio = fmu.dataio.ExportData(
+        name="Valysar",
+        config=CFG2,
+        content="depth",
+    )
+    obj = xtgeo.RegularSurface(
+        name="SomeName", ncol=3, nrow=4, xinc=22, yinc=22, values=0
+    )
+    exportitem = ei._ExportItem(dataio, obj, verbosity="INFO")
+    exportitem._data_process_tagname()
+    assert "tagname" not in dataio.metadata4data
+
+    # give warning when tagname is not proper, then correct it
+    dataio = fmu.dataio.ExportData(
+        name="Valysar",
+        config=CFG2,
+        content="depth",
+        tagname="wha t.EvEr",  # non-valid tagname
+    )
+    obj = xtgeo.RegularSurface(
+        name="SomeName", ncol=3, nrow=4, xinc=22, yinc=22, values=0
+    )
+    exportitem = ei._ExportItem(dataio, obj, verbosity="INFO")
+
+    with pytest.warns(UserWarning, match="shall be lowercase"):
+        exportitem._data_process_tagname()
+    assert dataio.metadata4data["tagname"] == "wha_t_ever"
+
+
 def test_display_name():
     """Test the display.name.
 


### PR DESCRIPTION
Adding tagname to the metadata to align with Webviz and to achieve uniqueness.

* Adding tagname to the schema, making it contractual but not required.
* Keeping tagname non-required to be backwards compatible.
