### PR TITLE
Transfer selected blocks from global_variables to case metadata

### DIFF
--- a/schema/definitions/0.8.0/examples/case.yml
+++ b/schema/definitions/0.8.0/examples/case.yml
@@ -34,6 +34,24 @@ fmu: # the fmu-block contains information directly related to the FMU context
 
   context:
     stage: case
+  
+  config:
+    globals:  # transferred from global_variables.yml
+      REGIONS:
+        WestLowland:
+          NUM: 1
+          OWC: 1660.0
+          FWL: 1660.0
+          GOC: 1000.0
+          COL: (238, 221, 130)
+          EQT: 0
+        CentralSouth:
+          NUM: 2
+          OWC: 1677.0
+          FWL: 1677.0
+          GOC: 1000.0
+          EQT: 0
+          COL: (105, 89, 205)
 
 access:
   asset:

--- a/schema/definitions/0.8.0/schema/fmu_results.json
+++ b/schema/definitions/0.8.0/schema/fmu_results.json
@@ -993,6 +993,10 @@
                     }
                 }
             },
+            "config": {
+                "type": "object",
+                "description": "Transferred elements from global config"
+            },
             "iteration": {
                 "type": "object",
                 "required": [
@@ -1226,6 +1230,9 @@
                         },
                         "case": {
                             "$ref": "#/definitions/fmu/case"
+                        },
+                        "config": {
+                            "$ref": "#/definitions/fmu/config"
                         }
                     }
                 },

--- a/src/fmu/dataio/_definitions.py
+++ b/src/fmu/dataio/_definitions.py
@@ -91,3 +91,9 @@ ALLOWED_FMU_CONTEXTS = {
     "case_symlink_realization": "To case/share, with symlinks on realizations level",
     "preprocessed": "To share/preprocessed; from interactive runs but re-used later",
 }
+
+CONFIG_FIELDS_2_CASE_METADATA = {
+    "REGIONS": {
+        "type": dict,
+    }
+}

--- a/src/fmu/dataio/_definitions.py
+++ b/src/fmu/dataio/_definitions.py
@@ -95,5 +95,8 @@ ALLOWED_FMU_CONTEXTS = {
 CONFIG_FIELDS_2_CASE_METADATA = {
     "REGIONS": {
         "type": dict,
-    }
+    },
+    "SEISMIC_DATES": {
+        "type": list,
+    },
 }

--- a/tests/test_units/test_initialize_case.py
+++ b/tests/test_units/test_initialize_case.py
@@ -1,8 +1,8 @@
-"""Test the dataio running from within RMS interactive as context.
+"""Test the InitializeCase class.
 
-In this case a user sits in RMS, which is in folder rms/model and runs
-interactive. Hence the basepath will be ../../
+This class is used for creating the case metadata.
 """
+
 import logging
 import os
 

--- a/tests/test_units/test_initialize_case.py
+++ b/tests/test_units/test_initialize_case.py
@@ -224,6 +224,8 @@ def test_inicase_get_globals_with_metadata_generation(globalconfig2, fmurun):
 
     cfg_gl = metadata["fmu"]["config"]["global"]  # short form
     assert "REGIONS" in cfg_gl
+    expected_type = CONFIG_FIELDS_2_CASE_METADATA["REGIONS"]["type"]
+    assert isinstance(cfg_gl["REGIONS"], expected_type)
     assert "WestLowland" in cfg_gl["REGIONS"]
 
 
@@ -237,3 +239,14 @@ def test_inicase_get_globals_missing_block(globalconfig2, fmurun):
     caseroot = fmurun.parent.parent
     with pytest.warns(match="REGIONS was not found"):
         metadata = icase.generate_case_metadata(rootfolder=caseroot, force=True)
+
+    assert "fmu" in metadata
+    assert "config" in metadata["fmu"]
+    assert "global" in metadata["fmu"]["config"]
+
+    cfg_gl = metadata["fmu"]["config"]["global"]  # short form
+    assert "REGIONS" not in cfg_gl
+    assert "SEISMIC_DATES" in cfg_gl
+
+    expected_type = CONFIG_FIELDS_2_CASE_METADATA["SEISMIC_DATES"]["type"]
+    assert isinstance(cfg_gl["SEISMIC_DATES"], expected_type)


### PR DESCRIPTION
First stab at partial solving of #337 

This PR will transfer selected blocks from `global_variables.yml` into case metadata, when they exist.