### PR TITLE
ENH: Add platform field to event-tracklog

### DIFF
--- a/schema/definitions/0.8.0/schema/fmu_meta.json
+++ b/schema/definitions/0.8.0/schema/fmu_meta.json
@@ -6396,25 +6396,76 @@
           ],
           "default": null,
           "examples": [
-            "1.2.3"
+            "2023.12.05-py38"
           ]
         },
-        "komodo": {
+        "operating_system": {
           "anyOf": [
             {
-              "$ref": "#/$defs/VersionInformation"
+              "$ref": "#/$defs/SystemInformationOperatingSystem"
             },
             {
               "type": "null"
             }
           ],
-          "default": null,
-          "examples": [
-            "2023.12.05-py38"
-          ]
+          "default": null
         }
       },
       "title": "SystemInformation",
+      "type": "object"
+    },
+    "SystemInformationOperatingSystem": {
+      "description": "This model encapsulates various pieces of\nsystem-related information using Python's platform module. It provides a\nstructured way to access details about the system's hardware, operating\nsystem, and interpreter version information.",
+      "properties": {
+        "hostname": {
+          "description": "The network name of the computer, possibly not fully qualified.",
+          "examples": [
+            "Johns-MacBook-Pro.local"
+          ],
+          "title": "Hostname",
+          "type": "string"
+        },
+        "operating_system": {
+          "description": "A detailed string identifying the underlying platform with as much useful information as possible.",
+          "examples": [
+            "Darwin-18.7.0-x86_64-i386-64bit"
+          ],
+          "title": "Platform",
+          "type": "string"
+        },
+        "release": {
+          "description": "The system's release version, such as a version number or a name.",
+          "examples": [
+            "18.7.0"
+          ],
+          "title": "Release",
+          "type": "string"
+        },
+        "system": {
+          "description": "The name of the operating system.",
+          "examples": [
+            "Darwin"
+          ],
+          "title": "System",
+          "type": "string"
+        },
+        "version": {
+          "description": "The specific release version of the system.",
+          "examples": [
+            "#1 SMP Tue Aug 27 21:37:59 PDT 2019"
+          ],
+          "title": "Version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "hostname",
+        "operating_system",
+        "release",
+        "system",
+        "version"
+      ],
+      "title": "SystemInformationOperatingSystem",
       "type": "object"
     },
     "TableSpecification": {
@@ -7267,8 +7318,7 @@
             {
               "type": "null"
             }
-          ],
-          "default": null
+          ]
         },
         "user": {
           "$ref": "#/$defs/User"

--- a/src/fmu/dataio/_metadata.py
+++ b/src/fmu/dataio/_metadata.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import datetime
 import getpass
 import os
+import platform
 from dataclasses import dataclass, field
 from datetime import timezone
 from pathlib import Path
@@ -64,6 +65,13 @@ def generate_meta_tracklog() -> list[dict]:
                 komodo=meta.VersionInformation.model_construct(version=kr)
                 if (kr := os.environ.get("KOMODO_RELEASE"))
                 else None,
+                operating_system=meta.SystemInformationOperatingSystem.model_construct(
+                    hostname=platform.node(),
+                    operating_system=platform.platform(),
+                    release=platform.release(),
+                    system=platform.system(),
+                    version=platform.version(),
+                ),
             ),
         ).model_dump(
             mode="json",

--- a/src/fmu/dataio/datastructure/meta/meta.py
+++ b/src/fmu/dataio/datastructure/meta/meta.py
@@ -254,6 +254,48 @@ class VersionInformation(BaseModel):
     version: str
 
 
+class SystemInformationOperatingSystem(BaseModel):
+    """
+    This model encapsulates various pieces of
+    system-related information using Python's platform module. It provides a
+    structured way to access details about the system's hardware, operating
+    system, and interpreter version information.
+    """
+
+    hostname: str = Field(
+        title="Hostname",
+        description="The network name of the computer, possibly not fully qualified.",
+        examples=["Johns-MacBook-Pro.local"],
+    )
+
+    operating_system: str = Field(
+        title="Platform",
+        description=(
+            "A detailed string identifying the underlying platform "
+            "with as much useful information as possible."
+        ),
+        examples=["Darwin-18.7.0-x86_64-i386-64bit"],
+    )
+
+    release: str = Field(
+        title="Release",
+        description="The system's release version, such as a version number or a name.",
+        examples=["18.7.0"],
+    )
+
+    system: str = Field(
+        title="System",
+        description="The name of the operating system.",
+        examples=["Darwin"],
+    )
+
+    version: str = Field(
+        title="Version",
+        description="The specific release version of the system.",
+        examples=["#1 SMP Tue Aug 27 21:37:59 PDT 2019"],
+    )
+
+
 class SystemInformation(BaseModel):
     fmu_dataio: Optional[VersionInformation] = Field(
         alias="fmu-dataio",
@@ -261,8 +303,12 @@ class SystemInformation(BaseModel):
         examples=["1.2.3"],
     )
     komodo: Optional[VersionInformation] = Field(
+        alias="fmu-dataio",
         default=None,
         examples=["2023.12.05-py38"],
+    )
+    operating_system: Optional[SystemInformationOperatingSystem] = Field(
+        default=None,
     )
 
 
@@ -279,7 +325,7 @@ class TracklogEvent(BaseModel):
     )
     user: User
     sysinfo: Optional[SystemInformation] = Field(
-        default=None,
+        default_factory=SystemInformation,
     )
 
 

