### PR TITLE
Aggregation_id

### DIFF
--- a/src/fmu/dataio/_utils.py
+++ b/src/fmu/dataio/_utils.py
@@ -178,7 +178,7 @@ def size(fname):
 
 def uuid_from_string(string):
     """Produce valid and repeteable UUID4 as a hash of given string"""
-    return uuid.UUID(hashlib.md5(string.encode("utf-8")).hexdigest())
+    return str(uuid.UUID(hashlib.md5(string.encode("utf-8")).hexdigest()))
 
 
 def read_parameters_txt(pfile: Union[Path, str]) -> Dict[str, Union[str, float, int]]:

--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -970,7 +970,7 @@ class AggregatedData:
         for xuuid in sorted(uuids):
             stringinput += xuuid
 
-        return uuid_from_string(stringinput)
+        return str(uuid_from_string(stringinput))
 
     def _update_settings(self, newsettings: dict) -> None:
         """Update instance settings (properties) from other routines."""

--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -969,7 +969,7 @@ class AggregatedData:
         for xuuid in sorted(uuids):
             stringinput += xuuid
 
-        return str(uuid_from_string(stringinput))
+        return uuid_from_string(stringinput)
 
     def _update_settings(self, newsettings: dict) -> None:
         """Update instance settings (properties) from other routines."""

--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -967,7 +967,7 @@ class AggregatedData:
         """Unless aggregation_id; use existing UUIDs to generate a new UUID."""
 
         stringinput = ""
-        for xuuid in uuids:
+        for xuuid in sorted(uuids):
             stringinput += xuuid
 
         return uuid_from_string(stringinput)

--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -932,9 +932,8 @@ class AggregatedData:
     """Instantate AggregatedData object.
 
     Args:
-        aggregation_id: Give an explicit ID for the aggregation. If None, or not
-            provided, an automatic ID based on existing realization uuid will be made.
-            Default is None which means it will be missing (null) in the metadata.
+        aggregation_id: Give an explicit ID for the aggregation. If None, an ID will be
+        made based on existing realization uuids.
         casepath: The root folder to the case, default is None. If None, the casepath
             is derived from the first input metadata paths (cf. ``source_metadata``) if
             possible. If given explicitly, the physical casepath folder must exist in

--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -932,8 +932,8 @@ class AggregatedData:
     """Instantate AggregatedData object.
 
     Args:
-        aggregation_id: Give an explicit ID for the aggregation. If set to True, an
-            automatic ID based on existing realization uuid will be made.
+        aggregation_id: Give an explicit ID for the aggregation. If None, or not
+            provided, an automatic ID based on existing realization uuid will be made.
             Default is None which means it will be missing (null) in the metadata.
         casepath: The root folder to the case, default is None. If None, the casepath
             is derived from the first input metadata paths (cf. ``source_metadata``) if
