### PR TITLE
Add fmu_restart metadata on iteration level

### DIFF
--- a/src/fmu/dataio/_fmu_provider.py
+++ b/src/fmu/dataio/_fmu_provider.py
@@ -21,6 +21,7 @@ from . import _utils
 
 # case metadata relative to rootpath
 ERT2_RELATIVE_CASE_METADATA_FILE = "share/metadata/fmu_case.yml"
+RESTART_PATH_ENVNAME = "RESTART_FROM_PATH"
 
 logger = logging.getLogger(__name__)
 
@@ -202,9 +203,9 @@ class _FmuProvider:
             logger.debug("parameters.txt was not found")
 
         # Load restart_from information
-        if "RESTART_FROM_PATH" in environ:
+        if RESTART_PATH_ENVNAME in environ:
             logger.info("Detected a restart run from environment variable")
-            restart_path = self.iter_path / environ["RESTART_FROM_PATH"]
+            restart_path = self.iter_path / environ[RESTART_PATH_ENVNAME]
             restart_iter = _get_folderlist(restart_path)[-1]
             restart_case_metafile = (
                 restart_path / "../.." / ERT2_RELATIVE_CASE_METADATA_FILE

--- a/src/fmu/dataio/_fmu_provider.py
+++ b/src/fmu/dataio/_fmu_provider.py
@@ -216,6 +216,15 @@ class _FmuProvider:
                     restart_metadata["fmu"]["case"]["uuid"]
                     + restart_iter.replace("iter-", "")
                 )
+            else:
+                print(
+                    f"{RESTART_PATH_ENVNAME} environment variable is set to {environ[RESTART_PATH_ENVNAME]} "
+                    "which is invalid. Metadata restart_from will remain empty."
+                )
+                logger.warning(
+                    f"{RESTART_PATH_ENVNAME} environment variable is set to {environ[RESTART_PATH_ENVNAME]} "
+                    "which is invalid. Metadata restart_from will remain empty."
+                )
 
         # store jobs.json if required!
         if self.dataio.include_ert2jobs:

--- a/src/fmu/dataio/_fmu_provider.py
+++ b/src/fmu/dataio/_fmu_provider.py
@@ -218,12 +218,14 @@ class _FmuProvider:
                 )
             else:
                 print(
-                    f"{RESTART_PATH_ENVNAME} environment variable is set to {environ[RESTART_PATH_ENVNAME]} "
-                    "which is invalid. Metadata restart_from will remain empty."
+                    f"{RESTART_PATH_ENVNAME} environment variable is set to "
+                    "{environ[RESTART_PATH_ENVNAME]} which is invalid. Metadata "
+                    "restart_from will remain empty."
                 )
                 logger.warning(
-                    f"{RESTART_PATH_ENVNAME} environment variable is set to {environ[RESTART_PATH_ENVNAME]} "
-                    "which is invalid. Metadata restart_from will remain empty."
+                    f"{RESTART_PATH_ENVNAME} environment variable is set to "
+                    "{environ[RESTART_PATH_ENVNAME]} which is invalid. Metadata "
+                    "restart_from will remain empty."
                 )
 
         # store jobs.json if required!

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,7 @@ logger = logging.getLogger(__name__)
 ROOTPWD = Path(".").absolute()
 RUN1 = "tests/data/drogon/ertrun1/realization-0/iter-0"
 RUN2 = "tests/data/drogon/ertrun1"
+RUN_PRED = "tests/data/drogon/ertrun1/realization-0/pred"
 
 
 def pytest_configure():
@@ -82,6 +83,16 @@ def fixture_fmurun_w_casemetadata(tmp_path_factory):
     rootpath = newpath / "realization-0/iter-0"
     logger.info("Ran %s", inspect.currentframe().f_code.co_name)
     return rootpath
+
+
+@pytest.fixture(name="fmurun_pred", scope="session", autouse=True)
+def fixture_fmurun_pred(tmp_path_factory):
+    """Create a tmp folder structure for testing; here a new fmurun for prediction."""
+    tmppath = tmp_path_factory.mktemp("data_pred")
+    newpath = tmppath / RUN_PRED
+    shutil.copytree(ROOTPWD / RUN_PRED, newpath)
+    logger.info("Ran %s", inspect.currentframe().f_code.co_name)
+    return newpath
 
 
 @pytest.fixture(name="rmsrun_fmu_w_casemetadata", scope="session", autouse=True)

--- a/tests/test_units/test_fmuprovider_class.py
+++ b/tests/test_units/test_fmuprovider_class.py
@@ -4,7 +4,7 @@ import os
 import pytest
 
 import fmu.dataio as dio
