### PR TITLE
Dump selected sysinfo to tracklog.

### DIFF
--- a/schema/definitions/0.8.0/examples/surface_depth.yml
+++ b/schema/definitions/0.8.0/examples/surface_depth.yml
@@ -9,6 +9,11 @@ tracklog:
     user:
       id: peesv
     event: created
+    sysinfo:
+      fmu-dataio:
+        version: 1.2.3
+      komodo: # only added when running in Komodo environment
+        release: 2023.12.05-py38
   - datetime: 2020-10-28T14:46:14
     user: 
       id: peesv

--- a/schema/definitions/0.8.0/schema/fmu_results.json
+++ b/schema/definitions/0.8.0/schema/fmu_results.json
@@ -154,6 +154,33 @@
                         "created",
                         "updated"
                     ]
+                },
+                "sysinfo": {
+                    "type": "object",
+                    "properties": {
+                        "fmu-dataio": {
+                            "type": "object",
+                            "properties": {
+                                "version": {
+                                    "type": "string",
+                                    "examples": [
+                                        "1.2.3"
+                                    ]
+                                }
+                            }
+                        },
+                        "komodo": {
+                            "type": "object",
+                            "properties": {
+                                "version": {
+                                    "type": "string",
+                                    "examples": [
+                                        "2023.12.05-py38"
+                                    ]
+                                }
+                            }
+                        }
+                    }
                 }
             }
         },

--- a/src/fmu/dataio/_utils.py
+++ b/src/fmu/dataio/_utils.py
@@ -361,6 +361,11 @@ def some_config_from_env(envvar: str = "FMU_GLOBAL_CONFIG") -> dict | None:
     return ut.yaml_load(cfg_path, loader="fmu")
 
 
+def read_named_envvar(envvar: str) -> str | None:
+    """Read a specific (named) environment variable."""
+    return os.environ.get(envvar, None)
+
+
 def filter_validate_metadata(metadata_in: dict) -> dict:
     """Validate metadatadict at topmost_level and strip away any alien keys."""
 

--- a/tests/test_units/test_metadata_class.py
+++ b/tests/test_units/test_metadata_class.py
@@ -6,7 +6,7 @@ import fmu.dataio as dio
 import pytest
 from dateutil.parser import isoparse
 from fmu.dataio._metadata import SCHEMA, SOURCE, VERSION, ConfigurationError, _MetaData
-from fmu.dataio._utils import prettyprint_dict
+from fmu.dataio._utils import prettyprint_dict, read_named_envvar
 
 # pylint: disable=no-member
 
@@ -43,6 +43,20 @@ def test_generate_meta_tracklog(edataobj1):
     assert "event" in logentry and logentry["event"] == "created"
     assert "user" in logentry and "id" in logentry["user"]
     assert "datetime" in logentry
+
+    # sysinfo contains versions of components used, for debugging purposes
+    assert "sysinfo" in logentry
+    assert "fmu-dataio" in logentry["sysinfo"]
+    assert "version" in logentry["sysinfo"]["fmu-dataio"]
+
+    _vrs = logentry["sysinfo"]["fmu-dataio"]["version"]
+    assert _vrs
+    assert isinstance(_vrs, str)
+
+    _kmd = read_named_envvar("KOMODO_RELEASE")
+    if _kmd:  # test shall run only when in a Komodo environment
+        assert "komodo" in logentry["sysinfo"]
+        assert logentry["sysinfo"]["komodo"]["version"] == _kmd
 
     # datetime in tracklog shall include time zone offset
     assert isoparse(logentry["datetime"]).tzinfo is not None

--- a/tests/test_units/test_utils.py
+++ b/tests/test_units/test_utils.py
@@ -1,5 +1,6 @@
 """Test the utils module"""
 
+import os
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 
@@ -184,3 +185,10 @@ def test_generate_description():
 
     with pytest.raises(ValueError):
         utils.generate_description(object())
+
+
+def test_read_named_envvar():
+    assert utils.read_named_envvar("DONTEXIST") is None
+
+    os.environ["MYTESTENV"] = "mytestvalue"
+    assert utils.read_named_envvar("MYTESTENV") == "mytestvalue"


### PR DESCRIPTION
Solve #387 

This PR includes some selected system information to the tracklog `created` entry when exporting data with fmu-dataio. The selected information include the current version of `fmu-dataio` used and the Komodo release when running in a Komodo environment.

The purpose of this is to ease debugging and user support, i.e. "as a developer I would like to know which version of fmu-dataio was used, so that I can understand the users context, detect and solve problems quicker."

Put into metadata the answer to the most common first debugging question: "Which version of fmu-dataio is the user running?"

Updated `tracklog` entry in produced metadata:

```yaml
tracklog:
  - datetime: 2020-10-28T14:28:02
    user:
      id: peesv
    event: created
    sysinfo:   # New ⚡
      fmu-dataio:
        version: 1.2.3
      komodo: # only added when running in Komodo environment
        release: 2023.12.05-py38
  - datetime: 2020-10-28T14:46:14
    user: 
      id: peesv
    event: updated
```
