### PR TITLE
allow field_region as content

### DIFF
--- a/schema/definitions/0.8.0/examples/polygons_field_region.yml
+++ b/schema/definitions/0.8.0/examples/polygons_field_region.yml
@@ -62,6 +62,8 @@ file:
 
 data: # The data block describes the actual data (e.g. surface). Only present in data objects
   content: field_region  # white-listed and standardized
+  field_region: # content-specific element, only present when content == "field_region"
+    id: 1 # if applicable, the number of the region
   name: CentralHorst
   stratigraphic: false
   format: csv

--- a/schema/definitions/0.8.0/examples/polygons_field_region.yml
+++ b/schema/definitions/0.8.0/examples/polygons_field_region.yml
@@ -1,0 +1,119 @@
+# Example metadata for a polygon(s)
+
+$schema: https://main-fmu-schemas-dev.radix.equinor.com/schemas/0.8.0/fmu_results.json
+version: "0.8.0"
+source: fmu
+
+tracklog:
+  - datetime: 2020-10-28T14:28:02
+    user:
+      id: peesv
+    event: created
+  - datetime: 2020-10-28T14:46:14
+    user: 
+      id: peesv
+    event: updated
+
+class: polygons
+
+fmu:
+  model:
+    name: ff
+    revision: 21.0.0.dev
+    description:
+      - detailed description
+      - optional
+
+  case:
+    name: MyCaseName
+    uuid: 8bb56d60-8758-481a-89a4-6bac8561d38e
+    user:
+      id: jriv # $USER from ERT
+
+  iteration:
+    id: 0 # always an int, will be 0 for e.g. "pred"
+    uuid: 4b939310-34b1-4179-802c-49460bc0f799
+    name: "iter-0" # /"pred"
+
+  realization:
+    id: 33
+    uuid: 29a15b21-ce13-471b-9a4a-0f791552aa51 # hash of case.uuid + iteration.uuid + realization.id
+    name: "realization-33"
+    parameters: # directly pass parameters.txt. This is potentially a lot of content, only a stub is included here.
+      SENSNAME: faultseal
+      SENSCASE: low
+      RMS_SEED: 1006
+      INIT_FILES:
+        PERM_FLUVCHAN_E1_NORM: 0.748433
+        PERM_FLUVCHAN_E21_NORM: 0.782068
+      KVKH_CHANNEL: 0.6
+      KVKH_US: 0.6
+      FAULT_SEAL_SCALING: 0.1
+      FWL_CENTRAL: 1677
+
+  context:
+    stage: realization
+
+file:
+  relative_path: realization-33/iter-0/share/results/polygons/field_region--central_horst.gri # case-relative
+  absolute_path: /some/absolute/path//realization-33/iter-0/share/results/polygons/field_region--central_horst.gri
+  checksum_md5: kjhsdfvsdlfk23knerknvk23  # checksum of the file, not the data.
+  size_bytes: 132
+
+data: # The data block describes the actual data (e.g. surface). Only present in data objects
+  content: field_region  # white-listed and standardized
+  name: central_horst
+  stratigraphic: false
+  format: csv
+  unit: m
+  vertical_domain: depth # / time / null
+  depth_reference: msl # / seabed / etc # mandatory when vertical_domain is depth?
+  spec:
+    npolys: 1
+  bbox:
+    xmin: 456012.5003497944
+    xmax: 467540.52762886323
+    ymin: 5926499.999511719
+    ymax: 5939492.128326312
+    zmin: 0.0
+    zmax: 0.0
+  is_prediction: false # A mechanism for separating pure QC output from actual predictions
+  is_observation: false # Used for 4D data currently but also valid for other data?
+  description:
+    - Field region
+
+display:
+  name: Central Horst
+  subtitle: null
+  line:
+    show: true
+    color: black
+    style: solid
+  fill:
+    show: false
+
+access:
+  asset:
+    name: Drogon
+  ssdl:
+    access_level: internal
+    rep_include: true
+
+masterdata:
+  smda:
+    country:
+      - identifier: Norway
+        uuid: ad214d85-8a1d-19da-e053-c918a4889309
+    discovery:
+      - short_identifier: DROGON
+        uuid: 00000000-0000-0000-0000-000000000000 # mock uuid for Drogon
+    field:
+      - identifier: DROGON
+        uuid: 00000000-0000-0000-0000-000000000000 # mock uuid for Drogon
+    coordinate_system:
+      identifier: ST_WGS84_UTM37N_P32637
+      uuid: ad214d85-dac7-19da-e053-c918a4889309
+    stratigraphic_column:
+      identifier: DROGON_2020
+      uuid: 00000000-0000-0000-0000-000000000000 # mock uuid for Drogon
+