--- a/tests/test_units/test_metadata_class.py
+++ b/tests/test_units/test_metadata_class.py
@@ -6,7 +6,10 @@ import fmu.dataio as dio
 import pytest
 from fmu.dataio._metadata import SCHEMA, SOURCE, VERSION, ConfigurationError, _MetaData
 from fmu.dataio._utils import prettyprint_dict
-from fmu.dataio.datastructure.meta.meta import TracklogEvent
+from fmu.dataio.datastructure.meta.meta import (
+    SystemInformationOperatingSystem,
+    TracklogEvent,
+)
 
 # pylint: disable=no-member
 
@@ -75,6 +78,21 @@ def test_generate_meta_tracklog_komodo_version(edataobj1, monkeypatch):
 
     assert parsed.sysinfo.komodo is not None
     assert parsed.sysinfo.komodo.version == fake_komodo_release
+
+
+def test_generate_meta_tracklog_operating_system(edataobj1):
+    mymeta = _MetaData("dummy", edataobj1)
+    mymeta._populate_meta_tracklog()
+    tracklog = mymeta.meta_tracklog
+
+    assert isinstance(tracklog, list)
+    assert len(tracklog) == 1  # assume "created"
+
+    parsed = TracklogEvent.model_validate(tracklog[0])
+    assert isinstance(
+        parsed.sysinfo.operating_system,
+        SystemInformationOperatingSystem,
+    )
 
 
 # --------------------------------------------------------------------------------------


### PR DESCRIPTION
Resolves: https://github.com/equinor/fmu-dataio/issues/387

Schema will be updated as soon as we decide to publish a new schema

```python
python -c"from pprint import pp; from fmu.dataio._metadata import generate_meta_tracklog; pp(generate_meta_tracklog())"
[{'datetime': '2024-02-12T13:46:27.159655Z',
  'event': 'created',
  'user': {'id': 'xxxxxx'},
  'sysinfo': {'fmu-dataio': {'version': '2.1.1.dev3+gbb36c6a'},
              'operating_system': {'hostname': 'AC-W6JD2YH37N',
                                   'operating_system': 'macOS-14.2.1-arm64-arm-64bit',
                                   'release': '23.2.0',
                                   'system': 'Darwin',
                                   'version': 'Darwin Kernel Version 23.2.0: '
                                              'Wed Nov 15 21:55:06 PST 2023; '
                                              'root:xnu-10002.61.3~2/RELEASE_ARM64_T6020'}}}]
```