### PR TITLE
Require data.spec only on certain data types

### DIFF
--- a/schema/definitions/0.8.0/examples/dictionary_parameters.yml
+++ b/schema/definitions/0.8.0/examples/dictionary_parameters.yml
@@ -1,0 +1,71 @@
+$schema: "https://main-fmu-schemas-prod.radix.equinor.com/schemas/0.8.0/fmu_results.json"
+version: "0.8.0"
+source: "fmu"
+tracklog:
+  - datetime: "2023-09-07T07:39:33.291683"
+    user:
+      id: "adnj"
+    event: "created"
+class: "dictionary"
+fmu:
+  model:
+    name: "ff"
+    revision: "undefined"
+  context:
+    stage: "realization"
+  case:
+    name: "adnj_drogon_parameters_test"
+    uuid: "0db864d3-ac25-4e0f-9195-36fd524e0840"
+    user:
+      id: "adnj"
+  iteration:
+    id: 0
+    uuid: "dad9a25a-3ad0-0f0a-08f2-c6fe8aae4c45"
+    name: "iter-0"
+  realization:
+    id: 0
+    uuid: "28274007-fd40-29c4-c6ef-10e2414ccdcd"
+    name: "realization-0"
+file:
+  relative_path: "realization-0/iter-0/share/results/dictionaries/parameters.json"
+  absolute_path: "/scratch/fmu/adnj/adnj_drogon_parameters_test/realization-0/iter-0/share/results/dictionaries/parameters.json"
+  checksum_md5: "ebbf160256cc2cf2011ed2fb6ac13f85"
+data:
+  name: "parameters"
+  stratigraphic: false
+  content: "parameters"
+  tagname: ""
+  format: "json"
+  layout: "dictionary"
+  unit: ""
+  vertical_domain: "depth"
+  depth_reference: "msl"
+  undef_is_zero: false
+  is_prediction: true
+  is_observation: false
+display:
+  name: "parameters"
+access:
+  asset:
+    name: "Drogon"
+  ssdl:
+    access_level: "internal"
+    rep_include: false
+  classification: "internal"
+masterdata:
+  smda:
+    country:
+      - identifier: "Norway"
+        uuid: "ad214d85-8a1d-19da-e053-c918a4889309"
+    discovery:
+      - short_identifier: "DROGON"
+        uuid: "ad214d85-8a1d-19da-e053-c918a4889309"
+    field:
+      - identifier: "DROGON"
+        uuid: "00000000-0000-0000-0000-000000000000"
+    coordinate_system:
+      identifier: "ST_WGS84_UTM37N_P32637"
+      uuid: "ad214d85-dac7-19da-e053-c918a4889309"
+    stratigraphic_column:
+      identifier: "DROGON_HAS_NO_STRATCOLUMN"
+      uuid: "00000000-0000-0000-0000-000000000000"

--- a/schema/definitions/0.8.0/schema/fmu_results.json
+++ b/schema/definitions/0.8.0/schema/fmu_results.json
@@ -170,7 +170,6 @@
                 "content",
                 "name",
                 "format",
-                "spec",
                 "stratigraphic",
                 "is_prediction",
                 "is_observation"
@@ -1370,7 +1369,31 @@
                         "ssdl"
                     ]
                 }
-            }
+            },
+            "allOf": [
+                {
+                    "$comment": "Require data.spec for table and surface objects",
+                    "if": {
+                        "properties": {
+                            "class": {
+                                "enum": [
+                                    "table",
+                                    "surface"
+                                ]
+                            }
+                        }
+                    },
+                    "then": {
+                        "properties": {
+                            "data": {
+                                "required": [
+                                    "spec"
+                                ]
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ]
 }

--- a/schema/definitions/0.8.0/schema/fmu_results.json
+++ b/schema/definitions/0.8.0/schema/fmu_results.json
@@ -1370,30 +1370,25 @@
                     ]
                 }
             },
-            "allOf": [
-                {
-                    "$comment": "Require data.spec for table and surface objects",
-                    "if": {
-                        "properties": {
-                            "class": {
-                                "enum": [
-                                    "table",
-                                    "surface"
-                                ]
-                            }
-                        }
-                    },
-                    "then": {
-                        "properties": {
-                            "data": {
-                                "required": [
-                                    "spec"
-                                ]
-                            }
-                        }
+            "if": {
+                "properties": {
+                    "class": {
+                        "enum": [
+                            "table",
+                            "surface"
+                        ]
                     }
                 }
-            ]
+            },
+            "then": {
+                "properties": {
+                    "data": {
+                        "required": [
+                            "spec"
+                        ]
+                    }
+                }
+            }
         }
     ]
 }

