### PR TITLE
Datetime in tracklog on UTC time.

### DIFF
--- a/src/fmu/dataio/_metadata.py
+++ b/src/fmu/dataio/_metadata.py
@@ -5,6 +5,7 @@ This contains the _MetaData class which collects and holds all relevant metadata
 # https://realpython.com/python-data-classes/#basic-data-classes
 
 import datetime
+from datetime import timezone
 import getpass
 import logging
 from dataclasses import dataclass, field
@@ -45,7 +46,7 @@ def generate_meta_tracklog() -> list:
     """Create the tracklog metadata, which here assumes 'created' only."""
     meta = list()
 
-    dtime = datetime.datetime.now().astimezone().isoformat()
+    dtime = datetime.datetime.now(timezone.utc).isoformat()
     user = getpass.getuser()
     meta.append({"datetime": dtime, "user": {"id": user}, "event": "created"})
     return meta

--- a/tests/test_units/test_metadata_class.py
+++ b/tests/test_units/test_metadata_class.py
@@ -49,6 +49,9 @@ def test_generate_meta_tracklog(edataobj1):
     # datetime in tracklog shall include time zone offset
     assert isoparse(logentry["datetime"]).tzinfo is not None
 
+    # datetime in tracklog shall be on UTC time
+    assert isoparse(logentry["datetime"]).utcoffset().total_seconds() == 0
+
 
 # --------------------------------------------------------------------------------------
 # DATA block (ObjectData)


### PR DESCRIPTION
Solving #397, related to #398.

Change from local time to UTC time in tracklog datetimes.

Somewhat clumsy to do this across two PR's, but OK, effect is the same. We want these two commits to be distinct.