### PR TITLE
ENH: replace verbosity with standard logging patterns

### DIFF
--- a/src/fmu/dataio/_design_kw.py
+++ b/src/fmu/dataio/_design_kw.py
@@ -7,14 +7,15 @@ along all dependencies of semeio"""
 
 from __future__ import annotations
 
-import logging
 import re
 import shlex
 from typing import Any, Final, Iterable
 
+from ._logging import null_logger
+
 _STATUS_FILE_NAME: Final = "DESIGN_KW.OK"
 
-_logger: Final = logging.getLogger(__name__)
+_logger: Final = null_logger(__name__)
 
 
 def run(

--- a/src/fmu/dataio/_filedata_provider.py
+++ b/src/fmu/dataio/_filedata_provider.py
@@ -5,14 +5,15 @@ as this is convinient to populate later, on demand)
 """
 from __future__ import annotations
 
-import logging
 from copy import deepcopy
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Final, Optional
 from warnings import warn
 
-logger: Final = logging.getLogger(__name__)
+from ._logging import null_logger
+
+logger: Final = null_logger(__name__)
 
 
 @dataclass
@@ -33,7 +34,6 @@ class _FileDataProvider:
     rootpath: Path = field(default_factory=Path)
     itername: str = ""
     realname: str = ""
-    verbosity: str = "CRITICAL"
 
     # storing results in these variables
     relative_path: Optional[str] = field(default="", init=False)
@@ -43,8 +43,6 @@ class _FileDataProvider:
     checksum_md5: Optional[str] = field(default="", init=False)
 
     def __post_init__(self) -> None:
-        logger.setLevel(level=self.verbosity)
-
         if self.dataio.name:
             self.name = self.dataio.name
         else:

--- a/src/fmu/dataio/_fmu_provider.py
+++ b/src/fmu/dataio/_fmu_provider.py
@@ -9,7 +9,6 @@ or it can detect that no providers are present (e.g. just ran from RMS interacti
 from __future__ import annotations
 
 import json
-import logging
 import pathlib
 import re
 from copy import deepcopy
@@ -22,12 +21,13 @@ from warnings import warn
 from fmu.config import utilities as ut
 
 from . import _utils
+from ._logging import null_logger
 
 # case metadata relative to rootpath
 ERT2_RELATIVE_CASE_METADATA_FILE: Final = "share/metadata/fmu_case.yml"
 RESTART_PATH_ENVNAME: Final = "RESTART_FROM_PATH"
 
-logger: Final = logging.getLogger(__name__)
+logger: Final = null_logger(__name__)
 
 
 def _get_folderlist(current: Path) -> list:
@@ -49,7 +49,6 @@ class _FmuProvider:
     """Class for detecting the run environment (e.g. an ERT2) and provide metadata."""
 
     dataio: Any
-    verbosity: str = "CRITICAL"
 
     provider: Optional[str] = field(default=None, init=False)
     is_fmurun: Optional[bool] = field(default=False, init=False)
@@ -68,8 +67,6 @@ class _FmuProvider:
     rootpath: Optional[Path] = field(default=None, init=False)
 
     def __post_init__(self) -> None:
-        logger.setLevel(level=self.verbosity)
-
         self.rootpath = Path(self.dataio._rootpath.absolute())
 
         self.rootpath_initial = self.rootpath

--- a/src/fmu/dataio/_logging.py
+++ b/src/fmu/dataio/_logging.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import logging
+
+
+def null_logger(name: str) -> logging.Logger:
+    """
+    Create and return a logger with a NullHandler.
+
+    This function creates a logger for the specified name and attaches a
+    NullHandler to it. The NullHandler prevents logging messages from being
+    automatically output to the console or other default handlers. This is
+    particularly useful in library modules where you want to provide the
+    users of the library the flexibility to configure their own logging behavior.
+
+    Args:
+        name (str): The name of the logger to be created. This is typically
+                    the name of the module in which the logger is
+                    created (e.g., using __name__).
+
+    Returns:
+        logging.Logger: A logger object configured with a NullHandler.
+
+    Example:
+        # In a library module
+        logger = null_logger(__name__)
+        logger.info("This info won't be logged to the console by default.")
+    """
+
+    logger = logging.getLogger(name)
+    logger.addHandler(logging.NullHandler())
+    return logger

--- a/src/fmu/dataio/_metadata.py
+++ b/src/fmu/dataio/_metadata.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import datetime
 import getpass
-import logging
 from dataclasses import dataclass, field
 from datetime import timezone
 from pathlib import Path
@@ -27,7 +26,9 @@ from fmu.dataio._utils import (
     read_metadata,
 )
 
-logger: Final = logging.getLogger(__name__)
+from ._logging import null_logger
+
+logger: Final = null_logger(__name__)
 
 
 class ConfigurationError(ValueError):
@@ -200,7 +201,6 @@ class _MetaData:
     # input variables
     obj: Any
     dataio: Any
-    verbosity: str = "CRITICAL"
     compute_md5: bool = True
 
     # storage state variables
@@ -224,7 +224,6 @@ class _MetaData:
     meta_existing: dict = field(default_factory=dict, init=False)
 
     def __post_init__(self) -> None:
-        logger.setLevel(level=self.verbosity)
         logger.info("Initialize _MetaData instance.")
 
         # one special case is that obj is a file path, and dataio.reuse_metadata_rule is
@@ -254,7 +253,7 @@ class _MetaData:
 
         The _FmuDataProvider is ran first -> self.fmudata
         """
-        self.fmudata = _FmuProvider(self.dataio, verbosity=self.verbosity)
+        self.fmudata = _FmuProvider(self.dataio)
         self.fmudata.detect_provider()
         logger.info("FMU provider is %s", self.fmudata.provider)
         return self.fmudata.case_metadata
@@ -267,7 +266,7 @@ class _MetaData:
 
         The _FmuDataProvider is ran first -> self.fmudata
         """
-        self.fmudata = _FmuProvider(self.dataio, verbosity=self.verbosity)
+        self.fmudata = _FmuProvider(self.dataio)
         self.fmudata.detect_provider()
         logger.info("FMU provider is %s", self.fmudata.provider)
         self.meta_fmu = self.fmudata.metadata
@@ -295,7 +294,6 @@ class _MetaData:
             Path(self.rootpath),
             self.fmudata.iter_name,
             self.fmudata.real_name,
-            self.verbosity,
         )
         fdata.derive_filedata()
 

