### PR TITLE
Do not allow contents volumetrics and inplace_volumes.

### DIFF
--- a/examples/s/d/nn/xcase/realization-0/iter-0/any/bin/export_volumetables.py
+++ b/examples/s/d/nn/xcase/realization-0/iter-0/any/bin/export_volumetables.py
@@ -80,7 +80,7 @@ def export_dataio(df, gridname):
     exp = fmu.dataio.ExportData(
         name=gridname,
         config=CFG,
-        content="volumetrics",
+        content="volumes",
         unit="m",
         is_prediction=True,
         is_observation=False,
@@ -94,7 +94,6 @@ def export_dataio(df, gridname):
 
 
 if __name__ == "__main__":
-
     if IN_ROXAR:
         for vtable in VTABLES:
             export_dataio(*volume_as_dataframe_rms(vtable))

--- a/src/fmu/dataio/_definitions.py
+++ b/src/fmu/dataio/_definitions.py
@@ -60,8 +60,6 @@ ALLOWED_CONTENTS = {
     "fault_lines": None,
     "velocity": None,
     "volumes": None,
-    "volumetrics": None,  # or?
-    "inplace_volumes": None,  # or?
     "khproduct": None,
     "timeseries": None,
     "wellpicks": None,


### PR DESCRIPTION
Solve #378 

As we seem to have converged on using `volumes`, this PR removes the unused contents `volumetrics` and `inplace_volumes`.