### PR TITLE
Use display_name when explicitly given

### DIFF
--- a/src/fmu/dataio/_metadata.py
+++ b/src/fmu/dataio/_metadata.py
@@ -344,7 +344,13 @@ class _MetaData:
     def _populate_meta_display(self):
         """Populate the display block."""
 
-        self.meta_display = {"name": self.objdata.name}
+        # display.name
+        if self.dataio.display_name is not None:
+            display_name = self.dataio.display_name
+        else:
+            display_name = self.objdata.name
+
+        self.meta_display = {"name": display_name}
 
     def _populate_meta_xpreprocessed(self):
         """Populate a few necessary 'tmp' metadata needed for preprocessed data."""

--- a/src/fmu/dataio/_metadata.py
+++ b/src/fmu/dataio/_metadata.py
@@ -341,6 +341,11 @@ class _MetaData:
         if self.dataio:
             self.meta_access = generate_meta_access(self.dataio.config)
 
+    def _populate_meta_display(self):
+        """Populate the display block."""
+
+        self.meta_display = {"name": self.objdata.name}
+
     def _populate_meta_xpreprocessed(self):
         """Populate a few necessary 'tmp' metadata needed for preprocessed data."""
         if self.dataio.fmu_context == "preprocessed":
@@ -375,6 +380,7 @@ class _MetaData:
         self._populate_meta_class()
         self._populate_meta_fmu()
         self._populate_meta_file()
+        self._populate_meta_display()
         self._populate_meta_xpreprocessed()
 
         # glue together metadata, order is as legacy code (but will be screwed if reuse
@@ -387,7 +393,7 @@ class _MetaData:
         meta["file"] = self.meta_file
 
         meta["data"] = self.meta_objectdata
-        meta["display"] = {"name": self.dataio.name}  # solution so far; TBD
+        meta["display"] = self.meta_display
 
         meta["access"] = self.meta_access
         meta["masterdata"] = self.meta_masterdata

--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -565,6 +565,7 @@ class ExportData:
     content: Union[dict, str, None] = None
     depth_reference: str = "msl"
     description: Union[str, list] = ""
+    display_name: Optional[str] = None
     fmu_context: str = "realization"
     forcefolder: str = ""
     grid_model: Optional[str] = None

--- a/tests/test_units/test_dataio.py
+++ b/tests/test_units/test_dataio.py
@@ -307,6 +307,26 @@ def test_content_deprecated_seismic_offset(regsurf, globalconfig2):
     }
 
 
+def test_set_display_name(regsurf, globalconfig2):
+    """Test that giving the display_name argument sets display.name."""
+    eobj = ExportData(
+        config=globalconfig2,
+        name="MyName",
+        display_name="MyDisplayName",
+        content="depth",
+    )
+    mymeta = eobj.generate_metadata(regsurf)
+
+    assert mymeta["data"]["name"] == "MyName"
+    assert mymeta["display"]["name"] == "MyDisplayName"
+
+    # also test when setting directly in the method call
+    mymeta = eobj.generate_metadata(regsurf, display_name="MyOtherDisplayName")
+
+    assert mymeta["data"]["name"] == "MyName"
+    assert mymeta["display"]["name"] == "MyOtherDisplayName"
+
+
 def test_global_config_from_env(globalconfig_asfile):
     """Testing getting global config from a file"""
     os.environ["FMU_GLOBAL_CONFIG"] = globalconfig_asfile

--- a/tests/test_units/test_metadata_class.py
+++ b/tests/test_units/test_metadata_class.py
@@ -332,6 +332,18 @@ def test_metadata_display_name_not_given(regsurf, edataobj2):
     assert mymeta.meta_display["name"] == mymeta.objdata.name
 
 
+def test_metadata_display_name_given(regsurf, edataobj2):
+    """Test that display.name is set when explicitly given."""
+
+    mymeta = _MetaData(regsurf, edataobj2)
+    edataobj2.display_name = "My Display Name"
+    mymeta._populate_meta_objectdata()
+    mymeta._populate_meta_display()
+
+    assert mymeta.meta_display["name"] == "My Display Name"
+    assert mymeta.objdata.name == mymeta.meta_objectdata["name"] == "VOLANTIS GP. Top"
+
+
 # --------------------------------------------------------------------------------------
 # The GENERATE method
 # --------------------------------------------------------------------------------------

--- a/tests/test_units/test_metadata_class.py
+++ b/tests/test_units/test_metadata_class.py
@@ -316,8 +316,20 @@ def test_metadata_access_no_input(globalconfig1):
     assert mymeta.meta_access["classification"] == "internal"  # mirrored
 
 
-def test_metadata_access_rep_include(globalconfig1):
-    """Test the input of the rep_include field."""
+# --------------------------------------------------------------------------------------
+# DISPLAY block
+# --------------------------------------------------------------------------------------
+
+
+def test_metadata_display_name_not_given(regsurf, edataobj2):
+    """Test that display.name == data.name when not explicitly provided."""
+
+    mymeta = _MetaData(regsurf, edataobj2)
+    mymeta._populate_meta_objectdata()
+    mymeta._populate_meta_display()
+
+    assert "name" in mymeta.meta_display
+    assert mymeta.meta_display["name"] == mymeta.objdata.name
 
 
 # --------------------------------------------------------------------------------------


### PR DESCRIPTION
Solve #319 

This PR makes `display.name` always populated in produced metadata.

- When `display_name` argument is given, use it to populate `display.name`
- When `display_name` not given, populate `display.name` with `data.name`