--- a/src/fmu/dataio/_objectdata_provider.py
+++ b/src/fmu/dataio/_objectdata_provider.py
@@ -85,7 +85,6 @@ data:
 """
 from __future__ import annotations
 
-import logging
 from dataclasses import dataclass, field
 from datetime import datetime as dt
 from pathlib import Path
@@ -97,9 +96,10 @@ import pandas as pd
 import xtgeo
 
 from ._definitions import ALLOWED_CONTENTS, STANDARD_TABLE_INDEX_COLUMNS, _ValidFormats
+from ._logging import null_logger
 from ._utils import generate_description, parse_timedata
 
-logger: Final = logging.getLogger(__name__)
+logger: Final = null_logger(__name__)
 
 
 class ConfigurationError(ValueError):

--- a/src/fmu/dataio/_utils.py
+++ b/src/fmu/dataio/_utils.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import contextlib
 import hashlib
 import json
-import logging
 import os
 import shutil
 import uuid
@@ -21,8 +20,9 @@ import yaml
 from fmu.config import utilities as ut
 
 from . import _design_kw
+from ._logging import null_logger
 
-logger: Final = logging.getLogger(__name__)
+logger: Final = null_logger(__name__)
 
 
 def detect_inside_rms() -> bool:
@@ -75,10 +75,8 @@ def export_metadata_file(
     file: Path,
     metadata: dict,
     savefmt: Literal["yaml", "json"] = "yaml",
-    verbosity: str = "WARNING",
 ) -> None:
     """Export genericly and ordered to the complementary metadata file."""
-    logger.setLevel(level=verbosity)
     if not metadata:
         raise RuntimeError(
             "Export of metadata was requested, but no metadata are present."

--- a/src/fmu/dataio/scripts/create_case_metadata.py
+++ b/src/fmu/dataio/scripts/create_case_metadata.py
@@ -88,8 +88,8 @@ class WfCreateCaseMetadata(ErtScript):
 def create_case_metadata_main(args: argparse.Namespace) -> None:
     """Create the case metadata and register case on Sumo."""
 
-    logger.setLevel(level=args.verbosity)
     check_arguments(args)
+
     case_metadata_path = create_metadata(args)
     assert case_metadata_path is not None
     register_on_sumo(args, case_metadata_path)
@@ -99,6 +99,8 @@ def create_case_metadata_main(args: argparse.Namespace) -> None:
 
 def create_metadata(args: argparse.Namespace) -> str | None:
     """Create the case metadata and print them to the disk"""
+    logger.setLevel(args.verbosity)
+
     _global_variables_path = Path(args.ert_config_path, args.global_variables_path)
     global_variables = _parse_yaml(_global_variables_path)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -496,7 +496,6 @@ def fixture_aggr_surfs_mean(fmurun_w_casemetadata, rmsglobalconfig, regsurf):
     edata = dio.ExportData(
         config=rmsglobalconfig,  # read from global config
         content="depth",
-        verbosity="INFO",
     )
 
     aggs = []

--- a/tests/test_units/test_aggregated_surfaces.py
+++ b/tests/test_units/test_aggregated_surfaces.py
@@ -23,7 +23,6 @@ def test_regsurf_aggregated(fmurun_w_casemetadata, aggr_surfs_mean):
         source_metadata=metas,
         operation="mean",
         name="myaggrd",
-        verbosity="INFO",
         aggregation_id="1234",
     )
     newmeta = aggdata.generate_metadata(aggr_mean)
@@ -50,7 +49,6 @@ def test_regsurf_aggregated_export(fmurun_w_casemetadata, aggr_surfs_mean):
         operation="mean",
         name="myaggrd",
         tagname="mean",
-        verbosity="INFO",
         aggregation_id="1234",
     )
 
@@ -79,7 +77,6 @@ def test_regsurf_aggregated_alt_keys(fmurun_w_casemetadata, aggr_surfs_mean):
         operation="mean",
         name="myaggrd",
         tagname="mean",
-        verbosity="INFO",
         aggregation_id="1234",
     ).generate_metadata(aggr_mean)
 
@@ -90,7 +87,6 @@ def test_regsurf_aggregated_alt_keys(fmurun_w_casemetadata, aggr_surfs_mean):
         operation="mean",
         name="myaggrd",
         tagname="mean",
-        verbosity="INFO",
         aggregation_id="1234",
     )
 
@@ -102,7 +98,6 @@ def test_regsurf_aggregated_alt_keys(fmurun_w_casemetadata, aggr_surfs_mean):
         operation="mean",
         name="myaggrd",
         tagname="mean",
-        verbosity="INFO",
         aggregation_id="1234",
     )
     meta3 = aggdata3._metadata
@@ -136,7 +131,6 @@ def test_regsurf_aggr_export_give_casepath(fmurun_w_casemetadata, aggr_surfs_mea
         operation="mean",
         name="myaggrd",
         tagname="mean",
-        verbosity="INFO",
         aggregation_id="1234abcd",
     )
 
@@ -168,7 +162,6 @@ def test_regsurf_aggr_export_give_casepath_noex(fmurun_w_casemetadata, aggr_surf
         operation="mean",
         name="myaggrd",
         tagname="mean",
-        verbosity="INFO",
         aggregation_id="1234abcd",
     )
 
@@ -195,7 +188,6 @@ def test_regsurf_aggr_export_abspath_none(fmurun_w_casemetadata, aggr_surfs_mean
         operation="mean",
         name="myaggrd",
         tagname="mean",
-        verbosity="INFO",
         aggregation_id="1234abcd",
     )
 
@@ -221,7 +213,6 @@ def test_regsurf_aggregated_aggregation_id(fmurun_w_casemetadata, aggr_surfs_mea
         source_metadata=metas,
         operation="mean",
         name="myaggrd2",
-        verbosity="INFO",
     )
     newmeta = aggdata.generate_metadata(aggr_mean)
     logger.debug("New metadata:\n%s", utils.prettyprint_dict(newmeta))
@@ -232,7 +223,6 @@ def test_regsurf_aggregated_aggregation_id(fmurun_w_casemetadata, aggr_surfs_mea
         source_metadata=metas,
         operation="mean",
         name="myaggrd2",
-        verbosity="INFO",
         aggregation_id=None,
     )
     newmeta = aggdata.generate_metadata(aggr_mean)
@@ -245,7 +235,6 @@ def test_regsurf_aggregated_aggregation_id(fmurun_w_casemetadata, aggr_surfs_mea
         source_metadata=metas,
         operation="mean",
         name="myaggrd2",
-        verbosity="INFO",
         aggregation_id="1234",
     )
     newmeta = aggdata.generate_metadata(aggr_mean)
@@ -258,7 +247,6 @@ def test_regsurf_aggregated_aggregation_id(fmurun_w_casemetadata, aggr_surfs_mea
             source_metadata=metas,
             operation="mean",
             name="myaggrd2",
-            verbosity="INFO",
             aggregation_id=True,
         )
         newmeta = aggdata.generate_metadata(aggr_mean)
@@ -269,7 +257,6 @@ def test_regsurf_aggregated_aggregation_id(fmurun_w_casemetadata, aggr_surfs_mea
             source_metadata=metas,
             operation="mean",
             name="myaggrd2",
-            verbosity="INFO",
         )
         newmeta = aggdata.generate_metadata(aggr_mean, aggregation_id=True)
 
@@ -288,7 +275,6 @@ def test_generate_aggr_uuid(fmurun_w_casemetadata, aggr_surfs_mean):
         source_metadata=metas,
         operation="mean",
         name="myaggrd2",
-        verbosity="INFO",
     )
 
     # Sorting shall be ignored
@@ -347,7 +333,6 @@ def test_regsurf_aggregated_diffdata(fmurun_w_casemetadata, rmsglobalconfig, reg
         source_metadata=metas,
         operation="mean",
         name="myaggrd",
-        verbosity="INFO",
         aggregation_id="789politipoliti",
     )
     newmeta = aggdata.generate_metadata(aggregated["mean"])

--- a/tests/test_units/test_dataio.py
+++ b/tests/test_units/test_dataio.py
@@ -294,7 +294,6 @@ def test_content_deprecated_seismic_offset(regsurf, globalconfig2):
                     "offset": "0-15",
                 }
             },
-            verbosity="DEBUG",
         )
         mymeta = eobj.generate_metadata(regsurf)
 
@@ -347,9 +346,7 @@ def test_settings_config_from_env(tmp_path, rmsglobalconfig, regsurf):
         yaml.dump(settings, stream)
 
     os.environ["FMU_DATAIO_CONFIG"] = str(tmp_path / "mysettings.yml")
-    edata = ExportData(
-        content="depth", verbosity="INFO"
-    )  # the env variable will override this
+    edata = ExportData(content="depth")  # the env variable will override this
     assert edata.name == "MyFancyName"
 
     meta = edata.generate_metadata(regsurf)
@@ -376,9 +373,7 @@ def test_settings_and_global_config_from_env(tmp_path, rmsglobalconfig, regsurf)
     os.environ["FMU_GLOBAL_CONFIG"] = str(tmp_path / "global_variables.yml")
     os.environ["FMU_DATAIO_CONFIG"] = str(tmp_path / "mysettings.yml")
 
-    edata = ExportData(
-        content="depth", verbosity="INFO"
-    )  # the env variable will override this
+    edata = ExportData(content="depth")  # the env variable will override this
     assert edata.name == "MyFancyName"
 
     meta = edata.generate_metadata(regsurf)
@@ -401,7 +396,7 @@ def test_settings_config_from_env_invalid(tmp_path, rmsglobalconfig):
 
     os.environ["FMU_DATAIO_CONFIG"] = str(tmp_path / "mysettings.yml")
     with pytest.raises(ValidationError):
-        _ = ExportData(content="depth", verbosity="INFO")
+        _ = ExportData(content="depth")
 
     del os.environ["FMU_DATAIO_CONFIG"]
 
@@ -515,3 +510,8 @@ def test_forcefolder_absolute_shall_raise_or_warn(tmp_path, globalconfig2, regsu
     )
     ExportData.allow_forcefolder_absolute = False  # reset
     ExportData._inside_rms = False
+
+
+def test_deprecated_verbosity(globalconfig1):
+    with pytest.warns(UserWarning, match="Using the 'verbosity' key is now deprecated"):
+        ExportData(config=globalconfig1, verbosity="INFO")

--- a/tests/test_units/test_ert2_context.py
+++ b/tests/test_units/test_ert2_context.py
@@ -19,7 +19,7 @@ def test_regsurf_generate_metadata(fmurun_w_casemetadata, rmsglobalconfig, regsu
     logger.info("Active folder is %s", fmurun_w_casemetadata)
     os.chdir(fmurun_w_casemetadata)
 
-    edata = dataio.ExportData(config=rmsglobalconfig, verbosity="INFO", content="depth")
+    edata = dataio.ExportData(config=rmsglobalconfig, content="depth")
 
     meta = edata.generate_metadata(regsurf)
     assert str(edata._pwd) == str(fmurun_w_casemetadata)
@@ -42,7 +42,6 @@ def test_regsurf_generate_metadata_incl_jobs(
     edata = dataio.ExportData(
         config=rmsglobalconfig,
         content="depth",
-        verbosity="INFO",
     )
 
     meta = edata.generate_metadata(regsurf)
@@ -61,14 +60,12 @@ def test_regsurf_metadata_with_timedata(
     edata = dataio.ExportData(
         config=rmsglobalconfig,
         content="depth",
-        verbosity="INFO",
     )
 
     meta1 = edata.generate_metadata(
         regsurf,
         name="TopVolantis",
         timedata=[[20300101, "moni"], [20100203, "base"]],
-        verbosity="INFO",
     )
     assert meta1["data"]["time"]["t0"]["value"] == "2010-02-03T00:00:00"
     assert meta1["data"]["time"]["t0"]["label"] == "base"
@@ -79,7 +76,6 @@ def test_regsurf_metadata_with_timedata(
         regsurf,
         name="TopVolantis",
         timedata=[[20300123, "one"]],
-        verbosity="INFO",
     )
 
     assert meta1["data"]["time"]["t0"]["value"] == "2030-01-23T00:00:00"
@@ -100,7 +96,6 @@ def test_regsurf_export_file_fmurun(fmurun_w_casemetadata, rmsglobalconfig, regs
 
     edata = dataio.ExportData(
         config=rmsglobalconfig,
-        verbosity="INFO",
         workflow="My test workflow",
         unit="myunit",
         content="depth",
@@ -191,7 +186,7 @@ def test_points_export_file_set_name_xtgeoheaders(
 
     dataio.ExportData.points_fformat = "csv"
     edata = dataio.ExportData(
-        config=rmsglobalconfig, verbosity="INFO", content="depth"
+        config=rmsglobalconfig, content="depth"
     )  # read from global config
     edata.points_fformat = "csv|xtgeo"  # override
 

--- a/tests/test_units/test_fmuprovider_class.py
+++ b/tests/test_units/test_fmuprovider_class.py
@@ -72,7 +72,7 @@ def test_fmuprovider_arbitrary_iter_name(edataobj1, fmurun_w_casemetadata_pred):
 
     edataobj1._rootpath = fmurun_w_casemetadata_pred
     os.chdir(fmurun_w_casemetadata_pred)
-    myfmu = _FmuProvider(edataobj1, verbosity="DEBUG")
+    myfmu = _FmuProvider(edataobj1)
     myfmu.detect_provider()
     assert myfmu.case_name == "ertrun1"
     assert myfmu.real_name == "realization-0"
@@ -95,7 +95,7 @@ def test_fmuprovider_prehook_case(globalconfig2, tmp_path):
     key casepath is given explicitly!.
     """
 
