### PR TITLE
Support data objects belong to a collection

### DIFF
--- a/schema/definitions/0.8.0/examples/table_inplace.yml
+++ b/schema/definitions/0.8.0/examples/table_inplace.yml
@@ -67,6 +67,11 @@ file:
   checksum_md5: kjhsdfvsdlfk23knerknvk23  # checksum of the file, not the data.
   size_bytes: 5010144
 
+relations:
+  collections:
+    - 1b4fb471-159d-4b46-9b25-229419cd349b
+    - 3d338cd7-926a-49c0-8d6b-8ae2063f681f
+
 data: # The data block describes the actual data (e.g. surface). Only present in data objects
 
   content: inplace_volumes   # white-listed and standardized

--- a/schema/definitions/0.8.0/examples/table_inplace.yml
+++ b/schema/definitions/0.8.0/examples/table_inplace.yml
@@ -69,8 +69,10 @@ file:
 
 relations:
   collections:
-    - 1b4fb471-159d-4b46-9b25-229419cd349b
-    - 3d338cd7-926a-49c0-8d6b-8ae2063f681f
+    - name: MyCollection
+      uuid: 1b4fb471-159d-4b46-9b25-229419cd349b
+    - name: MySecondCollection
+      uuid: 3d338cd7-926a-49c0-8d6b-8ae2063f681f
 
 data: # The data block describes the actual data (e.g. surface). Only present in data objects
 

--- a/schema/definitions/0.8.0/schema/fmu_results.json
+++ b/schema/definitions/0.8.0/schema/fmu_results.json
@@ -668,7 +668,18 @@
                 "collections": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/generic/uuid"
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "examples": [
+                                    "MyCollectionName"
+                                ]
+                            },
+                            "uuid": {
+                                "$ref": "#/definitions/generic/uuid"
+                            }
+                        }
                     }
                 }
             },

--- a/schema/definitions/0.8.0/schema/fmu_results.json
+++ b/schema/definitions/0.8.0/schema/fmu_results.json
@@ -662,6 +662,18 @@
                 }
             }
         },
