### PR TITLE
Use dependencies keyword on aggregation vs realization

### DIFF
--- a/schema/definitions/0.8.0/schema/fmu_results.json
+++ b/schema/definitions/0.8.0/schema/fmu_results.json
@@ -1163,13 +1163,6 @@
                         "case",
                         "workflow"
                     ],
-                    "$comment": "realization or aggregation or none, never both",
-                    "not": {
-                        "required": [
-                            "realization",
-                            "aggregation"
-                        ]
-                    },
                     "properties": {
                         "model": {
                             "$ref": "#/definitions/fmu/model"

--- a/schema/definitions/0.8.0/schema/fmu_results.json
+++ b/schema/definitions/0.8.0/schema/fmu_results.json
@@ -1183,6 +1183,7 @@
                             "$ref": "#/definitions/fmu/aggregation"
                         }
                     },
+                    "$comment": "implementation below allows realization or aggregation or none of them, never both",
                     "dependencies": {
                         "aggregation": {
                             "not": {

--- a/schema/definitions/0.8.0/schema/fmu_results.json
+++ b/schema/definitions/0.8.0/schema/fmu_results.json
@@ -1189,6 +1189,22 @@
                         "aggregation": {
                             "$ref": "#/definitions/fmu/aggregation"
                         }
+                    },
+                    "dependencies": {
+                        "aggregation": {
+                            "not": {
+                                "required": [
+                                    "realization"
+                                ]
+                            }
+                        },
+                        "realization": {
+                            "not": {
+                                "required": [
+                                    "aggregation"
+                                ]
+                            }
+                        }
                     }
                 },
                 "file": {


### PR DESCRIPTION
Solve problem with using the `not` keyword directly. Trying the `dependencies` keyword instead. The intention is to allow either `fmu.realization`, `fmu.aggregation` or none of them - never both.