### PR TITLE
Validate content value

### DIFF
--- a/schema/definitions/0.8.0/examples/table_wellpicks.yml
+++ b/schema/definitions/0.8.0/examples/table_wellpicks.yml
@@ -69,7 +69,7 @@ file:
 
 data: # The data block describes the actual data (e.g. surface). Only present in data objects
 
-  content: well_picks   # white-listed and standardized
+  content: wellpicks   # white-listed and standardized
 
   name: wellpicks
   stratigraphic: false

--- a/schema/definitions/0.8.0/schema/fmu_results.json
+++ b/schema/definitions/0.8.0/schema/fmu_results.json
@@ -251,8 +251,31 @@
                 "content": {
                     "type": "string",
                     "description": "The contents of this data object",
+                    "enum": [
+                        "depth",
+                        "time",
+                        "thickness",
+                        "property",
+                        "seismic",
+                        "fluid_contact",
+                        "field_outline",
+                        "field_region",
+                        "regions",
+                        "pinchout",
+                        "subcrop",
+                        "fault_lines",
+                        "velocity",
+                        "volumes",
+                        "volumetrics",
+                        "inplace_volumes",
+                        "khproduct",
+                        "timeseries",
+                        "wellpicks",
+                        "parameters"
+                    ],
                     "examples": [
-                        "depth"
+                        "depth",
+                        "time"
                     ]
                 },
                 "tagname": {

--- a/src/fmu/dataio/_definitions.py
+++ b/src/fmu/dataio/_definitions.py
@@ -61,6 +61,7 @@ ALLOWED_CONTENTS = {
     "velocity": None,
     "volumes": None,
     "volumetrics": None,  # or?
+    "inplace_volumes": None,  # or?
     "khproduct": None,
     "timeseries": None,
     "wellpicks": None,

--- a/tests/test_schema/test_schema_logic.py
+++ b/tests/test_schema/test_schema_logic.py
@@ -383,3 +383,19 @@ def test_schema_logic_data_spec(schema_080, metadata_examples):
 
     # assert data.spec not required when class === dictionary
     jsonschema.validate(instance=example_dict, schema=schema_080)
+
+
+def test_schema_logic_content_whitelist(schema_080, metadata_examples):
+    """Test that validation fails when value of data.content is not in
+    the whitelist."""
+
+    # fetch surface example
+    example_surface = deepcopy(metadata_examples["surface_depth.yml"])
+
+    # assert validation with no changes
+    jsonschema.validate(instance=example_surface, schema=schema_080)
+
+    # shall fail when content is not in whitelist
+    example_surface["data"]["content"] = "not_valid_content"
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        jsonschema.validate(instance=example_surface, schema=schema_080)

--- a/tests/test_schema/test_schema_logic.py
+++ b/tests/test_schema/test_schema_logic.py
@@ -6,6 +6,7 @@ import jsonschema
 
 import pytest
 
+from fmu.dataio._definitions import ALLOWED_CONTENTS
 
 # pylint: disable=no-member
 
@@ -399,3 +400,17 @@ def test_schema_logic_content_whitelist(schema_080, metadata_examples):
     example_surface["data"]["content"] = "not_valid_content"
     with pytest.raises(jsonschema.exceptions.ValidationError):
         jsonschema.validate(instance=example_surface, schema=schema_080)
+
+
+def test_schema_content_synch_with_code(schema_080):
+    """Currently, the whitelist for content is maintained both in the schema
+    and in the code. This test asserts that list used in the code is in synch
+    with schema. Note! This is one-way, and will not fail if additional
+    elements are added to the schema only."""
+
+    schema_allowed = schema_080["definitions"]["data"]["properties"]["content"]["enum"]
+    for allowed_content in ALLOWED_CONTENTS:
+        if allowed_content not in schema_allowed:
+            raise ValueError(
+                f"content '{allowed_content}' allowed in code, but not schema."
+            )


### PR DESCRIPTION
Partly solve #369 

`fmu-dataio` currently allows `ExportData` to be called without `content` explicitly set. It will in those cases default to a generic value. However, we do not want those data to be available to any data consumer. Long-term, we will require that the `content` argument is used. Short-term (this PR), we will not validate documents with the default schema.

This PR includes the whitelisted contents into the schema. It also introduces a test which fails if the list of contents in the code becomes out of synch with the list in the schema.