### PR TITLE
Adjust behaviour when invalid metadata

### DIFF
--- a/src/fmu/dataio/_metadata.py
+++ b/src/fmu/dataio/_metadata.py
@@ -309,9 +309,11 @@ class _MetaData:
         """Main function to generate the full metadata"""
 
         # populate order matters, in particular objectdata provides input to class/file
-        self._populate_meta_masterdata()
+        if self.dataio._config_is_valid:
+            self._populate_meta_masterdata()
+            self._populate_meta_access()
+
         self._populate_meta_tracklog()
-        self._populate_meta_access()
         self._populate_meta_objectdata()
         self._populate_meta_class()
         self._populate_meta_fmu()

--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -94,10 +94,11 @@ def _check_global_config(
 
     if not globalconfig and not strict:
         logger.info(
-            "Empty global config, expect input from environment_variable insteac"
+            "Empty global config, expect input from environment_variable instead"
         )
         return False
 
+    # strict is True:
     config_required_keys = ["access", "masterdata", "model"]
     missing_keys = []
     for required_key in config_required_keys:
@@ -853,7 +854,7 @@ class ExportData:
             export_metadata_file(metafile, metadata, savefmt=self.meta_format)
             logger.info("Metadata file is: %s", metafile)
         else:
-            warnings.warn("Metadata are invalid and will not be exported!", UserWarning)
+            warnings.warn("Data will be exported, but without metadata.", UserWarning)
 
         # generate symlink if requested
         outfile_target = None

--- a/tests/test_units/test_dataio.py
+++ b/tests/test_units/test_dataio.py
@@ -56,6 +56,27 @@ def test_missing_or_wrong_config_exports_with_warning(regsurf):
         read_metadata(out)
 
 
+def test_config_miss_required_fields(globalconfig1, regsurf):
+    """Global config exists but missing critical data; export file but skip metadata."""
+
+    cfg = globalconfig1.copy()
+
+    del cfg["access"]
+    del cfg["masterdata"]
+    del cfg["model"]
+
+    with pytest.warns(PendingDeprecationWarning, match="One or more keys required"):
+        edata = ExportData(config=cfg)
+
+    with pytest.warns(UserWarning, match="without metadata"):
+        out = edata.export(regsurf, name="mysurface")
+
+    assert "mysurface" in out
+
+    with pytest.raises(OSError, match="Cannot find requested metafile"):
+        read_metadata(out)
+
+
 def test_update_check_settings_shall_fail(globalconfig1):
 
     # pylint: disable=unexpected-keyword-arg

--- a/tests/test_units/test_prerealization_surfaces.py
+++ b/tests/test_units/test_prerealization_surfaces.py
@@ -352,6 +352,7 @@ def test_preprocessed_with_rel_forcefolder_ok(rmssetup, rmsglobalconfig, regsurf
         timedata=[[20240802, "moni"], [20200909, "base"]],
         forcefolder="tmp",
     )
+    with pytest.warns(UserWarning, match="The standard folder name is overrided"):
+        meta = edata.generate_metadata(regsurf)
 
-    meta = edata.generate_metadata(regsurf)
     assert "preprocessed/tmp" in meta["file"]["relative_path"]


### PR DESCRIPTION
The `fmu.dataio` is now being implemented in the next release of demo case Drogon, and this is applied further by numerous assets as a template. Since SUMO still is too immature for broad implementation, a request exists to make it possible for `dataio` to work with with "current" global config, at least for a time period (cf. @rnyb).

The behaviour now is that if  e.g. `masterdata` section is missing, the date file will be exported but without the metadata `.yml` file.

This request was partially solved by #269, when the global config is an empty dict.
 