### PR TITLE
pin xtgeo to 3.0.1

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-xtgeo>=2.16
+xtgeo==3.0.1
 PyYAML
 # skip pyarrow for RMS 11 and 12.0 which uses python 3.6.1 and too old numpy 1.13.3
 pyarrow; python_version > "3.6.1"


### PR DESCRIPTION
Issues with XTgeo causes all tests to fail. Attempting to pin to previous version temporarily.