### PR TITLE
Add validator

### DIFF
--- a/examples/s/d/nn/_project/validate_metadata.py
+++ b/examples/s/d/nn/_project/validate_metadata.py
@@ -1,0 +1,39 @@
+"""Example usage of the validation method.
+
+Metadata produced by FMU adheres to the JSON schema. Outgoing data are associated with
+metadata, which is validated in many different contexts.
+
+The embedded validation script in fmu-dataio enables validation directly, which is
+useful particularly in debugging situations.
+
+This is an example of how this script is used.
+"""
+
+from pathlib import Path
+
+from fmu.dataio import validate_metadata
+
+
+def main():
+
+    mycase = Path("../xcase/")
+    myreal = "realization-0"
+    myiter = "iter-0"
+    mydatapath = "share/results/maps/topvolantis--ds_extract_geogrid.gri"
+
+    # validate one
+    one_path = Path(mycase / myreal / myiter / mydatapath)
+
+    validate_metadata(one_path)
+
+    # validate many
+    reals = [0, 1, 9]
+    many_paths = [
+        mycase / f"realization-{real}" / myiter / mydatapath for real in reals
+    ]
+
+    validate_metadata(many_paths)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/fmu/dataio/_validator.py
+++ b/src/fmu/dataio/_validator.py
@@ -1,0 +1,111 @@
+"""Module for DataIO _Validator
+
+This contains validation functionality for FMU metadata.
+
+"""
+
+import logging
+import requests
+
+from pathlib import Path
+from typing import Optional, Union
+
+from fmu.dataio import read_metadata
+
+import yaml
+import json
+import jsonschema
+
+logger = logging.getLogger(__name__)
+logging.captureWarnings(True)
+
+
+class _Validator:
+    """Class for validating metadata.
+
+    This is a private class for fmu.dataio. The intention is that a public function in
+    fmu-dataio is to be facing the user.
+
+    """
+
+    def __init__(self, schema: Union[dict, str, Path] = None):
+        """Initialize the _Validator.
+
+        Args:
+            schema (dict | str | Path) (optional): A reference to a valid JSON schema or
+            a valid JSON schema. Default: None, which will prompt usage of the schema
+            referenced in the metadata.
+
+        """
+
+        if schema is not None:
+            self.schema = self._parse_schema(schema)
+        else:
+            self.schema = schema
+
+        self._schema_reference = None
+
+        logger.info("_Validator is initialized.")
+
+    # ==================================================================================
+    # Main methods
+    # ==================================================================================
+
+    def validate(self, filename):
+        """Validate the metadata associated with the filename.
+
+        Args:
+            metadata (dict or filename): The metadata to be validated, given as either a
+            dictionary or a filename to either data file or associated metadata file.
+
+        Returns:
+            dict: The validation results.
+        """
+
+        instance = read_metadata(filename)
+
+        if self.schema is None:
+            logger.info("Schema is not given, getting from metadata.")
+            logger.info("Schema reference is %s", self.schema_reference)
+            if self.schema_reference != instance["$schema"]:
+                logger.info("Schema reference is different from existing, parsing.")
+                self.schema_reference = instance["$schema"]
+                logger.info("Schema reference now set to %s", self.schema_reference)
+                self.schema = self._parse_schema_from_url(self._schema_reference)
+            else:
+                logger.info("Schema reference is same as existing, re-using.")
+                self.schema_reference = self._get_schema_reference(instance)
+
+        return self._validate(instance, self.schema)
+
+    # ==================================================================================
+    # Private methods
+    # ==================================================================================
+
+    def _parse_schema(self, schema_ref):
+        """Parse the schema from a reference.
+
+        Detect if schema_reference is a dict, a url or a path, and parse it.
+
+        Returns:
+            dict: The parsed schema.
+        """
+
+        if isinstance(schema_ref, dict):
+            logger.info("Schema given as a dict, use directly.")
+            return schema_ref
+        if isinstance(schema_ref, str) and schema_ref.startswith("http"):
+            logger.info("schema_reference is a URL")
+            return self._parse_schema_from_url(schema_url=schema_ref)
+        else:
+            return self._parse_schema_from_file(schema_path=schema_ref)
+
+    def _parse_schema_from_file(self, schema_path):
+        """Parse schema from file, return dict."""
+
+        with open(schema_path, "r", encoding="utf-8") as stream:
+            schema = json.load(stream)
+        return schema
+
+    def _parse_schema_from_url(self, schema_url):
+        """Parse schema from a url, return dict."""