-    icase = dio.InitializeCase(config=globalconfig2, verbosity="INFO")
+    icase = dio.InitializeCase(config=globalconfig2)
 
     caseroot = tmp_path / "prehook"
     caseroot.mkdir(parents=True)
@@ -122,7 +122,7 @@ def test_fmuprovider_prehook_case(globalconfig2, tmp_path):
         casepath=caseroot,
     )
 
-    myfmu = _FmuProvider(eobj, verbosity="INFO")
+    myfmu = _FmuProvider(eobj)
     myfmu.detect_provider()
     assert myfmu.case_name == "prehook"
     assert myfmu.real_name is None

--- a/tests/test_units/test_initialize_case.py
+++ b/tests/test_units/test_initialize_case.py
@@ -15,12 +15,12 @@ logger = logging.getLogger(__name__)
 
 
 def test_inicase_barebone(globalconfig2):
-    icase = InitializeCase(config=globalconfig2, verbosity="INFO")
+    icase = InitializeCase(config=globalconfig2)
     assert "Drogon" in str(icase.config)
 
 
 def test_inicase_barebone_with_export(globalconfig2, fmurun):
-    icase = InitializeCase(config=globalconfig2, verbosity="INFO")
+    icase = InitializeCase(config=globalconfig2)
     assert "Drogon" in str(icase.config)
 
     globalconfig2["masterdata"]["smda"]["field"][0]["identifier"] = "æøå"