--- a/schema/definitions/0.8.0/examples/polygons_field_region.yml
+++ b/schema/definitions/0.8.0/examples/polygons_field_region.yml
@@ -62,7 +62,7 @@ file:
 
 data: # The data block describes the actual data (e.g. surface). Only present in data objects
   content: field_region  # white-listed and standardized
-  name: central_horst
+  name: CentralHorst
   stratigraphic: false
   format: csv
   unit: m

--- a/schema/definitions/0.8.0/schema/fmu_results.json
+++ b/schema/definitions/0.8.0/schema/fmu_results.json
@@ -550,6 +550,19 @@
                         }
                     }
                 },
+                "field_region": {
+                    "description": "Conditional field",
+                    "type": "object",
+                    "required": [
+                        "id"
+                    ],
+                    "properties": {
+                        "id": {
+                            "description": "The ID of the region",
+                            "type": "integer"
+                        }
+                    }
+                },
                 "description": {
                     "$ref": "#/definitions/generic/_description"
                 },
@@ -1266,6 +1279,21 @@
                             "then": {
                                 "required": [
                                     "field_outline"
+                                ]
+                            }
+                        },
+                        {
+                            "$comment": "When content == field_region, require data.field_region",
+                            "if": {
+                                "properties": {
+                                    "content": {
+                                        "const": "field_region"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "required": [
+                                    "field_region"
                                 ]
                             }
                         },

--- a/src/fmu/dataio/_definitions.py
+++ b/src/fmu/dataio/_definitions.py
@@ -49,7 +49,7 @@ ALLOWED_CONTENTS = {
     },
     "fluid_contact": {"contact": str, "truncated": bool},
     "field_outline": {"contact": str},
-    "field_region": None,
+    "field_region": {"id": int},
     "regions": None,
     "pinchout": None,
     "subcrop": None,
@@ -74,6 +74,7 @@ DEPRECATED_CONTENTS = {
 CONTENTS_REQUIRED = {
     "fluid_contact": {"contact": True},
     "field_outline": {"contact": False},
+    "field_region": {"id": True},
 }
 
 # This setting sets the FMU context for the output. If detected as a non-fmu run,

--- a/src/fmu/dataio/_definitions.py
+++ b/src/fmu/dataio/_definitions.py
@@ -49,6 +49,7 @@ ALLOWED_CONTENTS = {
     },
     "fluid_contact": {"contact": str, "truncated": bool},
     "field_outline": {"contact": str},
+    "field_region": None,
     "regions": None,
     "pinchout": None,
     "subcrop": None,

--- a/tests/test_units/test_dataio.py
+++ b/tests/test_units/test_dataio.py
@@ -190,6 +190,21 @@ def test_content_is_dict_with_wrong_types(globalconfig2):
         )
 
 
+def test_content_with_subfields(globalconfig2, polygons):
+    """When subfield is given and allowed, it shall be produced to metadata."""
+    eobj = ExportData(
+        config=globalconfig2,
+        name="Central Horst",
+        content={"field_region": {"id": 1}},
+    )
+    mymeta = eobj.generate_metadata(polygons)
+
+    assert mymeta["data"]["name"] == "Central Horst"
+    assert mymeta["data"]["content"] == "field_region"
+    assert "field_region" in mymeta["data"]
+    assert mymeta["data"]["field_region"] == {"id": 1}
+
+
 def test_content_deprecated_seismic_offset(regsurf, globalconfig2):
     """Assert that usage of seismic.offset still works but give deprecation warning."""
     with pytest.warns(DeprecationWarning, match="seismic.offset is deprecated"):


### PR DESCRIPTION
Solving/contributing to #200 

This PR allows `field_region` as content. It is singular, and may be joined by `field_regions` in the future for objects containing many regions. This is request from REP and JS, purpose is to the able to effectively and consistently identify specific type of region from FMU results. The more generic `regions` is already allowed, but will include other types of regions as well.