### PR TITLE
data.size and data.columns in schema

### DIFF
--- a/schema/definitions/0.8.0/examples/table_inplace.yml
+++ b/schema/definitions/0.8.0/examples/table_inplace.yml
@@ -115,6 +115,10 @@ data: # The data block describes the actual data (e.g. surface). Only present in
     ncol: 281
     nrow: 441
     undef: -999.25  # Allow both number and string
+    columns:
+      - BULK_OIL
+      - NET_OIL
+      - PORE_OIL
   is_prediction: true # A mechanism for separating pure QC output from actual predictions
   is_observation: false
   description:

--- a/schema/definitions/0.8.0/schema/fmu_results.json
+++ b/schema/definitions/0.8.0/schema/fmu_results.json
@@ -21,6 +21,7 @@
         "data.is_prediction",
         "data.is_observation",
         "data.seismic.attribute",
+        "data.spec.columns",
         "access",
         "masterdata",
         "fmu.model",
@@ -428,6 +429,26 @@
                             "examples": [
                                 1
                             ]
+                        },
+                        "size": {
+                            "description": "Size of data object.",
+                            "type": "integer",
+                            "examples": [
+                                1,
+                                9999
+                            ]
+                        },
+                        "columns": {
+                            "description": "List of columns present in a table.",
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "examples": [
+                                    "FOPT",
+                                    "STOIIP_OIL",
+                                    "COL_1"
+                                ]
+                            }
                         }
                     }
                 },


### PR DESCRIPTION
Solve #309 

Include `data.size` and `data.columns` in schema, and make `data.columns` contractual.