+        "relations": {
+            "type": "object",
+            "properties": {
+                "collections": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/generic/uuid"
+                    }
+                }
+            },
+            "additionalProperties": false
+        },
         "display": {
             "type": "object",
             "properties": {
@@ -1229,6 +1241,9 @@
         },
         "class": {
             "$ref": "#/definitions/class"
+        },
+        "relations": {
+            "$ref": "#/definitions/relations"
         }
     },
     "oneOf": [

--- a/src/fmu/dataio/_metadata.py
+++ b/src/fmu/dataio/_metadata.py
@@ -201,7 +201,7 @@ def generate_meta_relations(dataio, meta_fmu: dict) -> Optional[dict]:
         logger.debug("Making collection uuid for %s", cname)
         collection_uuid = uuid_from_string(f"{case_uuid}{cname}")
         logger.debug("uuid returned was %s", collection_uuid)
-        r_meta["collections"].append(collection_uuid)
+        r_meta["collections"].append({"name": cname, "uuid": collection_uuid})
 
     return r_meta
 

--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -385,6 +385,9 @@ class ExportData:
             the file structure or by other means. See also fmu_context, where "case"
             may need an explicit casepath!
 
+        collection_name: To include a data object in a collection. Shall be string or
+            list of strings. Will be combined with case uuid.
+
         config: Required in order to produce valid metadata, either as key (here) or
             through an environment variable. A dictionary with static settings.
             In the standard case this is read from FMU global variables
@@ -561,6 +564,7 @@ class ExportData:
     access_ssdl: dict = field(default_factory=dict)
     aggregation: bool = False
     casepath: Union[str, Path, None] = None
+    collection_name: Union[str, List[str], None] = None
     config: dict = field(default_factory=dict)
     content: Union[dict, str, None] = None
     depth_reference: str = "msl"

--- a/tests/test_schema/test_schema_logic.py
+++ b/tests/test_schema/test_schema_logic.py
@@ -414,3 +414,32 @@ def test_schema_content_synch_with_code(schema_080):
             raise ValueError(
                 f"content '{allowed_content}' allowed in code, but not schema."
             )
+
+
+def test_schema_relations(schema_080, metadata_examples):
+    """Test the relations.collections."""
+
+    # fetch surface example
+    metadata = deepcopy(metadata_examples["table_inplace.yml"])
+
+    # test assumption
+    assert "relations" in metadata
+    assert isinstance(metadata["relations"]["collections"], list)
+
+    # validate as-is
+    jsonschema.validate(instance=metadata, schema=schema_080)
+
+    # non-uuid, shall fail
+    metadata["relations"]["collections"].append("non-uuid")
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        jsonschema.validate(instance=metadata, schema=schema_080)
+    metadata["relations"]["collections"].pop()  # cleanup
+
+    # insert non-valid property, shall fail
+    metadata["relations"]["tst"] = "hei"
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        jsonschema.validate(instance=metadata, schema=schema_080)
+
+    # remove relations block, shall still validate (not required)
+    del metadata["relations"]
+    jsonschema.validate(instance=metadata, schema=schema_080)

--- a/tests/test_units/test_dataio.py
+++ b/tests/test_units/test_dataio.py
@@ -497,3 +497,20 @@ def test_forcefolder_absolute_shall_raise_or_warn(tmp_path, globalconfig2, regsu
     )
     ExportData.allow_forcefolder_absolute = False  # reset
     ExportData._inside_rms = False
+
+
+def test_exportdata_with_collection_name(globalconfig2, regsurf, arrowtable, polygons):
+    """Test export of multiple objects with common collection_name."""
+
+    edata = ExportData(
+        config=globalconfig2, content="volumes", collection_name="mycollection"
+    )
+    metadatas = []
+    for obj in [regsurf, arrowtable, polygons]:
+        metadatas.append(edata.generate_metadata(obj, name="myname"))
+
+    collection_uuids = [
+        metadata["relations"]["collections"][0] for metadata in metadatas
+    ]
+    assert len(set(collection_uuids)) == 1
+    assert len(collection_uuids[0]) == 36

--- a/tests/test_units/test_dataio.py
+++ b/tests/test_units/test_dataio.py
@@ -505,12 +505,17 @@ def test_exportdata_with_collection_name(globalconfig2, regsurf, arrowtable, pol
     edata = ExportData(
         config=globalconfig2, content="volumes", collection_name="mycollection"
     )
-    metadatas = []
-    for obj in [regsurf, arrowtable, polygons]:
-        metadatas.append(edata.generate_metadata(obj, name="myname"))
 
-    collection_uuids = [
-        metadata["relations"]["collections"][0] for metadata in metadatas
+    # Use .generate_metadata, not .export, as file export is not needed here.
+    metadatas = [
+        edata.generate_metadata(obj, name="myname")
+        for obj in [regsurf, arrowtable, polygons]
     ]
-    assert len(set(collection_uuids)) == 1
-    assert len(collection_uuids[0]) == 36
+
+    # Have now produced metadata for 3 objects, all of which shall belong to the same
+    # collection. Hence they will all have exactly 1 entry in relation.collections, and
+    # they will all be identical.
+
+    collections = [metadata["relations"]["collections"] for metadata in metadatas]
+    for collection in collections:
+        assert collection == collections[0]

--- a/tests/test_units/test_metadata_class.py
+++ b/tests/test_units/test_metadata_class.py
@@ -1,7 +1,6 @@
 """Test the _MetaData class from the _metadata.py module"""
 import logging
 from copy import deepcopy
-import os
 
 import pytest
 

--- a/tests/test_units/test_metadata_class.py
+++ b/tests/test_units/test_metadata_class.py
@@ -336,9 +336,10 @@ def test_metadata_relations_with_case_uuid(globalconfig1, fmurun_w_casemetadata)
     second = deepcopy(mymeta.meta_relations["collections"][0])
     assert len(mymeta.meta_relations["collections"]) == 1
 
-    # verify different
-    assert first != second
-    assert len(first) == len(second) == 36
+    # verify differences
+    assert first["uuid"] != second["uuid"]  # different case, different uuid
+    assert first["name"] == second["name"]  # different case, but SAME name
+    assert len(first["uuid"]) == len(second["uuid"]) == 36
 
 
 def test_metadata_relations_one_collection_name(globalconfig1):
@@ -360,10 +361,15 @@ def test_metadata_relations_one_collection_name(globalconfig1):
     assert isinstance(mymeta_list.meta_relations["collections"], list)
     assert len(mymeta_list.meta_relations["collections"]) == 1
 
-    collections_ref_list = mymeta_list.meta_relations["collections"][0]
+    collections_1 = mymeta_list.meta_relations["collections"]
+    assert isinstance(collections_1, list)
 
-    assert isinstance(collections_ref_list, str)
-    assert len(collections_ref_list) == 36  # poor mans verification of uuid4
+    mycollection = mymeta_list.meta_relations["collections"][0]
+    assert isinstance(mycollection, dict)
+    assert "name" in mycollection
+    assert "uuid" in mycollection
+
+    assert len(mycollection["uuid"]) == 36  # poor mans verification of uuid4
 
     # === Input as str
     edata_str = dio.ExportData(
@@ -376,13 +382,8 @@ def test_metadata_relations_one_collection_name(globalconfig1):
     assert isinstance(mymeta_str.meta_relations["collections"], list)
     assert len(mymeta_str.meta_relations["collections"]) == 1
 
-    collections_ref_str = mymeta_str.meta_relations["collections"][0]
-
-    assert isinstance(collections_ref_str, str)
-    assert len(collections_ref_str) == 36  # poor mans verification of uuid4
-
     # === Confirm identical
-    assert collections_ref_str == collections_ref_list
+    assert mymeta_str.meta_relations["collections"][0] == collections_1[0]
 
 
 def test_metadata_relations_multiple_collection_name(globalconfig1):
@@ -397,9 +398,11 @@ def test_metadata_relations_multiple_collection_name(globalconfig1):
     assert isinstance(mymeta.meta_relations["collections"], list)
     assert len(mymeta.meta_relations["collections"]) == 3
 
-    for collections_ref in mymeta.meta_relations["collections"]:
-        assert isinstance(collections_ref, str)
-        assert len(collections_ref) == 36  # poor mans verification of uuid4
+    for collection in mymeta.meta_relations["collections"]:
+        assert isinstance(collection, dict)
+        assert "uuid" in collection
+        assert "name" in collection
+        assert len(collection["uuid"]) == 36  # poor mans verification of uuid4
 
 
 # --------------------------------------------------------------------------------------

--- a/tests/test_units/test_utils.py
+++ b/tests/test_units/test_utils.py
@@ -25,3 +25,16 @@ from fmu.dataio import _utils as utils
 )
 def test_check_if_number(value, result):
     assert utils.check_if_number(value) == result
+
+
+def test_uuid_from_string():
+    """Test the uuid_from_string method."""
+    result = utils.uuid_from_string("mystring")
+    assert len(result) == 36
+    assert isinstance(result, str)
+
+    # test repeatability
+    first = utils.uuid_from_string("mystring")
+    second = utils.uuid_from_string("mystring")
+
+    assert first == second


### PR DESCRIPTION
Solve #394. See issue for details.

Summary, this PR:
- Enables the `collection_name` argument to `ExportData`
- When `collection_name` is given, add it to `relations.collections` in outgoing metadata
- Add definition of `relations.collections` in schema

This allows for multiple objects to be exported with a common tag defining a collection they all belong to. The purpose of this is for clients to quickly identify other data objects related to a data object. The produced `relations.collections` will be `uuid4` and identical within a case.

This is done by taking the provided `collections_name` argument and combining it with the current `fmu.case.uuid`.

Use case: When looking at a volume table, identify if the same volumes are represented as a 3D parameter or a surface.

Clients would do this through the following workflow: Given a data object, if "relations.collections" is present, find other data objects with the same reference.

There are some unanswered questions:
- [ ] A requirement is that a data object can belong to several collections. Hence, `relations.collections` is a list. But does this work in reality? E.g. if a data object has 3 entries in `relations.collections` - how will the consumer know which one he wants to unravel?
- [ ] What about pre-processed data that belongs to a collection? The `fmu.case.uuid` does not exist when these data are made, hence `relations.collections` must probably be remade when dealing with preprocessed data.