### PR TITLE
FIX: Remove deprecated `verbosity` from examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,8 @@ venv.bak/
 
 # setuptools_scm version
 src/fmu/dataio/version.py
+# aggregated examples directory
+examples/s/d/nn/xcase/iter-0/
 
 # mypy
 .dmypy.json

--- a/docs/preparations.rst
+++ b/docs/preparations.rst
@@ -214,11 +214,10 @@ from the Drogon workflow:
     --  --sumo: If passed, case will be registered on Sumo. Use this is intention to upload data.
     --  --sumo_env (str): Specify Sumo environment. Default: prod
     --  --global_variables_path (str): Path to global variables relative to CONFIG path
-    --  --verbosity (str): Python logging level to use
     -- 
     -- NOTE! If using optional arguments, note that the "--" annotation will be interpreted
     --       as comments by ERT if not wrapped in quotes. This is the syntax to use:
-    --       (existing arguments) "--sumo" "--sumo_env" dev "--verbosity" DEBUG
+    --       (existing arguments) "--sumo" "--sumo_env" dev
 
 .. note::
     Note that there are references to Sumo in the script above. You don't have to worry

--- a/examples/s/d/nn/xcase/realization-0/iter-0/any/bin/export_grid3d.py
+++ b/examples/s/d/nn/xcase/realization-0/iter-0/any/bin/export_grid3d.py
@@ -1,10 +1,13 @@
 """Export 3D griddata with properties."""
-
+import logging
 import pathlib
 
 import fmu.dataio as dataio
 import xtgeo
 from fmu.config import utilities as ut
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.WARNING)
 
 CFG = ut.yaml_load("../../fmuconfig/output/global_variables.yml")
 
@@ -13,7 +16,6 @@ GFILE = "gg"
 GNAME = "geogrid"
 PROPS_SEISMIC = ["phit", "sw"]
 PROPS_OTHER = ["klogh", "facies"]
-VERBOSITY = "WARNING"
 
 
 def export_geogrid_geometry():
@@ -30,7 +32,6 @@ def export_geogrid_geometry():
         is_prediction=True,
         is_observation=False,
         tagname="",
-        verbosity=VERBOSITY,
         workflow="rms structural model",
     )
 
@@ -57,7 +58,6 @@ def export_geogrid_parameters():
             timedata=None,
             is_prediction=True,
             is_observation=False,
-            verbosity=VERBOSITY,
             workflow="rms property model",
         )
 

--- a/examples/s/d/nn/xcase/realization-0/iter-0/any/bin/export_volumetables.py
+++ b/examples/s/d/nn/xcase/realization-0/iter-0/any/bin/export_volumetables.py
@@ -5,11 +5,15 @@ RMS (to demostrate how volume tables can be fetched via Roxar API).
 
 For the file case, CSV files are read from disk. The dataio function is the same.
 """
+import logging
 import pathlib
 
 import fmu.dataio
 import pandas as pd
 from fmu.config import utilities as ut
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.WARNING)
 
 CFG = ut.yaml_load("../../fmuconfig/output/global_variables.yml")
 
@@ -25,7 +29,6 @@ else:
 
 
 TAGNAME = "volumes"
-VERBOSITY = "WARNING"
 
 # renaming columns from RMS to FMU standard
 RENAMING = {
@@ -86,7 +89,6 @@ def export_dataio(df, gridname):
         is_prediction=True,
         is_observation=False,
         tagname=TAGNAME,
-        verbosity=VERBOSITY,
         workflow="Volume calculation",
     )
 

--- a/examples/s/d/nn/xcase/realization-0/iter-0/rms/bin/export_a_surface.py
+++ b/examples/s/d/nn/xcase/realization-0/iter-0/rms/bin/export_a_surface.py
@@ -4,11 +4,15 @@ I.e. what we do is actually add metadata and store in the right place
 
 The input maps is poro_average.grid
 """
+import logging
 from pathlib import Path
 
 import fmu.dataio as dataio
 import xtgeo
 from fmu.config import utilities as ut
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.WARNING)
 
 CFG = ut.yaml_load("../../fmuconfig/output/global_variables.yml")
 

--- a/examples/s/d/nn/xcase/realization-0/iter-0/rms/bin/export_faultpolygons.py
+++ b/examples/s/d/nn/xcase/realization-0/iter-0/rms/bin/export_faultpolygons.py
@@ -1,9 +1,13 @@
 """Export faultpolygons via dataio with metadata."""
+import logging
 from pathlib import Path
 
 import fmu.dataio as dataio
 import xtgeo
 from fmu.config import utilities as utils
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.WARNING)
 
 CFG = utils.yaml_load("../../fmuconfig/output/global_variables.yml")
 
@@ -28,7 +32,6 @@ def export_faultlines():
         is_prediction=True,
         is_observation=False,
         tagname="faultlines",
-        verbosity="INFO",
         workflow="rms structural model",
     )
 
@@ -46,7 +49,7 @@ def export_faultlines():
         # xtgeo column names as-is while "csv" will force column names to "X Y Z ID"
         for fmt in ["csv|xtgeo", "irap_ascii"]:
             ed.polygons_fformat = fmt
-            ed.export(poly, verbosity="WARNING")
+            ed.export(poly)
 
 
 if __name__ == "__main__":

--- a/examples/s/d/nn/xcase/realization-0/iter-0/rms/bin/export_propmaps.py
+++ b/examples/s/d/nn/xcase/realization-0/iter-0/rms/bin/export_propmaps.py
@@ -10,11 +10,15 @@ We wan to use the file names here to extract some data (like name of formation,
 e.g. Therys).
 
 """
+import logging
 from pathlib import Path
 
 import fmu.dataio as dataio
 import xtgeo
 from fmu.config import utilities as ut
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.WARNING)
 
 CFG = ut.yaml_load("../../fmuconfig/output/global_variables.yml")
 
@@ -64,7 +68,6 @@ def main():
             is_prediction=True,
             is_observation=False,
             tagname="average_" + attribute,
-            verbosity="INFO",
             workflow="rms property model",
         )
         fname = ed.export(surf)

--- a/examples/s/d/nn/xcase/realization-1/iter-0/rms/bin/export_a_surface.py
+++ b/examples/s/d/nn/xcase/realization-1/iter-0/rms/bin/export_a_surface.py
@@ -4,11 +4,15 @@ I.e. what we do is actually add metadata and store in the right place
 
 The input maps is poro_average.grid
 """
+import logging
 from pathlib import Path
 
 import fmu.dataio as dataio
 import xtgeo
 from fmu.config import utilities as ut
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.WARNING)
 
 CFG = ut.yaml_load("../../fmuconfig/output/global_variables.yml")
 

--- a/examples/s/d/nn/xcase/realization-9/iter-0/rms/bin/export_a_surface.py
+++ b/examples/s/d/nn/xcase/realization-9/iter-0/rms/bin/export_a_surface.py
@@ -4,11 +4,15 @@ I.e. what we do is actually add metadata and store in the right place
 
 The input maps is poro_average.grid
 """
+import logging
 from pathlib import Path
 
 import fmu.dataio as dataio
 import xtgeo
 from fmu.config import utilities as ut
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.WARNING)
 
 CFG = ut.yaml_load("../../fmuconfig/output/global_variables.yml")
 


### PR DESCRIPTION
The example scripts generated warnings about passing the deprecated `verbosity` keyword and the docs also referenced it. The scripts were modified to set the logging level to `WARNING` which seems a reasonable example for users to follow as INFO may be more than they care about.