### PR TITLE
lock data.time to a dictionary with t0 and t1

### DIFF
--- a/schema/definitions/0.8.0/examples/aggregated_surface_depth.yml
+++ b/schema/definitions/0.8.0/examples/aggregated_surface_depth.yml
@@ -137,11 +137,6 @@ data: # The data block describes the actual data (e.g. surface). Only present in
     ymax: 5939492.128326312
     zmin: 1244.039
     zmax: 2302.683
-  time:
-    - value: 2020-10-28T14:28:02
-      label: "some label"
-    - value: 2020-10-28T14:28:02
-      label: "some other label"
   is_prediction: true # A mechanism for separating pure QC output from actual predictions
   is_observation: true # Used for 4D data currently but also valid for other data?
   description:

--- a/schema/definitions/0.8.0/examples/polygons_field_outline.yml
+++ b/schema/definitions/0.8.0/examples/polygons_field_outline.yml
@@ -101,11 +101,6 @@ data: # The data block describes the actual data (e.g. surface). Only present in
     ymax: 5939492.128326312
     zmin: 1244.039
     zmax: 2302.683
-  time:
-    - value: 2020-10-28T14:28:02
-      label: "some label"
-    - value: 2020-10-28T14:28:02
-      label: "some other label"
   is_prediction: true # A mechanism for separating pure QC output from actual predictions
   is_observation: false # Used for 4D data currently but also valid for other data?
   description:

--- a/schema/definitions/0.8.0/examples/preprocessed_surface_depth.yml
+++ b/schema/definitions/0.8.0/examples/preprocessed_surface_depth.yml
@@ -112,11 +112,6 @@ data: # The data block describes the actual data (e.g. surface). Only present in
     ymax: 5939492.128326312
     zmin: 1244.039
     zmax: 2302.683
-  time:
-    - value: 2020-10-28T14:28:02
-      label: "some label"
-    - value: 2020-10-28T14:28:02
-      label: "some other label"
   is_prediction: true # A mechanism for separating pure QC output from actual predictions
   is_observation: true # Used for 4D data currently but also valid for other data?
   description:

--- a/schema/definitions/0.8.0/examples/surface_depth.yml
+++ b/schema/definitions/0.8.0/examples/surface_depth.yml
@@ -127,11 +127,6 @@ data: # The data block describes the actual data (e.g. surface). Only present in
     ymax: 5939492.128326312
     zmin: 1244.039
     zmax: 2302.683
-  time:
-    - value: 2020-10-28T14:28:02
-      label: "some label"
-    - value: 2020-10-28T14:28:02
-      label: "some other label"
   is_prediction: true # A mechanism for separating pure QC output from actual predictions
   is_observation: true # Used for 4D data currently but also valid for other data?
   undef_is_zero: false # Used to flag if undef should be considered 0.0 in statistics

--- a/schema/definitions/0.8.0/examples/surface_fluid_contact.yml
+++ b/schema/definitions/0.8.0/examples/surface_fluid_contact.yml
@@ -134,11 +134,6 @@ data: # The data block describes the actual data (e.g. surface).Only present in 
     ymax: 5939492.128326312
     zmin: 1244.039
     zmax: 2302.683
-  time:
-    - value: 2020-10-28T14:28:02
-      label: "some label"
-    - value: 2020-10-28T14:28:02
-      label: "some other label"
   is_prediction: true # A mechanism for separating pure QC output from actual predictions
   is_observation: true # Used for 4D data currently but also valid for other data?
   description:

--- a/schema/definitions/0.8.0/examples/surface_seismic_amplitude.yml
+++ b/schema/definitions/0.8.0/examples/surface_seismic_amplitude.yml
@@ -138,10 +138,12 @@ data: # The data block describes the actual data (e.g. surface). Only present in
     zmin: 1244.039
     zmax: 2302.683
   time:
-    - value: 2020-10-28T14:28:02
-      label: "some label"
-    - value: 2020-10-28T14:28:02
-      label: "some other label"
+    t0:
+      value: 2020-10-28T14:28:02
+      label: "base"
+    t1: 
+      value: 2020-10-28T14:28:03
+      label: "monitor"
   is_prediction: true # A mechanism for separating pure QC output from actual predictions
   is_observation: true # Used for 4D data currently but also valid for other data?
   description:

--- a/schema/definitions/0.8.0/schema/fmu_results.json
+++ b/schema/definitions/0.8.0/schema/fmu_results.json
@@ -80,27 +80,24 @@
         },
         "fmu_time": {
             "title": "FMU time object",
-            "description": "List of time stamps referring to simulated time",
+            "description": "Time stamp for data object.",
             "type": [
                 "object",
-                "array",
                 "null"
             ],
-            "items": {
-                "type": "object",
-                "properties": {
-                    "value": {
-                        "$ref": "#/definitions/generic/datetime"
-                    },
-                    "label": {
-                        "type": "string",
-                        "examples": [
-                            "Label for time stamp"
-                        ]
-                    }
+            "properties": {
+                "value": {
+                    "$ref": "#/definitions/generic/datetime"
+                },
+                "label": {
+                    "type": "string",
+                    "examples": [
+                        "base",
+                        "monitor",
+                        "mylabel"
+                    ]
                 }
-            },
-            "minItems": 1
+            }
         },
         "class": {
             "title": "Metadata class",
@@ -488,7 +485,15 @@
                     }
                 },
                 "time": {
-                    "$ref": "#/definitions/fmu_time"
+                    "type": "object",
+                    "properties": {
+                        "t0": {
+                            "$ref": "#/definitions/fmu_time"
+                        },
+                        "t1": {
+                            "$ref": "#/definitions/fmu_time"
+                        }
+                    }
                 },
                 "is_prediction": {
                     "title": "Is prediction flag",
@@ -1066,7 +1071,9 @@
                     "stage": {
                         "type": "string",
                         "examples": [
-                            "case", "iteration", "realization"
+                            "case",
+                            "iteration",
+                            "realization"
                         ]
                     }
                 }

