### PR TITLE
ENH: Graceful metadata validation

### DIFF
--- a/tests/test_units/test_utils.py
+++ b/tests/test_units/test_utils.py
@@ -1,5 +1,6 @@
 """Test the utils module"""
 
+import logging
 import os
 from pathlib import Path
 from tempfile import NamedTemporaryFile
@@ -195,3 +196,20 @@ def test_read_named_envvar():
 
     os.environ["MYTESTENV"] = "mytestvalue"
     assert utils.read_named_envvar("MYTESTENV") == "mytestvalue"
+
+
+def test_export_metadata_file_illformed_warning(tmp_path, caplog, monkeypatch):
+    with caplog.at_level(logging.WARNING):
+        utils.export_metadata_file(
+            tmp_path / "tmp.yml",
+            metadata={"foo": "bar"},
+        )
+    assert "Unable to validate/roundtrip metadata" not in caplog.text
+
+    monkeypatch.setenv("_ERT_SIMULATION_MODE", "<TESTING_PLACEHOLER>")
+    with caplog.at_level(logging.WARNING):
+        utils.export_metadata_file(
+            tmp_path / "tmp.yml",
+            metadata={"foo": "bar"},
+        )
+    assert "Unable to validate/roundtrip metadata" in caplog.text


### PR DESCRIPTION
Unsure if graceful will be the right term here, any content that is not part of the schema will be dropped. However, if there is types or structures that are not according to the model validation fails and we fallback the to original object.

Related to: https://github.com/equinor/fmu-dataio/pull/440