### PR TITLE
Include time zone offset in tracklog datetime.

### DIFF
--- a/src/fmu/dataio/_metadata.py
+++ b/src/fmu/dataio/_metadata.py
@@ -45,7 +45,7 @@ def generate_meta_tracklog() -> list:
     """Create the tracklog metadata, which here assumes 'created' only."""
     meta = list()
 
-    dtime = datetime.datetime.now().isoformat()
+    dtime = datetime.datetime.now().astimezone().isoformat()
     user = getpass.getuser()
     meta.append({"datetime": dtime, "user": {"id": user}, "event": "created"})
     return meta

--- a/tests/test_units/test_metadata_class.py
+++ b/tests/test_units/test_metadata_class.py
@@ -2,6 +2,8 @@
 import logging
 from copy import deepcopy
 
+from dateutil.parser import isoparse
+
 import pytest
 
 import fmu.dataio as dio
@@ -25,6 +27,27 @@ def test_metadata_dollars(edataobj1):
     assert mymeta.meta_dollars["version"] == VERSION
     assert mymeta.meta_dollars["$schema"] == SCHEMA
     assert mymeta.meta_dollars["source"] == SOURCE
+
+
+# --------------------------------------------------------------------------------------
+# Tracklog
+# --------------------------------------------------------------------------------------
+
+
+def test_generate_meta_tracklog(edataobj1):
+    mymeta = _MetaData("dummy", edataobj1)
+    mymeta._populate_meta_tracklog()
+    tracklog = mymeta.meta_tracklog
+
+    assert isinstance(tracklog, list) and len(tracklog) == 1  # assume "created"
+
+    logentry = tracklog[0]
+    assert "event" in logentry and logentry["event"] == "created"
+    assert "user" in logentry and "id" in logentry["user"]
+    assert "datetime" in logentry
+
+    # datetime in tracklog shall include time zone offset
+    assert isoparse(logentry["datetime"]).tzinfo is not None
 
 
 # --------------------------------------------------------------------------------------


### PR DESCRIPTION
Solve #397 

This PR adds (local) time zone offset to the datetime in `tracklog`.
E.g. `2023-12-14T15:22:45.729902` -> `2023-12-14T15:22:45.729902+01:00`

Issue states "ZULU" time. In this PR, I have deliberately chosen to implement local time instead. I figure that the most important element here is to include time zone offset. I don't currently have full overview of what possible confusion we could risk if these time stamps are not on local time.