### PR TITLE
Populate metadata with prod url instead of dev

### DIFF
--- a/src/fmu/dataio/_definitions.py
+++ b/src/fmu/dataio/_definitions.py
@@ -1,7 +1,9 @@
 """Various definitions and hard settings used in fmu-dataio."""
 from dataclasses import dataclass, field
 
-SCHEMA = "https://main-fmu-schemas-dev.radix.equinor.com/schemas/0.8.0/fmu_results.json"
+SCHEMA = (
+    "https://main-fmu-schemas-prod.radix.equinor.com/schemas/0.8.0/fmu_results.json"
+)
 VERSION = "0.8.0"
 SOURCE = "fmu"
 


### PR DESCRIPTION
The first step in an attempt to introduce staging to the fmu schema. We would like to use the dev version of the schema in sumo-dev and the prod schema in sumo-prod. This will hopefully allow us to experiment and make changes to the structure of the schema and test it in sumo without the fear of introducing problems in production.

The plan is to make changes to the uploader where we will set `$schema` to the dev url if `SUMO_ENV` == `dev`. Otherwise the default value will remain, which is now the prod url.