--- a/src/fmu/dataio/_validator.py
+++ b/src/fmu/dataio/_validator.py
@@ -8,7 +8,7 @@ import logging
 import urllib
 
 from pathlib import Path
-from typing import Optional, Union, List
+from typing import Union
 
 from fmu.dataio import read_metadata
 
@@ -89,7 +89,7 @@ class _Validator:
 
         # pre-flight validation to check basics
         preflight_valid, preflight_reason = self._preflight_validation(instance)
-        if preflight_valid == False:
+        if preflight_valid is False:
             return self._create_results(preflight_valid, preflight_reason)
 
         if schema_reference is not None:
@@ -205,7 +205,7 @@ class _Validator:
             logger.info("Validation failed, returning results.")
             return self._create_results(False, err.message)
         except jsonschema.exceptions.SchemaError as err:
-            raise
+            raise err
 
     def _create_results(self, valid: bool, reason: str = None):
         """Correctly format the validation results."""

--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -206,28 +206,6 @@ def read_metadata(filename: Union[str, Path]) -> dict:
 
 
 # ======================================================================================
-# Public function to validate metadata given a file
-# ======================================================================================
-
-
-def validate_metadata(filename: Union[str, Path]) -> dict:
-    """Validate the metadata associated with the filename given.
-
-    Args:
-        filename: The full path filename to the data-object.
-
-    Returns:
-        Validation result as a dictionary.
-    """
-
-    from ._validator import _Validator  # lazy-load this
-
-    validator = _Validator()
-
-    return validator.validate(filename)
-
-
-# ======================================================================================
 # ExportData, public class
 # ======================================================================================
 

--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -206,6 +206,28 @@ def read_metadata(filename: Union[str, Path]) -> dict:
 
 
 # ======================================================================================
+# Public function to validate metadata given a file
+# ======================================================================================
+
+
+def validate_metadata(filename: Union[str, Path]) -> dict:
+    """Validate the metadata associated with the filename given.
+
+    Args:
+        filename: The full path filename to the data-object.
+
+    Returns:
+        Validation result as a dictionary.
+    """
+
+    from ._validator import _Validator  # lazy-load this
+
+    validator = _Validator()
+
+    return validator.validate(filename)
+
+
+# ======================================================================================
 # ExportData, public class
 # ======================================================================================
 

--- a/src/fmu/dataio/scripts/validate_metadata.py
+++ b/src/fmu/dataio/scripts/validate_metadata.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+
+"""Command-line script for validating metadata."""
+
+import logging
+import argparse
+from typing import Union
+from pathlib import Path
+import glob
+
+from fmu.dataio._validator import _Validator
+
+logging.basicConfig()
+logger = logging.getLogger(__name__)
+logging.captureWarnings(True)
+logger.setLevel(level="CRITICAL")
+
+
+def main():
+    args = _parse_arguments()
+
+    if args.v:
+        verbosity = "INFO"
+    else:
+        verbosity = "CRITICAL"
+
+    logger.setLevel(level=verbosity)
+
+    logger.info("validate_metadata.py is starting")
+
+    filenames = _get_filenames(args.filenames)
+
+    # sanity check
+    if len(filenames) > 100:
+        raise IOError("Your search pattern yields more than 100 hits, please refine.")
+
+    validator = _Validator(args.schema, verbosity=verbosity)
+
+    for filename in filenames:
+        result = validator.validate(filename)
+
+        if result["valid"] is True:
+            if not args.q:
+                print(f"{filename} 👍")
+        else:
+            print(f"{filename} ❌")
+            print("==========================")
+            print("Validation failed. Reason given was:")
+            print(result["reason"])
+            print("==========================")
+
+            if args.x:
+                break
+
+
+def _get_filenames(filenames: Union[str, Path]):
+    """Given a reference to one or more files, return filenames."""
+
+    if "*" in filenames:
+        logger.info("Assuming searchpath")
+        filenames = glob.glob(filenames)
+        logger.info("Found %s files", len(filenames))
+        return filenames
+    logger.info("Assuming single file.")
+    return [filenames]
+
+
+def _parse_arguments():
+    """Parse the input arguments."""
+
+    parser = argparse.ArgumentParser(description="Validate FMU metadata")
+
+    parser.add_argument("filenames", type=str, help="Path to file to be validated.")
+    parser.add_argument("--schema", type=str, help="Path or url to schema.")
+    parser.add_argument("-v", help="Increase verbosity", action="store_true")
+    parser.add_argument("-q", help="Quiet, reduce verbosity", action="store_true")
+    parser.add_argument(
+        "-x", help="Exit instantly on first failed validation", action="store_true"
+    )
+
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_schema/test_validator.py
+++ b/tests/test_schema/test_validator.py
@@ -1,0 +1,35 @@
+"""Test the JSON Schema validator."""
+
+import logging
+
+from fmu.dataio._validator import _Validator
+
+import jsonschema
+
+logger = logging.getLogger(__name__)
+
+
+def test_validator_initialization():
+    """Initialize the _Validate class."""
+
+    vdr = _Validator()
+
+
+def test_validator_basic_validation():
+    """On a minimum schema, test a minimum candidate."""
+
+    instance = {"mytag": "myvalue"}
+    schema = {"mytag": {"type": "string"}}
+
+    # validate directly first to confirm assumptions
+    assert jsonschema.validate(instance, schema) is None
+
+    # now validate with our code
+    vdr = _Validator(schema=schema)
+    res = vdr._validate(instance)
+    assert res["valid"] == True
+
+    # non-valid example
+    instance = {"mytag": 123.0}
+    res = vdr._validate(instance)
+    assert res["valid"] == False

