### PR TITLE
add file.size_bytes to schema and examples

### DIFF
--- a/schema/definitions/0.8.0/examples/aggregated_surface_depth.yml
+++ b/schema/definitions/0.8.0/examples/aggregated_surface_depth.yml
@@ -71,6 +71,7 @@ file:
   relative_path: iter-0/share/results/maps/volantis_gp_base--amplitude--mean.gri # case-relative
   absolute_path: /some/absolute/path/iter-0/share/results/maps/volantis_gp_base--amplitude--mean.gri
   checksum_md5: kjhsdfvsdlfk23knerknvk23  # checksum of the file, not the data.
+  size_bytes: 132321
 
 data: # The data block describes the actual data (e.g. surface). Only present in data objects
 

--- a/schema/definitions/0.8.0/examples/polygons_field_outline.yml
+++ b/schema/definitions/0.8.0/examples/polygons_field_outline.yml
@@ -73,6 +73,7 @@ file:
   relative_path: realization-33/iter-0/share/results/polygons/field_outline--goc.gri # case-relative
   absolute_path: /some/absolute/path//realization-33/iter-0/share/results/polygons/field_outline--goc.gri
   checksum_md5: kjhsdfvsdlfk23knerknvk23  # checksum of the file, not the data.
+  size_bytes: 132321
 
 data: # The data block describes the actual data (e.g. surface). Only present in data objects
 

--- a/schema/definitions/0.8.0/examples/surface_depth.yml
+++ b/schema/definitions/0.8.0/examples/surface_depth.yml
@@ -73,7 +73,8 @@ file:
   relative_path: realization-33/iter-0/share/results/maps/volantis_gp_base--amplitude.gri # case-relative
   absolute_path: /some/absolute/path//realization-33/iter-0/share/results/maps/volantis_gp_base--amplitude.gri
   checksum_md5: kjhsdfvsdlfk23knerknvk23  # checksum of the file, not the data.
-
+  size_bytes: 132321
+  
 data: # The data block describes the actual data (e.g. surface). Only present in data objects
 
   # if stratigraphic, name must match the strat column. This is the official name of this surface.

--- a/schema/definitions/0.8.0/examples/surface_fluid_contact.yml
+++ b/schema/definitions/0.8.0/examples/surface_fluid_contact.yml
@@ -76,7 +76,8 @@ file:
   relative_path: realization-33/iter-0/share/results/maps/volantis_gp_base--amplitude.gri # case-relative
   absolute_path: /some/absolute/path//realization-33/iter-0/share/results/maps/volantis_gp_base--amplitude.gri
   checksum_md5: kjhsdfvsdlfk23knerknvk23 # checksum of the file, not the data.
-
+  size_bytes: 132321
+  
 data: # The data block describes the actual data (e.g. surface).Only present in data objects
   # if stratigraphic, name must match the strat column. This is the official name of this surface.
   name: volantis_top-volantis_base

--- a/schema/definitions/0.8.0/examples/surface_seismic_amplitude.yml
+++ b/schema/definitions/0.8.0/examples/surface_seismic_amplitude.yml
@@ -75,7 +75,8 @@ file:
   relative_path: realization-33/iter-0/share/results/maps/volantis_gp_base--amplitude.gri # case-relative
   absolute_path: /some/absolute/path//realization-33/iter-0/share/results/maps/volantis_gp_base--amplitude.gri
   checksum_md5: kjhsdfvsdlfk23knerknvk23  # checksum of the file, not the data.
-
+  size_bytes: 132321
+  
 data: # The data block describes the actual data (e.g. surface). Only present in data objects
 
   # if stratigraphic, name must match the strat column. This is the official name of this surface.

--- a/schema/definitions/0.8.0/schema/fmu_results.json
+++ b/schema/definitions/0.8.0/schema/fmu_results.json
@@ -32,7 +32,8 @@
         "fmu.aggregation.operation",
         "fmu.aggregation.realization_ids",
         "file.relative_path",
-        "file.checksum_md5"
+        "file.checksum_md5",
+        "file.size_bytes"
     ],
     "definitions": {
         "generic": {
@@ -1031,7 +1032,8 @@
             "type": "object",
             "required": [
                 "relative_path",
-                "checksum_md5"
+                "checksum_md5",
+                "size_bytes"
             ],
             "properties": {
                 "relative_path": {
@@ -1053,6 +1055,13 @@
                     "type": "string",
                     "examples": [
                         "kjhsdfvsdlfk23knerknvk23"
+                    ]
+                },
+                "size_bytes": {
+                    "description": "Size of file object in bytes",
+                    "type": "integer",
+                    "examples": [
+                        123
                     ]
                 }
             }

--- a/schema/definitions/0.8.0/schema/fmu_results.json
+++ b/schema/definitions/0.8.0/schema/fmu_results.json
@@ -1032,8 +1032,7 @@
             "type": "object",
             "required": [
                 "relative_path",
-                "checksum_md5",
-                "size_bytes"
+                "checksum_md5"
             ],
             "properties": {
                 "relative_path": {


### PR DESCRIPTION
Solving #235 

Element is already added to outgoing metadata, but was not included in the schema.