### PR TITLE
Ensure correct data.name when preprocessed/merged

### DIFF
--- a/src/fmu/dataio/_metadata.py
+++ b/src/fmu/dataio/_metadata.py
@@ -152,6 +152,8 @@ class _MetaData:
     meta_file: dict = field(default_factory=dict, init=False)
     meta_tracklog: list = field(default_factory=list, init=False)
     meta_fmu: dict = field(default_factory=dict, init=False)
+    # temporary storage for preprocessed data:
+    meta_xpreprocessed: dict = field(default_factory=dict, init=False)
 
     # relevant when ERT* fmu_context; same as rootpath in the ExportData class!:
     rootpath: str = field(default="", init=False)
@@ -282,6 +284,13 @@ class _MetaData:
         if self.dataio:
             self.meta_access = generate_meta_access(self.dataio.config)
 
+    def _populate_meta_xpreprocessed(self):
+        """Populate a few necessary 'tmp' metadata needed for preprocessed data."""
+        if self.dataio.fmu_context == "preprocessed":
+            self.meta_xpreprocessed["name"] = self.dataio.name
+            self.meta_xpreprocessed["tagname"] = self.dataio.tagname
+            self.meta_xpreprocessed["subfolder"] = self.dataio.subfolder
+
     def _reuse_existing_metadata(self, meta):
         """Perform a merge procedure if the key `reuse_metadata_rule` is active."""
         if self.dataio and self.dataio.reuse_metadata_rule:
@@ -307,6 +316,7 @@ class _MetaData:
         self._populate_meta_class()
         self._populate_meta_fmu()
         self._populate_meta_file()
+        self._populate_meta_xpreprocessed()
 
         # glue together metadata, order is as legacy code (but will be screwed if reuse
         # of existing metadata...)
@@ -322,6 +332,9 @@ class _MetaData:
 
         meta["access"] = self.meta_access
         meta["masterdata"] = self.meta_masterdata
+
+        if self.dataio.fmu_context == "preprocessed":
+            meta["_preprocessed"] = self.meta_xpreprocessed
 
         if skip_null:
             meta = drop_nones(meta)

--- a/src/fmu/dataio/_utils.py
+++ b/src/fmu/dataio/_utils.py
@@ -450,15 +450,16 @@ def glue_metadata_preprocessed(oldmeta, newmeta):
     """Glue (combine) to metadata dicts according to rule 'preprocessed'."""
 
     meta = oldmeta.copy()
+
+    if "_preprocessed" in meta:
+        del meta["_preprocessed"]
+
     meta["fmu"] = newmeta["fmu"]
     meta["file"] = newmeta["file"]
     meta["access"] = newmeta["access"]
 
     newmeta["tracklog"][-1]["event"] = "merged"
     meta["tracklog"].extend(newmeta["tracklog"])
-
-    # the only field in 'data' that are allowed to update is name:
-    meta["data"]["name"] = newmeta["data"]["name"]
 
     return meta
 

--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -733,22 +733,22 @@ class ExportData:
                 self.reuse_metadata_rule = "preprocessed"
 
             currentmeta = read_metadata(obj)
-            if not self.name and currentmeta["data"].get("name", ""):
-                self.name = currentmeta["data"]["name"]
+            if "_preprocessed" not in currentmeta:
+                raise ValidationError(
+                    "The special entry for preprocessed data <_preprocessed> is"
+                    "missing in the metadata. A possible solution is to rerun the"
+                    "preprocessed export."
+                )
 
-            if not self.tagname and currentmeta["data"].get("tagname", ""):
-                self.tagname = currentmeta["data"]["tagname"]
+            if not self.name and currentmeta["_preprocessed"].get("name", ""):
+                self.name = currentmeta["_preprocessed"]["name"]
 
-            # detect if object is on a subfolder relative to /preprocessed/xxxx
-            for ipar in range(3):
-                foldername = obj.parents[ipar].stem
-                if foldername == "preprocessed" and ipar == 2:
-                    if not self.subfolder:
-                        self.subfolder = obj.parents[0].stem
-                        logger.info(
-                            "Subfolder is auto-derived from preprocessed file path: %s",
-                            self.subfolder,
-                        )
+            if not self.tagname and currentmeta["_preprocessed"].get("tagname", ""):
+                self.tagname = currentmeta["_preprocessed"]["tagname"]
+
+            if not self.subfolder and currentmeta["_preprocessed"].get("subfolder", ""):
+                self.subfolder = currentmeta["_preprocessed"]["subfolder"]
+
         return obj
 
     # ==================================================================================

--- a/tests/test_units/test_prerealization_surfaces.py
+++ b/tests/test_units/test_prerealization_surfaces.py
@@ -91,7 +91,7 @@ def test_regsurf_preprocessed_observation(
         edata = dataio.ExportData(
             config=rmsglobalconfig,  # read from global config
             fmu_context="preprocessed",
-            name="preprocessedmap",
+            name="TopVolantis",
             is_observation=True,
             timedata=[[20240802, "moni"], [20200909, "base"]],
         )
@@ -101,8 +101,10 @@ def test_regsurf_preprocessed_observation(
 
         assert (
             metadata["file"]["relative_path"]
-            == "share/preprocessed/maps/preprocessedmap--20240802_20200909.gri"
+            == "share/preprocessed/maps/topvolantis--20240802_20200909.gri"
         )
+        assert metadata["data"]["name"] == "VOLANTIS GP. Top"
+        assert "_preprocessed" in metadata
 
         return edata.export(regsurf)
 
@@ -123,7 +125,6 @@ def test_regsurf_preprocessed_observation(
         edata = dataio.ExportData(
             config=rmsglobalconfig,  # read from global config
             fmu_context="case",
-            name="preprocessed_v2",
             is_observation=True,
         )
         metadata = edata.generate_metadata(
@@ -132,9 +133,12 @@ def test_regsurf_preprocessed_observation(
         logger.debug("\n%s", utils.prettyprint_dict(metadata))
         assert (
             metadata["file"]["relative_path"]
-            == "share/observations/maps/preprocessed_v2--20240802_20200909.gri"
+            == "share/observations/maps/topvolantis--20240802_20200909.gri"
         )
         assert "merged" in metadata["tracklog"][-1]["event"]
+        assert metadata["data"]["name"] == "VOLANTIS GP. Top"
+        assert "TopVolantis" in metadata["data"]["alias"]
+        assert "_preprocessed" not in metadata
 
     # run two stage process
     mysurf = _export_data_from_rms(rmssetup, rmsglobalconfig, regsurf)

--- a/tests/test_units/test_rms_context.py
+++ b/tests/test_units/test_rms_context.py
@@ -92,6 +92,13 @@ def test_regsurf_export_file_set_name(rmssetup, rmsglobalconfig, regsurf):
         (edata._rootpath / "share/results/maps/topvolantis.gri").resolve()
     )
 
+    meta = edata.generate_metadata(
+        regsurf,
+        name="TopVolantis",
+    )
+    assert meta["data"]["name"] == "VOLANTIS GP. Top"  # strat name from SMDA
+    assert "TopVolantis" in meta["data"]["alias"]
+
 
 @inside_rms
 def test_regsurf_metadata_with_timedata(rmssetup, rmsglobalconfig, regsurf):


### PR DESCRIPTION
Now the true stratigraphic name is propagated correctly from pre- processed to FMU merged result. Some refaktor/simplification; needed variables such as input name, tagname and subfolder from preprocessed are tmp stored under a _preprocessed field in the metadata.