--- a/src/fmu/dataio/_objectdata_provider.py
+++ b/src/fmu/dataio/_objectdata_provider.py
@@ -144,7 +144,6 @@ class _ObjectDataProvider:
     time1: str = field(default="", init=False)
 
     def __post_init__(self):
-
         logger.info("Ran __post_init__")
 
     def _derive_name_stratigraphy(self) -> dict:
@@ -497,7 +496,6 @@ class _ObjectDataProvider:
                 xfield["label"] = elem[1]
             tresult["time"].append(xfield)
         if len(tdata) == 2:
-
             elem1 = tdata[0]
             xfield1 = {"value": dt.strptime(str(elem1[0]), "%Y%m%d").isoformat()}
             if len(elem1) == 2:

--- a/src/fmu/dataio/_utils.py
+++ b/src/fmu/dataio/_utils.py
@@ -93,7 +93,6 @@ def export_metadata_file(yfile, metadata, savefmt="yaml", verbosity="WARNING") -
     """Export genericly and ordered to the complementary metadata file."""
     logger.setLevel(level=verbosity)
     if metadata:
-
         xdata = drop_nones(metadata)
 
         if savefmt == "yaml":

--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -708,7 +708,6 @@ class ExportData:
 
         else:
             if self._inside_rms or INSIDE_RMS or "RUN_DATAIO_EXAMPLES" in os.environ:
-
                 self._rootpath = (self._pwd / "../../.").absolute().resolve()
                 logger.info("Run from inside RMS (or pretend)")
                 self._inside_rms = True
@@ -970,7 +969,6 @@ class InitializeCase:  # pylint: disable=too-few-public-methods
         logger.info("Set rootpath (case): %s", str(self._casepath))
 
     def _check_already_metadata_or_create_folder(self, force=False) -> bool:
-
         if not self._casepath.exists():
             self._casepath.mkdir(parents=True, exist_ok=True)
             logger.info("Created rootpath (case) %s", self._casepath)
@@ -1269,7 +1267,6 @@ class AggregatedData:
     def _generate_aggrd_metadata(
         self, obj: Any, real_ids: List[int], uuids: List[str], compute_md5: bool = True
     ):
-
         logger.info(
             "self.aggregation is %s (%s)",
             self.aggregation_id,

--- a/tests/test_units/test_dataio.py
+++ b/tests/test_units/test_dataio.py
@@ -78,7 +78,6 @@ def test_config_miss_required_fields(globalconfig1, regsurf):
 
 
 def test_update_check_settings_shall_fail(globalconfig1):
-
     # pylint: disable=unexpected-keyword-arg
     with pytest.raises(TypeError):
         _ = ExportData(config=globalconfig1, stupid="str")

--- a/tests/test_units/test_initialize_case.py
+++ b/tests/test_units/test_initialize_case.py
@@ -16,13 +16,11 @@ logger = logging.getLogger(__name__)
 
 
 def test_inicase_barebone(globalconfig2):
-
     icase = InitializeCase(config=globalconfig2, verbosity="INFO")
     assert "Drogon" in str(icase.config)
 
 
 def test_inicase_barebone_with_export(globalconfig2, fmurun):
-
     icase = InitializeCase(config=globalconfig2, verbosity="INFO")
     assert "Drogon" in str(icase.config)
 
@@ -57,7 +55,6 @@ def test_inicase_barebone_with_export(globalconfig2, fmurun):
 
 
 def test_inicase_pwd_basepath(fmurun, globalconfig2):
-
     logger.info("Active folder is %s", fmurun)
     os.chdir(fmurun)
 
@@ -132,7 +129,6 @@ def test_inicase_update_settings_shall_fail(fmurun, globalconfig2):
 
 
 def test_inicase_generate_case_metadata(fmurun, globalconfig2):
-
     logger.info("Active folder is %s", fmurun)
     os.chdir(fmurun)
     myroot = fmurun.parent.parent.parent / "mycase"
@@ -146,7 +142,6 @@ def test_inicase_generate_case_metadata(fmurun, globalconfig2):
 def test_inicase_generate_case_metadata_exists_so_fails(
     fmurun_w_casemetadata, globalconfig2
 ):
-
     logger.info("Active folder is %s", fmurun_w_casemetadata)
     os.chdir(fmurun_w_casemetadata)
     logger.info("Folder is %s", fmurun_w_casemetadata)
@@ -160,7 +155,6 @@ def test_inicase_generate_case_metadata_exists_so_fails(
 def test_inicase_generate_case_metadata_exists_but_force(
     fmurun_w_casemetadata, globalconfig2
 ):
-
     logger.info("Active folder is %s", fmurun_w_casemetadata)
     os.chdir(fmurun_w_casemetadata)
     logger.info("Folder is %s", fmurun_w_casemetadata)

--- a/tests/test_units/test_metadata_class.py
+++ b/tests/test_units/test_metadata_class.py
@@ -39,7 +39,6 @@ def test_populate_meta_objectdata(regsurf, edataobj2):
 
 
 def test_populate_meta_undef_is_zero(regsurf, globalconfig2):
-
     eobj1 = dio.ExportData(
         config=globalconfig2,
         name="TopVolantis",


### PR DESCRIPTION
Following discussions and with reference to #195 this PR updates the metadata examples and the schema to assume data.time as a dictionary.