### PR TITLE
Remove table_index_values

### DIFF
--- a/src/fmu/dataio/_objectdata_provider.py
+++ b/src/fmu/dataio/_objectdata_provider.py
@@ -275,9 +275,7 @@ class _ObjectDataProvider:
 
         elif isinstance(self.obj, pd.DataFrame):
             result["table_index"] = self._derive_index()
-            result["table_index_values"] = self._derive_values_from_index(
-                result["table_index"]
-            )
+
             result["subtype"] = "DataFrame"
             result["classname"] = "table"
             result["layout"] = "table"
@@ -290,9 +288,7 @@ class _ObjectDataProvider:
 
         elif HAS_PYARROW and isinstance(self.obj, pa.Table):
             result["table_index"] = self._derive_index()
-            result["table_index_values"] = self._derive_values_from_index(
-                result["table_index"]
-            )
+
             result["subtype"] = "ArrowTable"
             result["classname"] = "table"
             result["layout"] = "table"
@@ -517,20 +513,6 @@ class _ObjectDataProvider:
         logger.debug("Available columns in table %s ", columns)
         return columns
 
-    def _derive_values_from_index(self, table_index):
-        """Get unique values in table_index columns"""
-        index_values = {}
-        for index_name in table_index:
-            if isinstance(self.obj, pd.DataFrame):
-                logger.debug("pandas")
-                index_values[index_name] = self.obj[index_name].unique()
-            else:
-                logger.debug("arrow")
-                index_values[index_name] = pc.unique(
-                    self.obj.column(index_name)
-                ).tolist()
-        return index_values
-
     def _derive_index(self):
         """Derive table index"""
         # This could in the future also return context
@@ -720,7 +702,6 @@ class _ObjectDataProvider:
         meta["spec"] = objres["spec"]
         meta["bbox"] = objres["bbox"]
         meta["table_index"] = objres.get("table_index")
-        meta["table_index_values"] = objres.get("table_index_values")
         meta["undef_is_zero"] = self.dataio.undef_is_zero
 
         # timedata:

--- a/src/fmu/dataio/_objectdata_provider.py
+++ b/src/fmu/dataio/_objectdata_provider.py
@@ -99,7 +99,6 @@ from ._utils import generate_description, parse_timedata
 
 try:
     import pyarrow as pa  # type: ignore
-    import pyarrow.compute as pc
 except ImportError:
     HAS_PYARROW = False
 else:

--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -534,7 +534,6 @@ class ExportData:
     vertical_domain: dict = field(default_factory=dict)
     workflow: str = ""
     table_index: Optional[list] = None
-    table_index_values: Optional[dict] = None
 
     # some keys that are modified version of input, prepended with _use
     _usecontent: dict = field(default_factory=dict, init=False)

--- a/tests/test_units/test_table.py
+++ b/tests/test_units/test_table.py
@@ -143,43 +143,6 @@ def test_table_index_real_summary(edataobj3, drogon_summary):
     assert res["table_index"] == ["DATE"], "Incorrect table index "
 
 
-def test_table_index_values_real_volumes(edataobj3, drogon_volumes):
-    """Test setting of table_index and table_index_values in real inplace volume file
-
-    Args:
-        edataobj3 (_type_): _description_
-        drogon_volumes (_type_): _description_
-    """
-    objdata = _ObjectDataProvider(drogon_volumes, edataobj3)
-    res = objdata._derive_objectdata()
-    correct_answers = {
-        "ZONE": ["Valysar", "Therys", "Volon"],
-        "REGION": [
-            "WestLowland",
-            "CentralSouth",
-            "CentralNorth",
-            "NorthHorst",
-            "CentralRamp",
-            "CentralHorst",
-            "EastLowland",
-        ],
-        "FACIES": [
-            "Floodplain",
-            "Channel",
-            "Crevasse",
-            "Coal",
-            "Calcite",
-            "Offshore",
-            "Lowershoreface",
-            "Uppershoreface",
-        ],
-    }
-
-    for col_name, answer_list in correct_answers.items():
-        index_items = res["table_index_values"][col_name]
-    assert_list_and_answer(index_items, answer_list, col_name)
-
-
 def test_table_wellpicks(wellpicks, globalconfig1):
     """Test export of wellpicks"""
 


### PR DESCRIPTION
This PR removes the table_index_values field from the metadata
Testing on large datasets like Snorre shows that the table_index_values is not sustainable.
There are also many problems with json serializability related to this field.
