### PR TITLE
allow data.time to be object/dict

### DIFF
--- a/schema/definitions/0.8.0/schema/fmu_results.json
+++ b/schema/definitions/0.8.0/schema/fmu_results.json
@@ -81,6 +81,7 @@
             "title": "FMU time object",
             "description": "List of time stamps referring to simulated time",
             "type": [
+                "object",
                 "array",
                 "null"
             ],


### PR DESCRIPTION
Retrofitting to match existing behavior of fmu-dataio where the `data.time` attribute is a dict/object, not a list.