### PR TITLE
Do not overwrite access when using preprocessed metadata.

### DIFF
--- a/src/fmu/dataio/_utils.py
+++ b/src/fmu/dataio/_utils.py
@@ -443,7 +443,6 @@ def glue_metadata_preprocessed(oldmeta, newmeta):
 
     meta["fmu"] = newmeta["fmu"]
     meta["file"] = newmeta["file"]
-    meta["access"] = newmeta["access"]
 
     newmeta["tracklog"][-1]["event"] = "merged"
     meta["tracklog"].extend(newmeta["tracklog"])


### PR DESCRIPTION
Partially solve #352 by reusing `access` from preprocessed metadata, not re-generating.