@@ -57,7 +57,7 @@ def test_inicase_pwd_basepath(fmurun, globalconfig2):
     logger.info("Active folder is %s", fmurun)
     os.chdir(fmurun)
 
-    icase = InitializeCase(config=globalconfig2, verbosity="INFO")
+    icase = InitializeCase(config=globalconfig2)
     with pytest.warns(UserWarning):
         icase._establish_pwd_casepath()
 
@@ -74,9 +74,7 @@ def test_inicase_pwd_basepath_explicit(fmurun, globalconfig2):
 
     myroot = fmurun
 
-    icase = InitializeCase(
-        config=globalconfig2, verbosity="INFO", rootfolder=myroot, casename="mycase"
-    )
+    icase = InitializeCase(config=globalconfig2, rootfolder=myroot, casename="mycase")
     icase._establish_pwd_casepath()
 
     logger.info("Casepath is %s", icase._casepath)
@@ -91,7 +89,7 @@ def test_inicase_update_settings(fmurun, globalconfig2):
     os.chdir(fmurun)
     myroot = fmurun / "mycase"
 
-    icase = InitializeCase(config=globalconfig2, verbosity="INFO", rootfolder=myroot)
+    icase = InitializeCase(config=globalconfig2, rootfolder=myroot)
     kwargs = {"rootfolder": "/tmp"}
     icase._update_settings(newsettings=kwargs)
 
