### PR TITLE
Reuse fmuconfig yaml load

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -3,3 +3,4 @@ PyYAML
 # skip pyarrow for RMS 11 and 12.0 which uses python 3.6.1 and too old numpy 1.13.3
 pyarrow; python_version > "3.6.1"
 jsonschema>=3.2.0
+fmu-config>=1.1.0

--- a/src/fmu/dataio/_fmu_provider.py
+++ b/src/fmu/dataio/_fmu_provider.py
@@ -17,6 +17,8 @@ from pathlib import Path
 from typing import Any, Optional
 from warnings import warn
 
+from fmu.config import utilities as ut
+
 from . import _utils
 
 # case metadata relative to rootpath
@@ -211,7 +213,9 @@ class _FmuProvider:
                 restart_path / "../.." / ERT2_RELATIVE_CASE_METADATA_FILE
             ).resolve()
             if restart_case_metafile.exists():
-                restart_metadata = _utils.load_yaml(restart_case_metafile)
+                restart_metadata = ut.yaml_load(
+                    restart_case_metafile, loader="standard"
+                )
                 self.ert2["restart_from"] = _utils.uuid_from_string(
                     restart_metadata["fmu"]["case"]["uuid"] + restart_iter
                 )
@@ -252,7 +256,7 @@ class _FmuProvider:
         self.case_metafile = self.case_metafile.resolve()
         if self.case_metafile.exists():
             logger.info("Case metadata file exists at %s", str(self.case_metafile))
-            self.case_metadata = _utils.load_yaml(self.case_metafile)
+            self.case_metadata = ut.yaml_load(self.case_metafile, loader="standard")
             logger.info("Case metadata are now read!")
         else:
             logger.info(

--- a/src/fmu/dataio/_utils.py
+++ b/src/fmu/dataio/_utils.py
@@ -14,6 +14,7 @@ from typing import Dict, List, Optional, Union
 
 import pandas as pd  # type: ignore
 import yaml
+from fmu.config import utilities as ut
 
 try:
     import pyarrow as pa  # type: ignore
@@ -345,7 +346,6 @@ def some_config_from_env(envvar="FMU_GLOBAL_CONFIG") -> dict:
     variable: Raise if the environment variable is not found.
     """
 
-    config = None
     logger.info("Getting config from file via environment %s", envvar)
     if envvar in os.environ:
         cfg_path = os.environ[envvar]
@@ -362,22 +362,7 @@ def some_config_from_env(envvar="FMU_GLOBAL_CONFIG") -> dict:
         )
         return None
 
-    with open(cfg_path, "r", encoding="utf8") as stream:
-        try:
-            config = yaml.safe_load(stream)
-        except yaml.YAMLError as exc:
-            logger.info(exc)
-            raise
-
-    return config
-
-
-def load_yaml(yfil: Union[str, Path]) -> dict:
-    """Loading a YAML file"""
-    cfg = None
-    with open(yfil, "r", encoding="UTF8") as stream:
-        cfg = yaml.safe_load(stream)
-    return cfg
+    return ut.yaml_load(cfg_path, loader="fmu")
 
 
 def filter_validate_metadata(metadata_in: dict) -> dict:

--- a/tests/test_units/test_metadata_class.py
+++ b/tests/test_units/test_metadata_class.py
@@ -224,7 +224,10 @@ def test_metadata_access_deprecated_input(globalconfig1):
     # Output shall be "restricted".
     edata = dio.ExportData(config=globalconfig1, access_ssdl={"access_level": "asset"})
     mymeta = _MetaData("dummy", edata)
-    with pytest.warns(match="The value 'asset' for access.ssdl.access_level is deprec"):
+    with pytest.warns(
+        UserWarning,
+        match="The value 'asset' for access.ssdl.access_level is deprec",
+    ):
         mymeta._populate_meta_access()
     assert mymeta.meta_access["ssdl"]["access_level"] == "restricted"
     assert mymeta.meta_access["classification"] == "restricted"


### PR DESCRIPTION
Instead of using the standard YAML loader, reuse the `fmu.config yaml_load()` function which opens for reading `YAML` files on
FMU input format (in-house extended `YAML` syntax). 

Closes #328 