--- a/tests/test_schema/test_schema_logic.py
+++ b/tests/test_schema/test_schema_logic.py
@@ -348,22 +348,23 @@ def test_schema_logic_classification(schema_080, metadata_examples):
     with pytest.raises(jsonschema.exceptions.ValidationError):
         jsonschema.validate(instance=example, schema=schema_080)
 
+
 def test_schema_logic_data_spec(schema_080, metadata_examples):
     """Test schema logic for data.spec"""
-    
+
     # fetch surface example
     example_surface = deepcopy(metadata_examples["surface_depth.yml"])
-    
+
     # assert validation with no changes
     jsonschema.validate(instance=example_surface, schema=schema_080)
-    
+
     # assert data.spec required when class == surface
     del example_surface["data"]["spec"]
     with pytest.raises(jsonschema.exceptions.ValidationError):
         jsonschema.validate(instance=example_surface, schema=schema_080)
-    
+
     # fetch dictionary example
     example_dict = deepcopy(metadata_examples["dictionary_parameters.yml"])
-    
+
     # assert data.spec not required when class === dictionary
     jsonschema.validate(instance=example_dict, schema=schema_080)

--- a/tests/test_schema/test_schema_logic.py
+++ b/tests/test_schema/test_schema_logic.py
@@ -366,5 +366,9 @@ def test_schema_logic_data_spec(schema_080, metadata_examples):
     # fetch dictionary example
     example_dict = deepcopy(metadata_examples["dictionary_parameters.yml"])
 
+    # assert data.spec is not present
+    with pytest.raises(KeyError):
+        example_dict["data"]["spec"]
+        
     # assert data.spec not required when class === dictionary
     jsonschema.validate(instance=example_dict, schema=schema_080)

--- a/tests/test_schema/test_schema_logic.py
+++ b/tests/test_schema/test_schema_logic.py
@@ -369,6 +369,6 @@ def test_schema_logic_data_spec(schema_080, metadata_examples):
     # assert data.spec is not present
     with pytest.raises(KeyError):
         example_dict["data"]["spec"]
-        
+
     # assert data.spec not required when class === dictionary
     jsonschema.validate(instance=example_dict, schema=schema_080)

--- a/tests/test_schema/test_schema_logic.py
+++ b/tests/test_schema/test_schema_logic.py
@@ -347,3 +347,23 @@ def test_schema_logic_classification(schema_080, metadata_examples):
     example["access"]["classification"] = "open"
     with pytest.raises(jsonschema.exceptions.ValidationError):
         jsonschema.validate(instance=example, schema=schema_080)
+
+def test_schema_logic_data_spec(schema_080, metadata_examples):
+    """Test schema logic for data.spec"""
+    
+    # fetch surface example
+    example_surface = deepcopy(metadata_examples["surface_depth.yml"])
+    
+    # assert validation with no changes
+    jsonschema.validate(instance=example_surface, schema=schema_080)
+    
+    # assert data.spec required when class == surface
+    del example_surface["data"]["spec"]
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        jsonschema.validate(instance=example_surface, schema=schema_080)
+    
+    # fetch dictionary example
+    example_dict = deepcopy(metadata_examples["dictionary_parameters.yml"])
+    
+    # assert data.spec not required when class === dictionary
+    jsonschema.validate(instance=example_dict, schema=schema_080)

--- a/tests/test_schema/test_schema_logic.py
+++ b/tests/test_schema/test_schema_logic.py
@@ -363,6 +363,17 @@ def test_schema_logic_data_spec(schema_080, metadata_examples):
     with pytest.raises(jsonschema.exceptions.ValidationError):
         jsonschema.validate(instance=example_surface, schema=schema_080)
 
+    # fetch table example
+    example_table = deepcopy(metadata_examples["table_inplace.yml"])
+
+    # assert validation with no changes
+    jsonschema.validate(instance=example_table, schema=schema_080)
+
+    # assert data.spec required when class == table
+    del example_table["data"]["spec"]
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        jsonschema.validate(instance=example_table, schema=schema_080)
+
     # fetch dictionary example
     example_dict = deepcopy(metadata_examples["dictionary_parameters.yml"])
 


### PR DESCRIPTION
This schema change makes `data.spec` required only when `class` is one of [`table`, `surface`].

Related to #365 