@@ -109,7 +107,7 @@ def test_inicase_update_settings_correct_key_wrong_type(fmurun, globalconfig2):
     os.chdir(fmurun)
     myroot = fmurun / "mycase"
 
-    icase = InitializeCase(config=globalconfig2, verbosity="INFO", rootfolder=myroot)
+    icase = InitializeCase(config=globalconfig2, rootfolder=myroot)
     kwargs = {"rootfolder": 1234567}
     with pytest.raises(ValueError, match=r"The value of '"):
         icase._update_settings(newsettings=kwargs)
@@ -121,7 +119,7 @@ def test_inicase_update_settings_shall_fail(fmurun, globalconfig2):
     os.chdir(fmurun)
     myroot = fmurun / "mycase"
 
-    icase = InitializeCase(config=globalconfig2, verbosity="INFO", rootfolder=myroot)
+    icase = InitializeCase(config=globalconfig2, rootfolder=myroot)
     kwargs = {"invalidfolder": "/tmp"}
     with pytest.raises(KeyError):
         icase._update_settings(newsettings=kwargs)
@@ -133,7 +131,7 @@ def test_inicase_generate_case_metadata(fmurun, globalconfig2):
     myroot = fmurun.parent.parent.parent / "mycase"
     logger.info("Case folder is now %s", myroot)
 
