### PR TITLE
make fmu.workflow not required

### DIFF
--- a/schema/definitions/0.8.0/schema/fmu_results.json
+++ b/schema/definitions/0.8.0/schema/fmu_results.json
@@ -1172,8 +1172,7 @@
                     "$comment": "This is the fmu block as it appears in data objects",
                     "required": [
                         "model",
-                        "case",
-                        "workflow"
+                        "case"
                     ],
                     "properties": {
                         "model": {


### PR DESCRIPTION
Solve #275 

Make `fmu.workflow` no longer _required_. Still part of `$contractual` attributes, and still defined - but we will allow data out of FMU that does not contain the `fmu.workflow` keyword.