### PR TITLE
Allow unicode in yaml export

### DIFF
--- a/src/fmu/dataio/_utils.py
+++ b/src/fmu/dataio/_utils.py
@@ -94,7 +94,7 @@ def export_metadata_file(yfile, metadata, savefmt="yaml", verbosity="WARNING") -
         xdata = drop_nones(metadata)
 
         if savefmt == "yaml":
-            yamlblock = oyaml.safe_dump(xdata)
+            yamlblock = oyaml.safe_dump(xdata, allow_unicode=True)
             with open(yfile, "w") as stream:
                 stream.write(yamlblock)
         else:

--- a/tests/test_units/test_initialize_case.py
+++ b/tests/test_units/test_initialize_case.py
@@ -15,10 +15,39 @@ from fmu.dataio._utils import prettyprint_dict
 logger = logging.getLogger(__name__)
 
 
-def test_inicase_barebone(globalconfig2):
+def test_inicase_barebone_with_export(globalconfig2, fmurun):
 
     icase = InitializeCase(config=globalconfig2, verbosity="INFO")
     assert "Drogon" in str(icase.config)
+
+    globalconfig2["masterdata"]["smda"]["field"][0]["identifier"] = "æøå"
+
+    caseroot = fmurun.parent.parent
+
+    icase.export(
+        rootfolder=caseroot,
+        force=True,
+        casename="MyCaseName_with_Æ",
+        caseuser="MyUser",
+        description="Some description",
+    )
+
+    casemetafile = caseroot / "share/metadata/fmu_case.yml"
+
+    # check that special characters made it through
+    with open(casemetafile, "r") as stream:
+        metadata = yaml.safe_load(stream)
+
+    assert metadata["fmu"]["case"]["name"] == "MyCaseName_with_Æ"
+    assert metadata["masterdata"]["smda"]["field"][0]["identifier"] == "æøå"
+
+    # Check that special characters are encoded properly in stored metadatafile.
+    # yaml.safe_load() seems to sort this out, but we want files on disk to be readable.
+    # Therefore check by reading the raw file content.
+    with open(casemetafile, "r") as stream:
+        metadata_string = stream.read()
+
+    assert "æøå" in metadata_string
 
 
 def test_inicase_pwd_basepath(fmurun, globalconfig2):


### PR DESCRIPTION
When special characters, e.g. æøå, are included in the metadata, they are not properly encoded when dumped to disk. However, it seems like they are properly read when yaml files are parsed. This PR allows for unicode in the yaml dump, and also checks the raw content of the dumped file.