@@ -948,7 +948,7 @@ class AggregatedData:
         tagname: Additional name, as part of file name
     """
 
-    aggregation_id: Optional[Union[str, bool]] = None
+    aggregation_id: Optional[str] = None
     casepath: Union[str, Path, None] = None
     source_metadata: list = field(default_factory=list)
     name: str = ""
@@ -1093,10 +1093,17 @@ class AggregatedData:
         self, obj: Any, real_ids: List[int], uuids: List[str], compute_md5: bool = True
     ):
 
+        logger.info(
+            "self.aggregation is %s (%s)",
+            self.aggregation_id,
+            type(self.aggregation_id),
+        )
+
         if self.aggregation_id is None:
-            self.aggregation_id = None
-        elif self.aggregation_id is True:
             self.aggregation_id = self._generate_aggr_uuid(uuids)
+        else:
+            if not isinstance(self.aggregation_id, str):
+                raise ValueError("aggregation_id must be a string")
 
         if not self.operation:
             raise ValueError("The 'operation' key has no value")

--- a/tests/test_units/test_aggregated_surfaces.py
+++ b/tests/test_units/test_aggregated_surfaces.py
@@ -279,13 +279,8 @@ def test_regsurf_aggregated_aggregation_id(fmurun_w_casemetadata, aggr_surfs_mea
         newmeta = aggdata.generate_metadata(aggr_mean, aggregation_id=True)
 
 
-def test_regsurf_aggregated_aggregation_id_sorting(
-    fmurun_w_casemetadata, aggr_surfs_mean
-):
-    """Test that aggregation_id is robust for different sorting of input.
-
-    We don't control the sorting of the input, but the result should not be affected.
-    """
+def test_generate_aggr_uuid(fmurun_w_casemetadata, aggr_surfs_mean):
+    """Test the _generate_aggr_uuid private method."""
     logger.info("Active folder is %s", fmurun_w_casemetadata)
 
     os.chdir(fmurun_w_casemetadata)
@@ -300,57 +295,19 @@ def test_regsurf_aggregated_aggregation_id_sorting(
         name="myaggrd2",
         verbosity="INFO",
     )
+
+    # Sorting shall be ignored
     agg_uuid_1 = aggdata._generate_aggr_uuid(["a", "b", "c"])
     agg_uuid_2 = aggdata._generate_aggr_uuid(["c", "a", "b"])
-
     assert agg_uuid_1 == agg_uuid_2
 
-
-def test_regsurf_aggregated_aggregation_id_sorting(
-    fmurun_w_casemetadata, aggr_surfs_mean
-):
-    """Test that aggregation_id is different for different input."""
-    logger.info("Active folder is %s", fmurun_w_casemetadata)
-
-    os.chdir(fmurun_w_casemetadata)
-
-    aggr_mean, metas = aggr_surfs_mean  # xtgeo_object, list-of-metadata-dicts
-    logger.info("Aggr. mean is %s", aggr_mean.values.mean())  # shall be 1238.5
-
-    # let missing aggregation_id argument generate the id
-    aggdata = dataio.AggregatedData(
-        source_metadata=metas,
-        operation="mean",
-        name="myaggrd2",
-        verbosity="INFO",
-    )
+    # Different input shall give different result
     agg_uuid_1 = aggdata._generate_aggr_uuid(["a", "b", "c"])
     agg_uuid_2 = aggdata._generate_aggr_uuid(["c", "a", "b", "e"])
-
     assert agg_uuid_1 != agg_uuid_2
 
-
-def test_regsurf_aggregated_aggregation_id_format(
-    fmurun_w_casemetadata, aggr_surfs_mean
-):
-    """Test that aggregation_id is a string."""
-    logger.info("Active folder is %s", fmurun_w_casemetadata)
-
-    os.chdir(fmurun_w_casemetadata)
-
-    aggr_mean, metas = aggr_surfs_mean  # xtgeo_object, list-of-metadata-dicts
-    logger.info("Aggr. mean is %s", aggr_mean.values.mean())  # shall be 1238.5
-
-    # let missing aggregation_id argument generate the id
-    aggdata = dataio.AggregatedData(
-        source_metadata=metas,
-        operation="mean",
-        name="myaggrd2",
-        verbosity="INFO",
-    )
-    agg_uuid = aggdata._generate_aggr_uuid(["a", "b", "c"])
-
-    assert isinstance(agg_uuid, str), str(type(agg_uuid))
+    # Returned value shall be a string
+    assert isinstance(agg_uuid_1, str), str(type(agg_uuid_1))
 
 
 def test_regsurf_aggregated_diffdata(fmurun_w_casemetadata, rmsglobalconfig, regsurf):

--- a/tests/test_units/test_aggregated_surfaces.py
+++ b/tests/test_units/test_aggregated_surfaces.py
@@ -330,6 +330,29 @@ def test_regsurf_aggregated_aggregation_id_sorting(
     assert agg_uuid_1 != agg_uuid_2
 
 
+def test_regsurf_aggregated_aggregation_id_format(
+    fmurun_w_casemetadata, aggr_surfs_mean
+):
+    """Test that aggregation_id is a string."""
+    logger.info("Active folder is %s", fmurun_w_casemetadata)
+
+    os.chdir(fmurun_w_casemetadata)
+
+    aggr_mean, metas = aggr_surfs_mean  # xtgeo_object, list-of-metadata-dicts
+    logger.info("Aggr. mean is %s", aggr_mean.values.mean())  # shall be 1238.5
+
+    # let missing aggregation_id argument generate the id
+    aggdata = dataio.AggregatedData(
+        source_metadata=metas,
+        operation="mean",
+        name="myaggrd2",
+        verbosity="INFO",
+    )
+    agg_uuid = aggdata._generate_aggr_uuid(["a", "b", "c"])
+
+    assert isinstance(agg_uuid, str), str(type(agg_uuid))
+
+
 def test_regsurf_aggregated_diffdata(fmurun_w_casemetadata, rmsglobalconfig, regsurf):
     """Test surfaces, where input is diffdata."""
     logger.info("Active folder is %s", fmurun_w_casemetadata)

--- a/tests/test_units/test_aggregated_surfaces.py
+++ b/tests/test_units/test_aggregated_surfaces.py
@@ -212,7 +212,7 @@ def test_regsurf_aggr_export_abspath_none(fmurun_w_casemetadata, aggr_surfs_mean
         _ = aggdata.export(aggr_mean)
 
 
-def test_regsurf_aggregated_aggrd_id(fmurun_w_casemetadata, aggr_surfs_mean):
+def test_regsurf_aggregated_aggregation_id(fmurun_w_casemetadata, aggr_surfs_mean):
     """Test generating aggragated metadata, tests on aggrd id"""
     logger.info("Active folder is %s", fmurun_w_casemetadata)
 
@@ -221,20 +221,18 @@ def test_regsurf_aggregated_aggrd_id(fmurun_w_casemetadata, aggr_surfs_mean):
     aggr_mean, metas = aggr_surfs_mean  # xtgeo_object, list-of-metadata-dicts
     logger.info("Aggr. mean is %s", aggr_mean.values.mean())  # shall be 1238.5
 
-    # let aggregation input True generate hash
+    # let missing aggregation_id argument generate the id
     aggdata = dataio.AggregatedData(
         source_metadata=metas,
         operation="mean",
         name="myaggrd2",
         verbosity="INFO",
-        aggregation_id=True,
     )
     newmeta = aggdata.generate_metadata(aggr_mean)
     logger.debug("New metadata:\n%s", utils.prettyprint_dict(newmeta))
-    assert newmeta["fmu"]["aggregation"]["id"] != "1234"
-    assert newmeta["fmu"]["aggregation"]["id"] is not True
+    assert newmeta["fmu"]["aggregation"]["id"] != "1234"  # shall be uuid
 
-    # let aggregation input None generate a missing key
+    # let aggregation input None generate the id
     aggdata = dataio.AggregatedData(
         source_metadata=metas,
         operation="mean",
@@ -244,7 +242,41 @@ def test_regsurf_aggregated_aggrd_id(fmurun_w_casemetadata, aggr_surfs_mean):
     )
     newmeta = aggdata.generate_metadata(aggr_mean)
     logger.debug("New metadata:\n%s", utils.prettyprint_dict(newmeta))
-    assert "id" not in newmeta["fmu"]["aggregation"]
+    assert "id" in newmeta["fmu"]["aggregation"]
+    assert newmeta["fmu"]["aggregation"]["id"] != "1234"  # shall be uuid
+
+    # let aggregation_id argument be used as aggregation_id
+    aggdata = dataio.AggregatedData(
+        source_metadata=metas,
+        operation="mean",
+        name="myaggrd2",
+        verbosity="INFO",
+        aggregation_id="1234",
+    )
+    newmeta = aggdata.generate_metadata(aggr_mean)
+    logger.debug("New metadata:\n%s", utils.prettyprint_dict(newmeta))
+    assert newmeta["fmu"]["aggregation"]["id"] == "1234"
+
+    # Raise when given aggregation_id is not a string 1
+    with pytest.raises(ValueError):
+        aggdata = dataio.AggregatedData(
+            source_metadata=metas,
+            operation="mean",
+            name="myaggrd2",
+            verbosity="INFO",
+            aggregation_id=True,
+        )
+        newmeta = aggdata.generate_metadata(aggr_mean)
+
+    # Raise when given aggregation_id is not a string 2
+    with pytest.raises(ValueError):
+        aggdata = dataio.AggregatedData(
+            source_metadata=metas,
+            operation="mean",
+            name="myaggrd2",
+            verbosity="INFO",
+        )
+        newmeta = aggdata.generate_metadata(aggr_mean, aggregation_id=True)
 
 
 def test_regsurf_aggregated_diffdata(fmurun_w_casemetadata, rmsglobalconfig, regsurf):

--- a/tests/test_units/test_aggregated_surfaces.py
+++ b/tests/test_units/test_aggregated_surfaces.py
@@ -279,6 +279,33 @@ def test_regsurf_aggregated_aggregation_id(fmurun_w_casemetadata, aggr_surfs_mea
         newmeta = aggdata.generate_metadata(aggr_mean, aggregation_id=True)
 
 
+def test_regsurf_aggregated_aggregation_id_sorting(
+    fmurun_w_casemetadata, aggr_surfs_mean
+):
+    """Test that aggregation_id is robust for different sorting of input.
+
+    We don't control the sorting of the input, but the result should not be affected.
+    """
+    logger.info("Active folder is %s", fmurun_w_casemetadata)
+
+    os.chdir(fmurun_w_casemetadata)
+
+    aggr_mean, metas = aggr_surfs_mean  # xtgeo_object, list-of-metadata-dicts
+    logger.info("Aggr. mean is %s", aggr_mean.values.mean())  # shall be 1238.5
+
+    # let missing aggregation_id argument generate the id
+    aggdata = dataio.AggregatedData(
+        source_metadata=metas,
+        operation="mean",
+        name="myaggrd2",
+        verbosity="INFO",
+    )
+    agg_uuid_1 = aggdata._generate_aggr_uuid(["a", "b", "c"])
+    agg_uuid_2 = aggdata._generate_aggr_uuid(["c", "a", "b"])
+
+    assert agg_uuid_1 == agg_uuid_2
+
+
 def test_regsurf_aggregated_diffdata(fmurun_w_casemetadata, rmsglobalconfig, regsurf):
     """Test surfaces, where input is diffdata."""
     logger.info("Active folder is %s", fmurun_w_casemetadata)

--- a/tests/test_units/test_aggregated_surfaces.py
+++ b/tests/test_units/test_aggregated_surfaces.py
@@ -306,6 +306,30 @@ def test_regsurf_aggregated_aggregation_id_sorting(
     assert agg_uuid_1 == agg_uuid_2
 
 
+def test_regsurf_aggregated_aggregation_id_sorting(
+    fmurun_w_casemetadata, aggr_surfs_mean
+):
+    """Test that aggregation_id is different for different input."""
+    logger.info("Active folder is %s", fmurun_w_casemetadata)
+
+    os.chdir(fmurun_w_casemetadata)
+
+    aggr_mean, metas = aggr_surfs_mean  # xtgeo_object, list-of-metadata-dicts
+    logger.info("Aggr. mean is %s", aggr_mean.values.mean())  # shall be 1238.5
+
+    # let missing aggregation_id argument generate the id
+    aggdata = dataio.AggregatedData(
+        source_metadata=metas,
+        operation="mean",
+        name="myaggrd2",
+        verbosity="INFO",
+    )
+    agg_uuid_1 = aggdata._generate_aggr_uuid(["a", "b", "c"])
+    agg_uuid_2 = aggdata._generate_aggr_uuid(["c", "a", "b", "e"])
+
+    assert agg_uuid_1 != agg_uuid_2
+
+
 def test_regsurf_aggregated_diffdata(fmurun_w_casemetadata, rmsglobalconfig, regsurf):
     """Test surfaces, where input is diffdata."""
     logger.info("Active folder is %s", fmurun_w_casemetadata)


### PR DESCRIPTION
Solving #221 

- Change the API - no longer accept non-string input for `aggregation_id`
- Returned `aggregation_id` is now a string
- Returned `aggregation_id` is now independent of sorting (same input give same output, regardless of input sorting)
- Add some more tests to it