### PR TITLE
Reverse order of ert.shared vs ert_shared

### DIFF
--- a/src/fmu/dataio/hook_implementations/jobs.py
+++ b/src/fmu/dataio/hook_implementations/jobs.py
@@ -1,9 +1,9 @@
 try:
-    from ert_shared.plugins.plugin_manager import hook_implementation
-    from ert_shared.plugins.plugin_response import plugin_response
-except ModuleNotFoundError:
     from ert.shared.plugins.plugin_manager import hook_implementation
     from ert.shared.plugins.plugin_response import plugin_response
+except ModuleNotFoundError:
+    from ert_shared.plugins.plugin_manager import hook_implementation
+    from ert_shared.plugins.plugin_response import plugin_response
 
 
 @hook_implementation

--- a/src/fmu/dataio/scripts/create_case_metadata.py
+++ b/src/fmu/dataio/scripts/create_case_metadata.py
@@ -14,9 +14,9 @@ import logging
 from pathlib import Path
 
 try:
-    from ert_shared.plugins.plugin_manager import hook_implementation  # type: ignore
+    from ert.shared.plugins.plugin_manager import hook_implementation  # type: ignore
 except ModuleNotFoundError:
-    from ert.shared.plugins.plugin_manager import hook_implementation
+    from ert_shared.plugins.plugin_manager import hook_implementation  # type: ignore
 
 try:
     from ert import ErtScript  # type: ignore


### PR DESCRIPTION
Importing the deprecated package name can trigger
a deprecation warning.