-    icase = InitializeCase(globalconfig2, verbosity="INFO")
+    icase = InitializeCase(globalconfig2)
     with pytest.warns(UserWarning, match="The rootfolder is defaulted"):
         icase.generate_case_metadata()
 
@@ -146,7 +144,7 @@ def test_inicase_generate_case_metadata_exists_so_fails(
     logger.info("Folder is %s", fmurun_w_casemetadata)
     casemetafolder = fmurun_w_casemetadata.parent.parent
 
-    icase = InitializeCase(globalconfig2, verbosity="INFO")
+    icase = InitializeCase(globalconfig2)
     with pytest.warns(UserWarning, match=r"The metadata file already exist!"):
         icase.generate_case_metadata(rootfolder=casemetafolder)
 
@@ -163,7 +161,7 @@ def test_inicase_generate_case_metadata_exists_but_force(
     with open(old_metafile, encoding="utf-8") as stream:
         old_content = yaml.safe_load(stream)
 
-    icase = InitializeCase(globalconfig2, verbosity="INFO")
+    icase = InitializeCase(globalconfig2)
     icase.export(
         rootfolder=casemetafolder,
         force=True,
@@ -184,7 +182,7 @@ def test_inicase_generate_case_metadata_exists_but_force(
 
 
 def test_inicase_deprecated_restart_from(fmurun_w_casemetadata, globalconfig2):
-    icase = InitializeCase(globalconfig2, verbosity="INFO")
+    icase = InitializeCase(globalconfig2)
     with pytest.warns(
         DeprecationWarning,
         match="The 'restart_from' argument is deprecated and will be removed in a "

--- a/tests/test_units/test_rms_context.py
+++ b/tests/test_units/test_rms_context.py
@@ -117,14 +117,12 @@ def test_regsurf_metadata_with_timedata(rmssetup, rmsglobalconfig, regsurf):
     edata = dataio.ExportData(
         config=rmsglobalconfig,
         content="depth",
-        verbosity="INFO",
     )  # read from global config
     meta1 = edata.generate_metadata(
         regsurf,
         name="TopVolantis",
         content="depth",
         timedata=[[20300101, "moni"], [20100203, "base"]],
-        verbosity="INFO",
     )
     assert meta1["data"]["time"]["t0"]["value"] == "2010-02-03T00:00:00"
     assert meta1["data"]["time"]["t0"]["label"] == "base"
@@ -135,7 +133,6 @@ def test_regsurf_metadata_with_timedata(rmssetup, rmsglobalconfig, regsurf):
         regsurf,
         name="TopVolantis",
         timedata=[[20300123, "one"]],
-        verbosity="INFO",
     )
 
     assert meta1["data"]["time"]["t0"]["value"] == "2030-01-23T00:00:00"
@@ -154,14 +151,12 @@ def test_regsurf_metadata_with_timedata_legacy(rmssetup, rmsglobalconfig, regsur
     dataio.ExportData.legacy_time_format = True
     edata = dataio.ExportData(
         config=rmsglobalconfig,
-        verbosity="INFO",
         content="depth",
     )  # read from global config
     meta1 = edata.generate_metadata(
         regsurf,
         name="TopVolantis",
         timedata=[[20300101, "moni"], [20100203, "base"]],
-        verbosity="INFO",
     )
     logger.debug(prettyprint_dict(meta1))
     assert "topvolantis--20300101_20100203" in meta1["file"]["relative_path"]
@@ -176,7 +171,6 @@ def test_regsurf_metadata_with_timedata_legacy(rmssetup, rmsglobalconfig, regsur
         name="TopVolantis",
         content="depth",
         timedata=[[20300123, "one"]],
-        verbosity="INFO",
     )
 
     logger.debug(prettyprint_dict(meta1))
@@ -203,7 +197,6 @@ def test_regsurf_export_file_fmurun(
 
     edata = dataio.ExportData(
         config=rmsglobalconfig,
-        verbosity="INFO",
         content="depth",
         workflow="My test workflow",
         unit="myunit",
@@ -285,7 +278,7 @@ def test_points_export_file_set_name_xtgeoheaders(rmssetup, rmsglobalconfig, poi
     dataio.ExportData.points_fformat = "csv|xtgeo"
 
     edata = dataio.ExportData(
-        config=rmsglobalconfig, verbosity="INFO", content="depth"
+        config=rmsglobalconfig, content="depth"
     )  # read from global config
 
     output = edata.export(points, name="TopVolantiz")


### PR DESCRIPTION
Using verbosity and setLevel within the library is an antipattern. 

The approach shall be that the end client script sets the logging level, format, etc. instead.

Closes #270 