### PR TITLE
Create yaml snippet while building on readthedocs environment

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,10 +1,14 @@
 version: 2
 
 build:
-  image: latest
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.8"
+  jobs:
+    post_install:
+      - bash examples/run_examples.sh
 
 python:
-  version: "3.8"
   install:
     - requirements: requirements/requirements.txt
     - requirements: requirements/requirements_docs.txt


### PR DESCRIPTION
Another attempt to resolve #271 

Trigger `bash examples/run_examples.sh` before building the documentation to create yaml snippets.