### PR TITLE
Populate the access.classification field

### DIFF
--- a/schema/definitions/0.8.0/examples/surface_depth.yml
+++ b/schema/definitions/0.8.0/examples/surface_depth.yml
@@ -161,6 +161,7 @@ access:
   ssdl:
     access_level: internal
     rep_include: true
+  classification: internal
 
 masterdata:
   smda:

--- a/schema/definitions/0.8.0/schema/fmu_results.json
+++ b/schema/definitions/0.8.0/schema/fmu_results.json
@@ -748,6 +748,17 @@
                         }
                     }
                 },
+                "classification": {
+                    "type": "string",
+                    "enum": [
+                        "internal",
+                        "restricted"
+                    ],
+                    "examples": [
+                        "internal",
+                        "restricted"
+                    ]
+                },
                 "ssdl": {
                     "type": "object",
                     "$comment": "Required for data objects",

--- a/src/fmu/dataio/_definitions.py
+++ b/src/fmu/dataio/_definitions.py
@@ -91,3 +91,8 @@ ALLOWED_FMU_CONTEXTS = {
     "case_symlink_realization": "To case/share, with symlinks on realizations level",
     "preprocessed": "To share/preprocessed; from interactive runs but re-used later",
 }
+
+# A default information classification to ensure backwards compatibility, and act as
+# ultimate fallback if missing in both arguments and config.
+DEFAULT_ACCESS_CLASSIFICATION = "restricted"
+ALLOWED_ACCESS_CLASSIFICATION = ["internal", "restricted"]

--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -20,6 +20,7 @@ from ._definitions import (
     ALLOWED_FMU_CONTEXTS,
     CONTENTS_REQUIRED,
     DEPRECATED_CONTENTS,
+    ALLOWED_ACCESS_CLASSIFICATION,
 )
 from ._utils import (
     create_symlink,
@@ -328,6 +329,11 @@ class ExportData:
              to the default ssdl settings read from the config. Example:
             ``{"access_level": "restricted", "rep_include": False}``
 
+        access_classification: Optional. A string representing the classification of the
+            exported object(s). Valid values are "internal" and "restricted". If not
+            passed, defaults will be grabbed from either global_variables or fallback
+            to using built-in default.
+
         casepath: To override the automatic and actual ``rootpath``. Absolute path to
             the case root. If not provided, the rootpath will be attempted parsed from
             the file structure or by other means. See also fmu_context, where "case"
@@ -506,6 +512,7 @@ class ExportData:
 
     # input keys (alphabetic)
     access_ssdl: dict = field(default_factory=dict)
+    access_classification: str = None
     aggregation: bool = False
     casepath: Union[str, Path, None] = None
     config: dict = field(default_factory=dict)
@@ -675,6 +682,16 @@ class ExportData:
             logger.info(
                 "Updated global config's access.ssdl value: %s", newglobals["access"]
             )
+
+        if self.access_classification is not None:
+            newglobals["access"]["classification"] = self.access_classification
+
+            if self.access_classification not in ALLOWED_ACCESS_CLASSIFICATION:
+                raise ValidationError(
+                    "Error in input arguments: "
+                    f"access_classifiation = {self.access_classification} "
+                    f"Allowed values are: {ALLOWED_ACCESS_CLASSIFICATION}"
+                )
 
         self.config = newglobals
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -219,6 +219,7 @@ def fixture_globalconfig1():
             "access_level": "internal",
             "rep_include": False,
         },
+        "classification": "internal",
     }
     logger.info("Ran %s", inspect.currentframe().f_code.co_name)
     return cfg

--- a/tests/data/drogon/global_config2/global_variables.yml
+++ b/tests/data/drogon/global_config2/global_variables.yml
@@ -25,6 +25,7 @@ access:
   ssdl:
     access_level: internal
     rep_include: true
+  classification: restricted # default for all data objects
 model:
   name: ff
   revision: AUTO

--- a/tests/data/drogon/global_config2/global_variables_norw_letters.yml
+++ b/tests/data/drogon/global_config2/global_variables_norw_letters.yml
@@ -22,6 +22,7 @@ access:
   ssdl:
     access_level: internal
     rep_include: true
+  classification: internal
 model:
   name: ff
   revision: AUTO

--- a/tests/test_schema/test_schema_logic.py
+++ b/tests/test_schema/test_schema_logic.py
@@ -114,7 +114,7 @@ def test_schema_080_logic_case(schema_080, metadata_examples):
 def test_schema_080_logic_fmu_block_aggr_real(schema_080, metadata_examples):
     """Test that fmu.realization and fmu.aggregation are not allowed at the same time"""
 
-    metadata = metadata_examples["surface_depth.yml"]
+    metadata = deepcopy(metadata_examples["surface_depth.yml"])
     # check that assumptions for the test is true
     assert "realization" in metadata["fmu"]
     assert "aggregation" not in metadata["fmu"]
@@ -325,3 +325,29 @@ def test_schema_080_data_time(schema_080, metadata_examples):
         _example["data"]["time"] = testvalue
         with pytest.raises(jsonschema.exceptions.ValidationError):
             jsonschema.validate(instance=_example, schema=schema_080)
+
+
+def test_schema_logic_classification(schema_080, metadata_examples):
+    """Test the classification of individual files."""
+
+    # fetch example
+    example = deepcopy(metadata_examples["surface_depth.yml"])
+
+    # assert validation with no changes
+    jsonschema.validate(instance=example, schema=schema_080)
+
+    # assert "internal" and "restricted" validates
+    example["access"]["classification"] = "internal"
+    jsonschema.validate(instance=example, schema=schema_080)
+
+    example["access"]["classification"] = "restricted"
+    jsonschema.validate(instance=example, schema=schema_080)
+
+    # assert erroneous value does not validate
+    example["access"]["classification"] = "open"
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        jsonschema.validate(instance=example, schema=schema_080)
+
+    # assert missing value validates
+    del example["access"]["classification"]
+    jsonschema.validate(instance=example, schema=schema_080)


### PR DESCRIPTION
This PR partly solves #295.

Metadata shall contain the `access.classification` field, the values shall be either `internal` or `restricted`. If the `access_classification` argument is given, it is used. First fallback is the `global_variables`/`config`. If not present in config, final fallback is default constant in fmu.dataio. This to ensure backwards compatibility, as this will hit several existing configs without this tag present combined with scripts without this argument given. 