-from fmu.dataio._fmu_provider import _FmuProvider, _get_folderlist
+from fmu.dataio._fmu_provider import _FmuProvider, _get_folderlist, RESTART_PATH_ENVNAME
 
 FOLDERTREE = "scratch/myfield/case/realization-13/iter-2"
 
@@ -119,6 +119,68 @@ def test_fmuprovider_detect_no_case_metadata(fmurun, edataobj1):
     assert myfmu.real_id == 0
     assert "fmu_case" in str(myfmu.case_metafile)
     assert not myfmu.case_metadata
+
+
+def test_fmuprovider_valid_restart_env(fmurun_w_casemetadata, fmurun_pred, edataobj1):
+    """Testing the scenario given a valid RESTART_FROM_PATH environment variable
+
+    This will give the correct restart_from uuid
+    """
+
+    edataobj1._rootpath = fmurun_w_casemetadata
+    os.chdir(fmurun_w_casemetadata)
+    fmu_restart_from = _FmuProvider(edataobj1)
+    fmu_restart_from.detect_provider()
+
+    os.environ[RESTART_PATH_ENVNAME] = str(fmurun_w_casemetadata)
+    edataobj1._rootpath = fmurun_pred
+    os.chdir(fmurun_pred)
+    fmu_restart = _FmuProvider(edataobj1)
+    with pytest.warns(UserWarning, match="ERT2 is found but no case metadata"):
+        fmu_restart.detect_provider()
+    assert (
+        fmu_restart.metadata["iteration"]["restart_from"]
+        == fmu_restart_from.metadata["iteration"]["uuid"]
+    )
+
+
+def test_fmuprovider_invalid_restart_env(fmurun_w_casemetadata, fmurun_pred, edataobj1):
+    """Testing the scenario given invalid RESTART_FROM_PATH environment variable
+
+    The iteration metadata will not contain restart_from key
+    """
+
+    edataobj1._rootpath = fmurun_w_casemetadata
+    os.chdir(fmurun_w_casemetadata)
+    fmu_restart_from = _FmuProvider(edataobj1)
+    fmu_restart_from.detect_provider()
+
+    os.environ[RESTART_PATH_ENVNAME] = "/path/to/somewhere/invalid"
+    edataobj1._rootpath = fmurun_pred
+    os.chdir(fmurun_pred)
+    fmu_restart = _FmuProvider(edataobj1)
+    with pytest.warns(UserWarning, match="ERT2 is found but no case metadata"):
+        fmu_restart.detect_provider()
+    assert "restart_from" not in fmu_restart.metadata["iteration"]
+
+
+def test_fmuprovider_no_restart_env(fmurun_w_casemetadata, fmurun_pred, edataobj1):
+    """Testing the scenario without RESTART_FROM_PATH environment variable
+
+    The iteration metadata will not contain restart_from key
+    """
+
+    edataobj1._rootpath = fmurun_w_casemetadata
+    os.chdir(fmurun_w_casemetadata)
+    fmu_restart_from = _FmuProvider(edataobj1)
+    fmu_restart_from.detect_provider()
+
+    edataobj1._rootpath = fmurun_pred
+    os.chdir(fmurun_pred)
+    fmu_restart = _FmuProvider(edataobj1)
+    with pytest.warns(UserWarning, match="ERT2 is found but no case metadata"):
+        fmu_restart.detect_provider()
+    assert "restart_from" not in fmu_restart.metadata["iteration"]
 
 
 def test_fmuprovider_detect_case_has_metadata(fmurun_w_casemetadata, edataobj1):


### PR DESCRIPTION
Add fmu_restart metadata on iteration level based on environment variable RESTART_FROM_PATH that user need to specify in ERT config file.

Typical setup for restart in the same case as AHM 
````
DEFINE <RESTART_DIR>      iter-3       -- name of the history folder to restart from
DEFINE <RESTART_CASE>     ../../../<RESTART_DIR>/eclipse/model/<ECLIPSE_NAME>-<IENS>   -- Note: path is relative to eclipse/model
DEFINE <RESTART_REPORT>   82
SETENV RESTART_FROM_PATH  ../<RESTART_DIR>  -- Note: path is relative to iteration path
````

Typical setup for restart in a new (different) case from AHM
````
DEFINE <RESTART_BASE_CASE>     01_drogon_ahm_sumo
DEFINE <RESTART_DIR>      iter-3       -- name of the history folder to restart from
DEFINE <RESTART_PATH>     <SCRATCH>/alifb/<RESTART_BASE_CASE>/realization-<IENS>/<RESTART_DIR>
DEFINE <RESTART_CASE>     <RESTART_PATH>/eclipse/model/<ECLIPSE_NAME>-<IENS>   -- Note: path is relative to eclipse/model
DEFINE <RESTART_REPORT>   82

SETENV RESTART_FROM_PATH  <RESTART_PATH>
````