--- a/tests/test_schema/test_validator.py
+++ b/tests/test_schema/test_validator.py
@@ -3,7 +3,6 @@
 import pytest
 
 import logging
-import requests
 
 from pathlib import PurePath, Path
 

--- a/tests/test_schema/test_validator.py
+++ b/tests/test_schema/test_validator.py
@@ -30,13 +30,13 @@ def test_is_metadata_file():
     """Test the _is_metadata_file private method."""
     vdr = _Validator()
     imf = vdr._is_metadata_file  # short-form
-    assert imf("/absolute/path/to/file.gri") == False
-    assert imf("/absolute/path/to/.file.gri.yml") == True
-    assert imf("/absolute/path/to/.file.gri.yaml") == True
-    assert imf("relative/path/to/file.gri") == False
-    assert imf("relative/path/to/.file.gri.yml") == True
-    assert imf(".file.gri.yml") == True
-    assert imf("file.gri") == False
+    assert imf("/absolute/path/to/file.gri") is False
+    assert imf("/absolute/path/to/.file.gri.yml") is True
+    assert imf("/absolute/path/to/.file.gri.yaml") is True
+    assert imf("relative/path/to/file.gri") is False
+    assert imf("relative/path/to/.file.gri.yml") is True
+    assert imf(".file.gri.yml") is True
+    assert imf("file.gri") is False
 
 
 def test_create_results():
@@ -57,12 +57,12 @@ def test_preflight_validation():
     # no $schema
     instance = {"some": "metadata"}
     valid, reason = vdr._preflight_validation(instance)
-    assert valid == False
+    assert valid is False
 
     # with $schema
     instance = {"some": "metadata", "$schema": "some_url"}
     valid, reason = vdr._preflight_validation(instance)
-    assert valid == True
+    assert valid is True
 
 
 def test_parse_schema():
@@ -131,7 +131,7 @@ def test_validate():
     # now validate with our code
     vdr = _Validator(global_schema=schema)
     res = vdr._validate(instance, schema)
-    assert res["valid"] == False
+    assert res["valid"] is False
     assert "reason" in res
     assert "123.0 is not of type 'string'" in res["reason"]
 

--- a/tests/test_schema/test_validator.py
+++ b/tests/test_schema/test_validator.py
@@ -1,6 +1,11 @@
 """Test the JSON Schema validator."""
 
+import pytest
+
 import logging
+import requests
+
+from pathlib import PurePath, Path
 
 from fmu.dataio._validator import _Validator
 
@@ -8,28 +13,148 @@ import jsonschema
 
 logger = logging.getLogger(__name__)
 
+ROOTPWD = Path(".").absolute()
+
 
 def test_validator_initialization():
     """Initialize the _Validate class."""
 
     vdr = _Validator()
 
+    _schema = {"mytag": {"type": "string"}}
+    vdr = _Validator(global_schema=_schema)
 
-def test_validator_basic_validation():
-    """On a minimum schema, test a minimum candidate."""
+    assert vdr._global_schema == _schema
 
