### PR TITLE
Set default content

### DIFF
--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -131,6 +131,7 @@ def _check_content(proposed: Union[str, dict]) -> Any:
     logger.info("Evaluate content")
 
     content = proposed
+    content_specific = None
     logger.debug("content is %s of type %s", str(content), type(content))
     usecontent = "unset"
     if content is None:

--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -136,11 +136,11 @@ def _check_content(proposed: Union[str, dict]) -> Any:
     usecontent = "unset"
     if content is None:
         warn(
-            "The <content> is not provided which defaults to 'depth'. "
+            "The <content> is not provided which defaults to 'unset'. "
             "It is strongly recommended that content is given explicitly!",
             UserWarning,
         )
-        usecontent = "depth"
+        usecontent = "unset"
 
     elif isinstance(content, str):
         logger.debug("content is a string")
@@ -167,7 +167,7 @@ def _check_content(proposed: Union[str, dict]) -> Any:
     else:
         raise ValidationError("The 'content' must be string or dict")
 
-    if usecontent not in ALLOWED_CONTENTS:
+    if usecontent != "unset" and usecontent not in ALLOWED_CONTENTS:
         raise ValidationError(
             f"Invalid content: <{usecontent}>! "
             f"Valid content: {', '.join(ALLOWED_CONTENTS.keys())}"
@@ -510,7 +510,7 @@ class ExportData:
     aggregation: bool = False
     casepath: Union[str, Path, None] = None
     config: dict = field(default_factory=dict)
-    content: Union[dict, str] = "depth"
+    content: Union[dict, str, None] = None
     depth_reference: str = "msl"
     description: Union[str, list] = ""
     fmu_context: str = "realization"

--- a/tests/test_units/test_dataio.py
+++ b/tests/test_units/test_dataio.py
@@ -119,6 +119,12 @@ def test_deprecated_keys(globalconfig1, regsurf, key, value, wtype, expected_msg
         edata.generate_metadata(regsurf, **kval)
 
 
+def test_content_not_given(globalconfig1):
+    """When content is not explicitly given, warning shall be issued."""
+    with pytest.warns(match="The <content> is not provided"):
+        ExportData(config=globalconfig1)
+
+
 def test_content_invalid_string(globalconfig1):
     with pytest.raises(ValidationError, match=r"Invalid content"):
         ExportData(config=globalconfig1, content="not_valid")

--- a/tests/test_units/test_rms_context.py
+++ b/tests/test_units/test_rms_context.py
@@ -45,10 +45,11 @@ def test_regsurf_generate_metadata_change_content(rmssetup, rmsglobalconfig, reg
 
     edata = dataio.ExportData(config=rmsglobalconfig)  # read from global config
 
-    meta1 = edata.generate_metadata(regsurf)
+    with pytest.warns(match="The <content> is not provided"):
+        meta1 = edata.generate_metadata(regsurf)
     meta2 = edata.generate_metadata(regsurf, content="time")
 
-    assert meta1["data"]["content"] == "depth"
+    assert meta1["data"]["content"] == "unset"
     assert meta2["data"]["content"] == "time"
 
 


### PR DESCRIPTION
Current behavior is that missing content is allowed, and unset content will default to "depth". This is polluting the data. This PR does not change the root cause, but stops the pollution by setting default content to "unset" instead.

Partially solve elements of #277 