+
+def test_is_metadata_file():
+    """Test the _is_metadata_file private method."""
+    vdr = _Validator()
+    imf = vdr._is_metadata_file  # short-form
+    assert imf("/absolute/path/to/file.gri") == False
+    assert imf("/absolute/path/to/.file.gri.yml") == True
+    assert imf("/absolute/path/to/.file.gri.yaml") == True
+    assert imf("relative/path/to/file.gri") == False
+    assert imf("relative/path/to/.file.gri.yml") == True
+    assert imf(".file.gri.yml") == True
+    assert imf("file.gri") == False
+
+
+def test_create_results():
+    """Test the _create_results private method."""
+    vdr = _Validator()
+    _result = vdr._create_results(False, "some reason")
+    assert _result == {"valid": False, "reason": "some reason"}
+
+    _result = vdr._create_results(True)
+    assert _result == {"valid": True, "reason": None}
+
+
+def test_preflight_validation():
+    """Test the _preflight_validation private method."""
+
+    vdr = _Validator()
+
+    # no $schema
+    instance = {"some": "metadata"}
+    valid, reason = vdr._preflight_validation(instance)
+    assert valid == False
+
+    # with $schema
+    instance = {"some": "metadata", "$schema": "some_url"}
+    valid, reason = vdr._preflight_validation(instance)
+    assert valid == True
+
+
+def test_parse_schema():
+    """Test the parse_schema private method."""
+
+    vdr = _Validator()
+    a_dict = {"mytag": {"type": "string"}}
+    a_url = _fmu_schema_url()
+    a_path = _fmu_schema_path()
+
+    # from dict
+    assert vdr._parse_schema(a_dict) == a_dict
+
+    # from url
+    res = vdr._parse_schema(a_url)
+    assert isinstance(res, dict)
+    assert "$id" in res
+
+    # from path
+    res = vdr._parse_schema(a_path)
+    assert isinstance(res, dict)
+    assert "$id" in res
+
+    # caching
+    vdr._parse_schema(a_path)
+    vdr._cached_schema["schema"]["a trace"] = "is left"
+    vdr._parse_schema(a_path)
+    assert "a trace" in vdr._cached_schema["schema"]
+
+    vdr._cached_schema["reference"] = "not the same as before"
+    vdr._parse_schema(a_path)
+    assert "a trace" not in vdr._cached_schema["schema"]
+
+
+def test_validate():
+    """Test the _validate private method."""
+
+    # shall be valid
     instance = {"mytag": "myvalue"}
-    schema = {"mytag": {"type": "string"}}
+    schema = {"properties": {"mytag": {"type": "string"}}}
 
     # validate directly first to confirm assumptions
     assert jsonschema.validate(instance, schema) is None
 
     # now validate with our code
-    vdr = _Validator(schema=schema)
-    res = vdr._validate(instance)
-    assert res["valid"] == True
+    vdr = _Validator(global_schema=schema)
+    assert vdr._validate(instance, schema) == {"valid": True, "reason": None}
 
-    # non-valid example
+    vdr = _Validator(global_schema=schema)
+    assert vdr._validate(instance, vdr._global_schema) == {
+        "valid": True,
+        "reason": None,
+    }
+
+    vdr = _Validator()
+    assert vdr._validate(instance, schema) == {"valid": True, "reason": None}
+
+    # shall be not valid
     instance = {"mytag": 123.0}
-    res = vdr._validate(instance)
+    schema = {"properties": {"mytag": {"type": "string"}}}
+
+    # validate directly first to confirm assumptions
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance, schema)
+
+    # now validate with our code
+    vdr = _Validator(global_schema=schema)
+    res = vdr._validate(instance, schema)
     assert res["valid"] == False
+    assert "reason" in res
+    assert "123.0 is not of type 'string'" in res["reason"]
+
+
+# ================
+# tmp fixtures
+# ================
+
+
+def _fmu_schema_url():
+    """Return the schema url."""
+    protocol = "https"
+    subdomain = "main-fmu-schemas-dev"
+    domain = "radix.equinor.com"
+
+    version = "0.8.0"
+    schema = "fmu_results.json"
+    path = f"schemas/{version}/{schema}"
+
+    return f"{protocol}://{subdomain}.{domain}/{path}"
+
+
+def _fmu_schema_path():
+    """Return the filepath to the fmu_results schema."""
+    return str(PurePath(ROOTPWD, "schema/definitions/0.8.0/schema/fmu_results.json"))


### PR DESCRIPTION
This PR closes #125 and replaces standalone draft validator in https://github.com/equinor/fmu-metadata-validator

This PR includes a class for metadata validation and a command line script for using it. The class enables local validation of metadata against remote schema or local schema. For remote schema, caching is implemented to avoid excessive network traffic.

- [ ] Consider adding support for using the `validate` endpoint on Sumo
- [ ] Agree on test schema, fixtures etc.
- [ ] Add documentation and examples