### PR TITLE
ENH: Apply ERT env variables in FMU runs

### DIFF
--- a/examples/run_examples.sh
+++ b/examples/run_examples.sh
@@ -2,8 +2,6 @@
 set -e
 # The examples scripts are ran and included in the documentation!
 
-export RUN_DATAIO_EXAMPLES=1  # this is important when running examples!
-
 current=$PWD
 
 # empty current results
@@ -13,6 +11,14 @@ rm -rf examples/s/d/nn/xcase/iter-0/*
 
 # Note! run from RUNPATH, NOT being inside RMS but need RUN_DATAIO_EXAMPLES env!
 cd $current/examples/s/d/nn/xcase/realization-0/iter-0/rms/bin
+
+# fake an ERT FMU run
+export _ERT_EXPERIMENT_ID=6a8e1e0f-9315-46bb-9648-8de87151f4c7
+export _ERT_ENSEMBLE_ID=b027f225-c45d-477d-8f33-73695217ba14
+export _ERT_SIMULATION_MODE=test_run
+export _ERT_ITERATION_NUMBER=0
+export _ERT_REALIZATION_NUMBER=0
+export _ERT_RUNPATH=$current/examples/s/d/nn/xcase/realization-0/iter-0
 
 python export_faultpolygons.py
 python export_propmaps.py
@@ -25,6 +31,10 @@ python export_volumetables.py
 # Emulate FMU run with 3 realizations and export data to disk
 for num in 0 1 9; do
     cd $current/examples/s/d/nn/xcase/realization-${num}/iter-0/rms/bin
+
+    export _ERT_REALIZATION_NUMBER=$num
+    export _ERT_RUNPATH=${current}/examples/s/d/nn/xcase/realization-${num}/iter-0
+
     python export_a_surface.py
 done
 

--- a/examples/s/d/nn/xcase/realization-0/iter-0/any/bin/export_grid3d.py
+++ b/examples/s/d/nn/xcase/realization-0/iter-0/any/bin/export_grid3d.py
@@ -6,8 +6,8 @@ import fmu.dataio as dataio
 import xtgeo
 from fmu.config import utilities as ut
 
+logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.WARNING)
 
 CFG = ut.yaml_load("../../fmuconfig/output/global_variables.yml")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,10 +89,9 @@ match = '(?!(test_|_)).*\.py'
 
 [tool.ruff]
 line-length = 88
+exclude = ["version.py"]
 [tool.ruff.lint]
-ignore = [
-    "C901",
-]
+ignore = ["C901"]
 select = [
     "C",
     "E",

--- a/src/fmu/dataio/_fmu_provider.py
+++ b/src/fmu/dataio/_fmu_provider.py
@@ -1,292 +1,384 @@
-"""Module for DataIO _FmuProvider
+"""Module for DataIO FmuProvider
 
-The FmuProvider will from the run environment and eventually API's detect valid
+The FmuProvider will from the environment and eventually API's detect valid
 fields to the FMU data block.
 
-Note that FMU may potentially have different providers, e.g. ERT2 vs ERT3
-or it can detect that no providers are present (e.g. just ran from RMS interactive)
+Note that FMU may potentially have different providers, e.g. ERT versions
+or it can detect that no FMU providers are present (e.g. just ran from RMS interactive)
+
+Note that establishing the FMU case metadata for a run, is currently *not* done
+here; this is done by code in the InitializeCase class.
+
+From ERT v. 5 (?), the following env variables are provided in startup (example):
+
+_ERT_EXPERIMENT_ID:   6a8e1e0f-9315-46bb-9648-8de87151f4c7
+_ERT_ENSEMBLE_ID:   b027f225-c45d-477d-8f33-73695217ba14
+_ERT_SIMULATION_MODE:   test_run
+
+and during a Forward model:
+
+_ERT_EXPERIMENT_ID:   6a8e1e0f-9315-46bb-9648-8de87151f4c7
+_ERT_ENSEMBLE_ID:   b027f225-c45d-477d-8f33-73695217ba14
+_ERT_SIMULATION_MODE:   test_run
+_ERT_ITERATION_NUMBER:   0
+_ERT_REALIZATION_NUMBER:   0
+_ERT_RUNPATH:   /scratch/fmu/jriv/01_drogon_ahm/realization-0/iter-0/
+
 """
 from __future__ import annotations
 
 import json
-import pathlib
-import re
+import os
 from copy import deepcopy
 from dataclasses import dataclass, field
+from enum import Enum, auto
 from os import environ
 from pathlib import Path
-from typing import Any, Final, Optional
+from typing import Final, Optional
 from warnings import warn
 
 from fmu.config import utilities as ut
 
 from . import _utils
+from ._definitions import FmuContext
 from ._logging import null_logger
 
-# case metadata relative to rootpath
-ERT2_RELATIVE_CASE_METADATA_FILE: Final = "share/metadata/fmu_case.yml"
+# case metadata relative to casepath
+ERT_RELATIVE_CASE_METADATA_FILE: Final = "share/metadata/fmu_case.yml"
 RESTART_PATH_ENVNAME: Final = "RESTART_FROM_PATH"
 
 logger: Final = null_logger(__name__)
 
 
-def _get_folderlist(current: Path) -> list:
-    """Return a list of pure folder names incl. current casepath up to system root.
+class FmuEnv(Enum):
+    EXPERIMENT_ID = auto()
+    ENSEMBLE_ID = auto()
+    SIMULATION_MODE = auto()
+    REALIZATION_NUMBER = auto()
+    ITERATION_NUMBER = auto()
+    RUNPATH = auto()
 
-    For example: current is /scratch/xfield/nn/case/realization-33/iter-1
-    shall return ['', 'scratch', 'xfield', 'nn', 'case', 'realization-33', 'iter-1']
-    """
-    flist = [current.name]
-    for par in current.parents:
-        flist.append(par.name)
+    @property
+    def value(self) -> str | None:
+        # Fetch the environment variable; name of the enum member prefixed with _ERT_
+        return os.getenv(f"_ERT_{self.name}")
 
-    flist.reverse()
-    return flist
+    @property
+    def keyname(self) -> str:
+        # Fetch the environment variable; name of the enum member prefixed with _ERT_
+        return f"_ERT_{self.name}"
 
 
 @dataclass
-class _FmuProvider:
-    """Class for detecting the run environment (e.g. an ERT2) and provide metadata."""
+class FmuProvider:
+    """Class for detecting the run environment (e.g. an ERT) and provide metadata.
 
-    dataio: Any
+    Args:
+        model: Name of the model (usually from global config)
+        rootpath: ....
+        fmu_context: The FMU context this is ran in; see FmuContext enum class
+        casepath_proposed: Proposed casepath ... needed?
+        include_ertjobs: True if we want to include ....
+        forced_realization: If we want to force the realization (use case?)
+        workflow: Descriptive work flow info
+    """
 
-    provider: Optional[str] = field(default=None, init=False)
-    is_fmurun: Optional[bool] = field(default=False, init=False)
-    iter_name: Optional[str] = field(default=None, init=False)
-    iter_id: Optional[int] = field(default=None, init=False)
-    iter_path: Optional[Path] = field(default=None, init=False)
-    real_name: Optional[str] = field(default=None, init=False)
-    real_id: int = field(default=0, init=False)
-    real_path: Optional[Path] = field(default=None, init=False)
-    case_name: Optional[str] = field(default=None, init=False)
-    user_name: Optional[str] = field(default=None, init=False)
-    ert2: dict = field(default_factory=dict, init=False)
-    case_metafile: Optional[Path] = field(default=None, init=False)
-    case_metadata: dict = field(default_factory=dict, init=False)
-    metadata: dict = field(default_factory=dict, init=False)
-    rootpath: Optional[Path] = field(default=None, init=False)
+    model: str = ""
+    fmu_context: FmuContext = FmuContext.REALIZATION
+    include_ertjobs: bool = True
+    casepath_proposed: str | Path = ""
+    forced_realization: Optional[int] = None
+    workflow: str | dict = ""
+
+    # private properties for this class
+    _stage: str = field(default="unset", init=False)
+    _runpath: Path | str = field(default="", init=False)
+    _casepath: Path | str = field(default="", init=False)  # actual casepath
+    _provider: str = field(default="", init=False)
+    _iter_name: str = field(default="", init=False)
+    _iter_id: int = field(default=0, init=False)
+    _iter_path: Path | str = field(default="", init=False)
+    _real_name: str = field(default="", init=False)
+    _real_id: int = field(default=0, init=False)
+    _real_path: Path | str = field(default="", init=False)
+    _case_name: str = field(default="", init=False)
+    _user_name: str = field(default="", init=False)
+    _ert_info: dict = field(default_factory=dict, init=False)
+    _case_metadata: dict = field(default_factory=dict, init=False)
+    _metadata: dict = field(default_factory=dict, init=False)
 
     def __post_init__(self) -> None:
-        self.rootpath = Path(self.dataio._rootpath.absolute())
+        logger.info("Initialize %s...", self.__class__)
+        logger.debug("Case path is initially <%s>...", self.casepath_proposed)
+        logger.debug("FMU context is <%s>...", self.fmu_context)
 
-        self.rootpath_initial = self.rootpath
+        if not FmuEnv.ENSEMBLE_ID.value:
+            return  # not an FMU run
 
-        logger.info("Initialize %s", self.__class__)
+        self._provider = "ERT"
 
-    def detect_provider(self) -> None:
-        """First order method to detect provider, ans also check fmu_context."""
-        if self._detect_ert2provider() or self._detect_ert2provider_case_only():
-            self.provider = "ERT2"
-            self.get_ert2_information()
-            self.get_ert2_case_metadata()
-            self.generate_ert2_metadata()
+        self._detect_fmurun_stage()
+        self._detect_absolute_runpath()
+        self._detect_and_update_casepath()
+        self._parse_folder_info()
+        self._read_case_metadata()
+
+        # the next ones will not be read if case metadata is empty, or stage is FMU CASE
+        self._read_optional_restart_data()
+        self._read_ert_information()
+        self._generate_ert_metadata()
+
+    def get_iter_name(self) -> str:
+        """The client (metadata) will ask for iter_name"""
+        """Return the iter_name, e.g. 'iter-3' or 'pred'."""
+        return self._iter_name
+
+    def get_real_name(self) -> str:
+        """Return the real_name, e.g. 'realization-23'."""
+        return self._real_name
+
+    def get_casepath(self) -> str:
+        """Return updated casepath in a FMU run, will be updated if initially blank."""
+        return "" if not self._casepath else str(self._casepath)
+
+    def get_provider(self) -> str | None:
+        """Return the name of the FMU provider (so far 'ERT' only), or None."""
+        return None if not self._provider else self._provider
+
+    def get_metadata(self) -> dict:
+        """The client (metadata) will ask for complete metadata for FMU section"""
+        return {} if not self._metadata else self._metadata
+
+    # private methods:
+    @staticmethod
+    def _get_folderlist_from_path(current: Path | str) -> list:
+        """Return a list of pure folder names incl. current casepath up to system root.
+
+        For example: current is /scratch/xfield/nn/case/realization-33/iter-1
+        shall return ['scratch', 'xfield', 'nn', 'case', 'realization-33', 'iter-1']
+        """
+        return [folder for folder in str(current).split("/") if folder]
+
+    @staticmethod
+    def _get_folderlist_from_runpath_env() -> list:
+        """Return a list of pure folder names incl. current from RUNPATH environment,
+
+        Derived from _ERT_RUNPATH.
+
+        For example: runpath is /scratch/xfield/nn/case/realization-33/iter-1/
+        shall return ['scratch', 'xfield', 'nn', 'case', 'realization-33', 'iter-1']
+        """
+        runpath = FmuEnv.RUNPATH.value
+        if runpath:
+            return [folder for folder in runpath.split("/") if folder]
+        return []
+
+    def _detect_fmurun_stage(self) -> None:
+        """Detect if ERT is in a PRE-HOOK or in a FORWARD MODEL stage
+
+        Update self._stage = "case" | "forward" | "unset"
+        """
+        if FmuEnv.EXPERIMENT_ID.value and not FmuEnv.RUNPATH.value:
+            self._stage = "case"
+        elif FmuEnv.EXPERIMENT_ID.value and FmuEnv.RUNPATH.value:
+            self._stage = "realization"
         else:
-            logger.info("Detecting FMU provider as None")
-            self.provider = None  # e.g. an interactive RMS run
-            self.dataio._usecontext = None  # e.g. an interactive RMS run
-            if self.dataio.fmu_context == "preprocessed":
-                self.dataio._usecontext = self.dataio.fmu_context
-            if self.dataio.fmu_context != self.dataio._usecontext:
-                logger.warning(
-                    "Requested fmu_context is <%s> but since this is detected as a non "
-                    "FMU run, the actual context is set to <%s>",
-                    self.dataio.fmu_context,
-                    self.dataio._usecontext,
-                )
+            self._stage = "unset"
+        logger.debug("Detecting FMU stage as %s", self._stage)
 
-    def _detect_ert2provider(self) -> bool:
-        """Detect if ERT2 is provider and set itername, casename, etc.
+    def _detect_absolute_runpath(self) -> None:
+        """In case _ERT_RUNPATH is relative, an absolute runpath is detected."""
+        if FmuEnv.RUNPATH.value:
+            self._runpath = Path(FmuEnv.RUNPATH.value).resolve()
 
-        This is the pattern in a forward model, where realization etc exists.
+    def _detect_and_update_casepath(self) -> None:
+        """If casepath is not given, then try update _casepath (if in realization).
+
+        There is also a validation here that casepath contains case metadata, and if not
+        then a second guess  is attempted, looking at `parent` insted of `parent.parent`
+        is case of unconventional structure.
         """
-        logger.info("Try to detect ERT2 provider")
+        logger.debug("Try detect casepath, RUNPATH is %s", self._runpath)
+        logger.debug("Proposed casepath is now <%s>", self.casepath_proposed)
 
-        folders = _get_folderlist(self.rootpath_initial)
-        logger.info("Folders to evaluate: %s", folders)
+        self._casepath = Path(self.casepath_proposed) if self.casepath_proposed else ""
+        if self._stage == "case" and self._casepath:
+            try_casepath = Path(self._casepath)
+            logger.debug("Try casepath (stage is case): %s", try_casepath)
 
-        for num, folder in enumerate(folders):
-            if folder and re.match("^realization-.", folder):
-                self.is_fmurun = True
-                realfolder = folders[num]
-                iterfolder = folders[num + 1]
-                casefolder = folders[num - 1]
-                userfolder = folders[num - 2]
+        elif not self._casepath:
+            try_casepath = Path(self._runpath).parent.parent
+            logger.debug("Try casepath (first attempt): %s", try_casepath)
 
-                case_path = Path("/".join(folders[0:num]))
+            if not (try_casepath / ERT_RELATIVE_CASE_METADATA_FILE).exists():
+                logger.debug("Cannot find metadata file, try just one parent...")
+                try_casepath = Path(self._runpath).parent
+                logger.debug("Try casepath (second attempt): %s", try_casepath)
+            self._casepath = try_casepath
 
-                # override:
-                if self.dataio.casepath:
-                    case_path = Path(self.dataio.casepath)
+        if not (Path(self._casepath) / ERT_RELATIVE_CASE_METADATA_FILE).exists():
+            logger.debug("No case metadata, issue a warning!")
+            warn(
+                "Case metadata does not exist; will not update initial casepath",
+                UserWarning,
+            )
+            self._casepath = ""
 
-                self.case_name = casefolder
-                self.user_name = userfolder
+    def _parse_folder_info(self) -> None:
+        """Retreive the folders (id's and paths)."""
+        logger.debug("Parse folder info...")
 
-                # store findings
-                self.iter_name = iterfolder  # name of the folder
+        folders = self._get_folderlist_from_runpath_env()
+        if self.fmu_context == FmuContext.CASE and self._casepath:
+            folders = self._get_folderlist_from_path(self._casepath)  # override
+            logger.debug("Folders to evaluate (case): %s", folders)
 
-                # also derive the realization_id (realization number) from the folder
-                self.real_id = int(realfolder.replace("realization-", ""))
-                self.real_name = realfolder  # name of the realization folder
+            self._iter_path = ""
+            self._real_path = ""
+            self._case_name = folders[-1]
+            self._user_name = folders[-2]
 
-                # override realization if input key 'realization' is >= 0; only in rare
-                # cases
-                if self.dataio.realization and self.dataio.realization >= 0:
-                    self.real_id = self.dataio.realization
-                    self.real_name = "realization-" + str(self.real_id)
+            logger.debug(
+                "case_name, user_name: %s %s", self._case_name, self._user_name
+            )
+            logger.debug("Detecting FMU provider as ERT (case only)")
+        else:
+            logger.debug("Folders to evaluate (realization): %s", folders)
 
-                # also derive iteration_id from the folder
-                if "iter-" in str(iterfolder):
-                    self.iter_id = int(iterfolder.replace("iter-", ""))
-                elif isinstance(iterfolder, str):
-                    # any custom name of the iteration, like "pred"
-                    self.iter_id = None
-                else:
-                    raise ValueError("Could not derive iteration ID")
+            self._case_name = folders[-3]
+            self._user_name = folders[-4]
 
-                self.iter_path = pathlib.Path(case_path / realfolder / iterfolder)
-                self.real_path = pathlib.Path(case_path / realfolder)
-                self.rootpath = case_path
+            self._iter_name = folders[-1]
+            self._real_name = folders[-2]
 
-                logger.info("Initial rootpath: %s", self.rootpath_initial)
-                logger.info("Updated rootpath: %s", self.rootpath)
+            self._iter_path = Path("/" + "/".join(folders))
+            self._real_path = Path("/" + "/".join(folders[:-1]))
 
-                logger.info("Detecting FMU provider as ERT2")
-                return True
+            self._iter_id = int(str(FmuEnv.ITERATION_NUMBER.value))
+            self._real_id = int(str(FmuEnv.REALIZATION_NUMBER.value))
 
-        return False
+    def _read_case_metadata(self) -> None:
+        """Check if metadatafile file for CASE exists, and if so parse metadata.
 
-    def _detect_ert2provider_case_only(self) -> bool:
-        """Detect ERT2 as provider when fmu_context is case'ish and casepath is given.
-
-        This is typically found in ERT prehook work flows where case is establed by
-        fmu.dataio.InitialiseCase() but no iter and realization folders exist. So
-        only case-metadata are revelant here.
+        If file does not exist, still give a proposed file path, but the
+        self.casepath_proposed_metadata will be {} (empty) and the physical file
+        will not be made.
         """
-        logger.info("Try to detect ERT2 provider (case context)")
+        logger.debug("Read case metadata, if any...")
+        if not self._casepath:
+            logger.info("No case path detected, hence FMU metadata will be empty.")
+            return
 
-        if (
-            self.dataio.fmu_context
-            and "case" in self.dataio.fmu_context
-            and self.dataio.casepath
-        ):
-            self.rootpath = Path(self.dataio.casepath)
+        case_metafile = Path(self._casepath) / ERT_RELATIVE_CASE_METADATA_FILE
+        if case_metafile.exists():
+            logger.debug("Case metadata file exists in file %s", str(case_metafile))
+            self._case_metadata = ut.yaml_load(case_metafile, loader="standard")
+            logger.debug("Case metadata are: %s", self._case_metadata)
+        else:
+            logger.debug("Case metadata file does not exists as %s", str(case_metafile))
+            warn(
+                "Cannot read case metadata, hence stop retrieving FMU data!",
+                UserWarning,
+            )
+            self._case_metadata = {}
 
-            folders = _get_folderlist(self.rootpath)
-            logger.info("Folders to evaluate (case): %s", folders)
+    def _read_optional_restart_data(self) -> None:
+        # Load restart_from information
+        logger.debug("Read optional restart data, if any, and requested...")
+        if not self._case_metadata:
+            return
 
-            self.iter_path = None
-            self.real_path = None
-            self.case_name = folders[-1]
-            self.user_name = folders[-2]
+        if not environ.get(RESTART_PATH_ENVNAME):
+            return
 
-            logger.info("Initial rootpath: %s", self.rootpath_initial)
-            logger.info("Updated rootpath: %s", self.rootpath)
-            logger.info("case_name, user_name: %s %s", self.case_name, self.user_name)
+        logger.debug("Detected a restart run from environment variable")
+        restart_path = Path(self._iter_path) / environ[RESTART_PATH_ENVNAME]
+        restart_iter = self._get_folderlist_from_path(restart_path)[-1]
+        restart_case_metafile = (
+            restart_path / "../.." / ERT_RELATIVE_CASE_METADATA_FILE
+        ).resolve()
+        if restart_case_metafile.exists():
+            restart_metadata = ut.yaml_load(restart_case_metafile, loader="standard")
+            self._ert_info["restart_from"] = _utils.uuid_from_string(
+                restart_metadata["fmu"]["case"]["uuid"] + restart_iter
+            )
+        else:
+            print(
+                f"{RESTART_PATH_ENVNAME} environment variable is set to "
+                f"{environ[RESTART_PATH_ENVNAME]} which is invalid. Metadata "
+                "restart_from will remain empty."
+            )
+            logger.warning(
+                f"{RESTART_PATH_ENVNAME} environment variable is set to "
+                f"{environ[RESTART_PATH_ENVNAME]} which is invalid. Metadata "
+                "restart_from will remain empty."
+            )
 
-            logger.info("Detecting FMU provider as ERT2 (case only)")
-            return True
-        return False
+    def _read_ert_information(self) -> None:
+        """Retrieve information from an ERT (ver 5 and later) run."""
+        logger.debug("Read ERT information, if any")
 
-    def get_ert2_information(self) -> None:
-        """Retrieve information from an ERT2 run."""
-        if not self.iter_path:
+        if not self._case_metadata:
+            return
+
+        logger.debug("Read ERT information")
+        if not self._iter_path:
+            logger.debug("Not _iter_path!")
             return
 
         # store parameters.txt
-        parameters_file = self.iter_path / "parameters.txt"
+        logger.debug("Read ERT information, if any (continues)")
+        parameters_file = Path(self._iter_path) / "parameters.txt"
         if parameters_file.is_file():
             params = _utils.read_parameters_txt(parameters_file)
             # BUG(?): value can contain Nones, loop in fn. below
             # does contains check, will fail.
             nested_params = _utils.nested_parameters_dict(params)  # type: ignore
-            self.ert2["params"] = nested_params
+            self._ert_info["params"] = nested_params
             logger.debug("parameters.txt parsed.")
         else:
-            self.ert2["params"] = None
-            logger.debug("parameters.txt was not found")
-
-        # Load restart_from information
-        if RESTART_PATH_ENVNAME in environ:
-            logger.info("Detected a restart run from environment variable")
-            restart_path = self.iter_path / environ[RESTART_PATH_ENVNAME]
-            restart_iter = _get_folderlist(restart_path)[-1]
-            restart_case_metafile = (
-                restart_path / "../.." / ERT2_RELATIVE_CASE_METADATA_FILE
-            ).resolve()
-            if restart_case_metafile.exists():
-                restart_metadata = ut.yaml_load(
-                    restart_case_metafile, loader="standard"
-                )
-                self.ert2["restart_from"] = _utils.uuid_from_string(
-                    restart_metadata["fmu"]["case"]["uuid"] + restart_iter
-                )
-            else:
-                print(
-                    f"{RESTART_PATH_ENVNAME} environment variable is set to "
-                    "{environ[RESTART_PATH_ENVNAME]} which is invalid. Metadata "
-                    "restart_from will remain empty."
-                )
-                logger.warning(
-                    f"{RESTART_PATH_ENVNAME} environment variable is set to "
-                    "{environ[RESTART_PATH_ENVNAME]} which is invalid. Metadata "
-                    "restart_from will remain empty."
-                )
+            self._ert_info["params"] = {}
+            warn("The parameters.txt file was not found", UserWarning)
 
         # store jobs.json if required!
-        if self.dataio.include_ert2jobs:
-            jobs_file = self.iter_path / "jobs.json"
+        if self.include_ertjobs:
+            jobs_file = Path(self._iter_path) / "jobs.json"
             if jobs_file.is_file():
                 with open(jobs_file) as stream:
-                    self.ert2["jobs"] = json.load(stream)
+                    self._ert_info["jobs"] = json.load(stream)
                 logger.debug("jobs.json parsed.")
-            logger.debug("jobs.json was not found")
+            else:
+                logger.debug("jobs.json was not found")
         else:
-            self.ert2["jobs"] = None
-            logger.info("Storing jobs.json is disabled")
+            self._ert_info["jobs"] = None
+            logger.debug("Storing jobs.json is disabled")
 
         logger.debug("ERT files has been parsed.")
 
-    def get_ert2_case_metadata(self) -> None:
-        """Check if metadatafile file for CASE exists, and if so parse metadata.
+    def _generate_ert_metadata(self) -> None:
+        """Construct the metadata FMU block for an ERT forward job."""
+        if not self._case_metadata:
+            return
 
-        If file does not exist, still give a proposed file path, but the
-        self.case_metadata will be {} (empty) and the physical file will not be made.
-        """
-
-        assert self.rootpath is not None
-        self.case_metafile = self.rootpath / ERT2_RELATIVE_CASE_METADATA_FILE
-        self.case_metafile = self.case_metafile.resolve()
-        if self.case_metafile.exists():
-            logger.info("Case metadata file exists at %s", str(self.case_metafile))
-            self.case_metadata = ut.yaml_load(self.case_metafile, loader="standard")
-            logger.info("Case metadata are now read!")
-        else:
-            logger.info(
-                "Case metadata file does not exists as %s", str(self.case_metafile)
-            )
-
-    def generate_ert2_metadata(self) -> None:
-        """Construct the metadata FMU block for an ERT2 forward job."""
-        logger.info("Generate ERT2 metadata...")
-
-        if not self.case_metadata:
-            logger.info("Trigger UserWarning!")
+        logger.debug("Generate ERT metadata...")
+        if not self._case_metadata:
+            logger.debug("Trigger UserWarning!")
             warn(
-                f"The fmu provider: {self.provider} is found but no case metadata!",
+                f"The fmu provider: {self._provider} is found but no case metadata!",
                 UserWarning,
             )
 
-        meta = self.metadata  # shortform
+        meta = self._metadata  # shortform
 
-        meta["model"] = self.dataio.config.get("model", None)
+        meta["model"] = self.model
 
-        meta["context"] = {"stage": self.dataio._usecontext}
+        meta["context"] = {"stage": self.fmu_context.name.lower()}
 
-        if self.dataio.workflow:
-            if isinstance(self.dataio.workflow, str):
-                meta["workflow"] = {"reference": self.dataio.workflow}
-            elif isinstance(self.dataio.workflow, dict):
-                if "reference" not in self.dataio.workflow:
+        if self.workflow:
+            if isinstance(self.workflow, str):
+                meta["workflow"] = {"reference": self.workflow}
+            elif isinstance(self.workflow, dict):
+                if "reference" not in self.workflow:
                     raise ValueError(
                         "When workflow is given as a dict, the 'reference' "
                         "key must be included and be a string"
@@ -297,39 +389,41 @@ class _FmuProvider:
                     PendingDeprecationWarning,
                 )
 
-                meta["workflow"] = {"reference": self.dataio.workflow["reference"]}
+                meta["workflow"] = {"reference": self.workflow["reference"]}
 
             else:
                 raise TypeError("'workflow' should be string.")
 
         case_uuid = "not_present"  # TODO! not allow missing case metadata?
-        if self.case_metadata and "fmu" in self.case_metadata:
-            meta["case"] = deepcopy(self.case_metadata["fmu"]["case"])
+        if self._case_metadata and "fmu" in self._case_metadata:
+            meta["case"] = deepcopy(self._case_metadata["fmu"]["case"])
             case_uuid = meta["case"]["uuid"]
 
-        if "realization" in self.dataio._usecontext:
-            iter_uuid = _utils.uuid_from_string(case_uuid + str(self.iter_name))
+        if self.fmu_context == FmuContext.REALIZATION:
+            iter_uuid = _utils.uuid_from_string(case_uuid + str(self._iter_name))
             meta["iteration"] = {
-                "id": self.iter_id,
+                "id": self._iter_id,
                 "uuid": iter_uuid,
-                "name": self.iter_name,
+                "name": self._iter_name,
                 **(
-                    {"restart_from": self.ert2["restart_from"]}
-                    if "restart_from" in self.ert2
+                    {"restart_from": self._ert_info["restart_from"]}
+                    if "restart_from" in self._ert_info
                     else {}
                 ),
             }
             real_uuid = _utils.uuid_from_string(
-                case_uuid + str(iter_uuid) + str(self.real_id)
+                case_uuid + str(iter_uuid) + str(self._real_id)
             )
 
-            logger.info(
-                "Generate ERT2 metadata continues, and real ID %s", self.real_id
+            logger.debug(
+                "Generate ERT metadata continues, and real ID %s", self._real_id
             )
 
             mreal = meta["realization"] = {}
-            mreal["id"] = self.real_id
+            mreal["id"] = self._real_id
             mreal["uuid"] = real_uuid
-            mreal["name"] = self.real_name
-            mreal["parameters"] = self.ert2["params"]
-            mreal["jobs"] = self.ert2["jobs"]
+            mreal["name"] = self._real_name
+            mreal["parameters"] = self._ert_info["params"]
+
+            if self.include_ertjobs:
+                mreal["jobs"] = self._ert_info["jobs"]

--- a/src/fmu/dataio/_utils.py
+++ b/src/fmu/dataio/_utils.py
@@ -145,8 +145,8 @@ def export_file(
 
         if isinstance(obj, Table):
             from pyarrow import feather
-            # comment taken from equinor/webviz_subsurface/smry2arrow.py
 
+            # comment taken from equinor/webviz_subsurface/smry2arrow.py
             # Writing here is done through the feather import, but could also be
             # done using pa.RecordBatchFileWriter.write_table() with a few
             # pa.ipc.IpcWriteOptions(). It is convenient to use feather since it
@@ -400,7 +400,7 @@ def generate_description(desc: str | list | None = None) -> list | None:
     raise ValueError("Description of wrong type, must be list of strings or string")
 
 
-def read_metadata(filename: str | Path) -> dict:
+def read_metadata_from_file(filename: str | Path) -> dict:
     """Read the metadata as a dictionary given a filename.
 
     If the filename is e.g. /some/path/mymap.gri, the assosiated metafile

--- a/tests/test_units/test_dictionary.py
+++ b/tests/test_units/test_dictionary.py
@@ -36,7 +36,7 @@ def _fixture_json(fmurun_w_casemetadata):
         return json.load(stream)
 
 
-@pytest.fixture(name="simple_parameters", scope="session")
+@pytest.fixture(name="simple_parameters", scope="function")
 def _fixture_simple_parameters(fmurun_w_casemetadata):
     """Return dictionary read from parameters.txt
 

--- a/tests/test_units/test_enum_classes.py
+++ b/tests/test_units/test_enum_classes.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import pytest
+from fmu.dataio._definitions import FmuContext
+
+
+def test_fmu_context_validation() -> None:
+    """Test the FmuContext enum class."""
+    rel = FmuContext.get("realization")
+    assert rel.name == "REALIZATION"
+
+    with pytest.raises(KeyError, match="Invalid key"):
+        FmuContext.get("invalid_context")
+
+    valid_types = FmuContext.list_valid()
+    assert list(valid_types.keys()) == [
+        "REALIZATION",
+        "CASE",
+        "CASE_SYMLINK_REALIZATION",
+        "PREPROCESSED",
+        "NON_FMU",
+    ]

--- a/tests/test_units/test_ert_context.py
+++ b/tests/test_units/test_ert_context.py
@@ -1,7 +1,9 @@
-"""Test the dataio running from ERT2 aka forward model as pretended context.
+"""Test the dataio running from ERT aka forward model as pretended context.
 
 In this case a user sits in ERT. Hence the rootpath will be ./
 """
+from __future__ import annotations
+
 import logging
 import os
 import sys
@@ -15,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 def test_regsurf_generate_metadata(fmurun_w_casemetadata, rmsglobalconfig, regsurf):
-    """Test generating metadata for a surface pretend ERT2 job"""
+    """Test generating metadata for a surface pretend ERT job"""
     logger.info("Active folder is %s", fmurun_w_casemetadata)
     os.chdir(fmurun_w_casemetadata)
 
@@ -37,7 +39,7 @@ def test_regsurf_generate_metadata_incl_jobs(
     logger.info("Active folder is %s", fmurun_w_casemetadata)
     os.chdir(fmurun_w_casemetadata)
 
-    dataio.ExportData.include_ert2jobs = True
+    dataio.ExportData.include_ertjobs = True
 
     edata = dataio.ExportData(
         config=rmsglobalconfig,
@@ -47,7 +49,7 @@ def test_regsurf_generate_metadata_incl_jobs(
     meta = edata.generate_metadata(regsurf)
     assert meta["fmu"]["realization"]["jobs"]["umask"] == "0002"
 
-    dataio.ExportData.include_ert2jobs = False
+    dataio.ExportData.include_ertjobs = False
 
 
 def test_regsurf_metadata_with_timedata(

--- a/tests/test_units/test_fmuprovider_class.py
+++ b/tests/test_units/test_fmuprovider_class.py
@@ -1,101 +1,130 @@
-"""Test the _MetaData class from the _metadata.py module"""
+"""Test the FmuProvider class applied the _metadata.py module"""
+import logging
 import os
+from pathlib import Path
 
-import fmu.dataio as dio
+import fmu.dataio as dataio
 import pytest
-from fmu.dataio._fmu_provider import RESTART_PATH_ENVNAME, _FmuProvider, _get_folderlist
 
-FOLDERTREE = "scratch/myfield/case/realization-13/iter-2"
+# from conftest import pretend_ert_env_run1
+from fmu.dataio._definitions import FmuContext
+from fmu.dataio._fmu_provider import RESTART_PATH_ENVNAME, FmuEnv, FmuProvider
 
+logger = logging.getLogger(__name__)
 
-def test_get_folderlist(fmurun):
-    os.chdir(fmurun)
-    mylist = _get_folderlist(fmurun)
-    assert mylist[-1] == "iter-0"
-    assert mylist[-3] == "ertrun1"
+FOLDERTREE = "/scratch/myfield/case/realization-13/iter-2/"
 
 
-def test_fmuprovider_no_provider(testroot, globalconfig1):
-    """Testing the FmuProvider basics where no ERT context is found from folder tree."""
-    os.chdir(testroot)
+def test_get_folderlist_from_path():
+    """Test static method on getting folders from a path"""
+    ftree = Path(FOLDERTREE)
+    mylist = FmuProvider._get_folderlist_from_path(ftree)
+    assert mylist[-1] == "iter-2"
+    assert mylist[-3] == "case"
+    assert mylist[0] == "scratch"
 
-    ex = dio.ExportData(
-        fmu_context="realization", config=globalconfig1, content="depth"
+
+def test_get_folderlist_from_ert_runpath(monkeypatch):
+    """Test static method on getting folders from a _ERT_RUNPATH env variable"""
+    logger.debug("Set ENV for RUNPATH as %s", FmuEnv.RUNPATH.keyname)
+    monkeypatch.setenv(FmuEnv.RUNPATH.keyname, FOLDERTREE)
+    mylist = FmuProvider._get_folderlist_from_runpath_env()
+    assert mylist[-1] == "iter-2"
+    assert mylist[-3] == "case"
+
+
+def test_fmuprovider_no_provider():
+    """Testing the FmuProvider where no ERT context is found from env variables."""
+
+    myfmu = FmuProvider(
+        model="Model2",
+        fmu_context=FmuContext.REALIZATION,
+        casepath_proposed="",
+        include_ertjobs=False,
+        forced_realization=None,
+        workflow="some work flow",
     )
-    myfmu = _FmuProvider(ex)
-    myfmu.detect_provider()
-
-    assert myfmu.is_fmurun is False
-    assert myfmu.case_name is None
+    assert myfmu.get_provider() is None
 
 
-def test_fmuprovider_ert2_provider(fmurun, globalconfig1):
-    """Testing the FmuProvider for an ERT2 case; case metadata are missing here"""
+def test_fmuprovider_ert_provider_guess_casemeta_path(fmurun):
+    """The casepath input is empty, but try guess from ERT RUNPATH without success.
+
+    Since there are mot metadata here, this will issue a warning
+    """
     os.chdir(fmurun)
+    with pytest.warns(UserWarning, match="Case metadata does not exist"):
+        myfmu = FmuProvider(
+            model="Model2",
+            fmu_context=FmuContext.REALIZATION,
+            casepath_proposed="",  # if casepath is undef, try deduce from, _ERT_RUNPATH
+            include_ertjobs=False,
+            forced_realization=None,
+            workflow="some work flow",
+        )
 
-    ex = dio.ExportData(
-        fmu_context="realization", config=globalconfig1, content="depth"
-    )
-    ex._rootpath = fmurun
-
-    myfmu = _FmuProvider(ex)
-    with pytest.warns(UserWarning, match="ERT2 is found but no case metadata"):
-        # since case name is missing
-        myfmu.detect_provider()
-    assert myfmu.case_name == "ertrun1"
-    assert myfmu.real_name == "realization-0"
-    assert myfmu.real_id == 0
-
-
-def test_fmuprovider_ert2_provider_missing_parameter_txt(fmurun, globalconfig1):
-    """Test for an ERT2 case, when missing file parameter.txt (e.g. pred. run)"""
-
-    os.chdir(fmurun)
-    (fmurun / "parameters.txt").unlink()
-
-    ex = dio.ExportData(
-        fmu_context="realization", content="depth", config=globalconfig1
-    )
-    ex._rootpath = fmurun
-
-    myfmu = _FmuProvider(ex)
-    with pytest.warns(UserWarning, match="ERT2 is found but no case metadata"):
-        myfmu.detect_provider()
-    assert myfmu.case_name == "ertrun1"
-    assert myfmu.real_name == "realization-0"
-    assert myfmu.real_id == 0
+    assert myfmu.get_provider() == "ERT"
+    assert myfmu._stage == "realization"  # i.e. being a so-called forward model
+    assert not myfmu.get_metadata()
+    assert myfmu.get_casepath() == ""
 
 
-def test_fmuprovider_arbitrary_iter_name(edataobj1, fmurun_w_casemetadata_pred):
-    """Test that iteration block correctly populated also with arbitrary iteration
-    names."""
+def test_fmuprovider_ert_provider_missing_parameter_txt(
+    fmurun_w_casemetadata, globalconfig1
+):
+    """Test for an ERT case, when missing file parameter.txt (e.g. pred. run)"""
 
-    edataobj1._rootpath = fmurun_w_casemetadata_pred
+    os.chdir(fmurun_w_casemetadata)
+
+    # delete the file for this test
+    (fmurun_w_casemetadata / "parameters.txt").unlink()
+
+    with pytest.warns(UserWarning, match="parameters.txt file was not found"):
+        myfmu = FmuProvider(
+            model="Model2",
+            fmu_context=FmuContext.REALIZATION,
+            include_ertjobs=True,
+            workflow="some work flow",
+        )
+    assert myfmu._case_name == "ertrun1"
+    assert myfmu._real_name == "realization-0"
+    assert myfmu._real_id == 0
+
+
+def test_fmuprovider_arbitrary_iter_name(fmurun_w_casemetadata_pred):
+    """Test iteration block is correctly set, also with arbitrary iteration names."""
+
     os.chdir(fmurun_w_casemetadata_pred)
-    myfmu = _FmuProvider(edataobj1)
-    myfmu.detect_provider()
-    assert myfmu.case_name == "ertrun1"
-    assert myfmu.real_name == "realization-0"
-    assert myfmu.real_id == 0
-    assert myfmu.iter_name == "pred"
-    assert myfmu.iter_id is None
-    assert "fmu_case" in str(myfmu.case_metafile)
+    myfmu = FmuProvider(
+        model="Model2",
+        fmu_context=FmuContext.REALIZATION,
+        include_ertjobs=True,
+        workflow="some work flow",
+    )
+    assert myfmu._case_name == "ertrun1"
+    assert myfmu._real_name == "realization-0"
+    assert myfmu._real_id == 0
+    assert myfmu._iter_name == "pred"
+    assert not myfmu._iter_id
     assert (
-        myfmu.case_metadata["fmu"]["case"]["uuid"]
+        myfmu._case_metadata["fmu"]["case"]["uuid"]
         == "a40b05e8-e47f-47b1-8fee-f52a5116bd37"
     )
 
 
-def test_fmuprovider_prehook_case(globalconfig2, tmp_path):
-    """The fmu run case metadata is initialized with Initialize case; then fet provider.
+def test_fmuprovider_prehook_case(tmp_path, globalconfig2, fmurun_prehook):
+    """The fmu run case metadata is initialized with Initialize case; then get provider.
 
-    A typical prehook section in a ERT2 run is to establish case metadata, and then
-    subsequent hook workflows should still recognize this as an ERT2 run, altough
+    A typical prehook section in a ERT run is to establish case metadata, and then
+    subsequent hook workflows should still recognize this as an ERT run, altough
     no iter and realization folders exists. This requires fmu_contact=case* and that
-    key casepath is given explicitly!.
+    key casepath_proposed is given explicitly!.
+
+    I *may* be that this behaviour can be removed in near future, since the ERT env
+    variables now will tell us that this is an active ERT run.
     """
 
-    icase = dio.InitializeCase(config=globalconfig2)
+    icase = dataio.InitializeCase(config=globalconfig2)
 
     caseroot = tmp_path / "prehook"
     caseroot.mkdir(parents=True)
@@ -111,120 +140,96 @@ def test_fmuprovider_prehook_case(globalconfig2, tmp_path):
     casemetafile = caseroot / "share/metadata/fmu_case.yml"
     assert casemetafile.is_file()
     assert exp == str(casemetafile.resolve())
+    os.chdir(fmurun_prehook)
 
-    eobj = dio.ExportData(
-        config=globalconfig2,
-        name="TopWhatever",
-        content="depth",
-        tagname="mytag",
-        is_observation=True,
-        fmu_context="case",
-        casepath=caseroot,
+    logger.debug("Case root proposed is: %s", caseroot)
+    myfmu = FmuProvider(
+        model="Model567",
+        fmu_context=FmuContext.CASE,
+        include_ertjobs=False,
+        workflow="some work flow",
+        casepath_proposed=caseroot,
     )
 
-    myfmu = _FmuProvider(eobj)
-    myfmu.detect_provider()
-    assert myfmu.case_name == "prehook"
-    assert myfmu.real_name is None
+    assert myfmu._case_name == "prehook"
+    assert myfmu._real_name == ""
 
 
-def test_fmuprovider_detect_no_case_metadata(fmurun, edataobj1):
+def test_fmuprovider_detect_no_case_metadata(fmurun):
     """Testing the case metadata file which is not found here.
 
     That will still provide a file path but the metadata will be {} i.e. empty
     """
     os.chdir(fmurun)
-    edataobj1._rootpath = fmurun
 
-    myfmu = _FmuProvider(edataobj1)
-    with pytest.warns(UserWarning, match="ERT2 is found but no case metadata"):
-        myfmu.detect_provider()
-    assert myfmu.case_name == "ertrun1"
-    assert myfmu.real_name == "realization-0"
-    assert myfmu.real_id == 0
-    assert "fmu_case" in str(myfmu.case_metafile)
-    assert not myfmu.case_metadata
+    with pytest.warns(UserWarning):
+        myfmu = FmuProvider(
+            model="Model567",
+            fmu_context=FmuContext.REALIZATION,
+        )
+    assert myfmu._case_name == "ertrun1"
+    assert myfmu._real_name == "realization-0"
+    assert myfmu._real_id == 0
+    assert not myfmu._case_metadata
 
 
-def test_fmuprovider_valid_restart_env(fmurun_w_casemetadata, fmurun_pred, edataobj1):
+def test_fmuprovider_valid_restart_env(monkeypatch, fmurun_w_casemetadata, fmurun_pred):
     """Testing the scenario given a valid RESTART_FROM_PATH environment variable
 
-    This will give the correct restart_from uuid
+    This shall give the correct restart_from uuid
     """
-
-    edataobj1._rootpath = fmurun_w_casemetadata
     os.chdir(fmurun_w_casemetadata)
-    fmu_restart_from = _FmuProvider(edataobj1)
-    fmu_restart_from.detect_provider()
+    fmu_restart_from = FmuProvider(
+        model="Model with restart", fmu_context=FmuContext.REALIZATION
+    )
 
-    os.environ[RESTART_PATH_ENVNAME] = str(fmurun_w_casemetadata)
-    edataobj1._rootpath = fmurun_pred
+    monkeypatch.setenv(RESTART_PATH_ENVNAME, str(fmurun_w_casemetadata))
+
     os.chdir(fmurun_pred)
-    fmu_restart = _FmuProvider(edataobj1)
-    with pytest.warns(UserWarning, match="ERT2 is found but no case metadata"):
-        fmu_restart.detect_provider()
+    fmu_restart = FmuProvider(model="Modelrun", fmu_context=FmuContext.REALIZATION)
+
     assert (
-        fmu_restart.metadata["iteration"]["restart_from"]
-        == fmu_restart_from.metadata["iteration"]["uuid"]
+        fmu_restart._metadata["iteration"]["restart_from"]
+        == fmu_restart_from._metadata["iteration"]["uuid"]
     )
 
 
-def test_fmuprovider_invalid_restart_env(fmurun_w_casemetadata, fmurun_pred, edataobj1):
+def test_fmuprovider_invalid_restart_env(
+    monkeypatch, fmurun_w_casemetadata, fmurun_pred
+):
     """Testing the scenario given invalid RESTART_FROM_PATH environment variable
 
     The iteration metadata will not contain restart_from key
     """
-
-    edataobj1._rootpath = fmurun_w_casemetadata
     os.chdir(fmurun_w_casemetadata)
-    fmu_restart_from = _FmuProvider(edataobj1)
-    fmu_restart_from.detect_provider()
 
-    os.environ[RESTART_PATH_ENVNAME] = "/path/to/somewhere/invalid"
-    edataobj1._rootpath = fmurun_pred
+    _ = FmuProvider(model="Model with restart", fmu_context=FmuContext.REALIZATION)
+
+    monkeypatch.setenv(RESTART_PATH_ENVNAME, "/path/to/somewhere/invalid")
+
     os.chdir(fmurun_pred)
-    fmu_restart = _FmuProvider(edataobj1)
-    with pytest.warns(UserWarning, match="ERT2 is found but no case metadata"):
-        fmu_restart.detect_provider()
-    assert "restart_from" not in fmu_restart.metadata["iteration"]
+    fmu_restart = FmuProvider(model="Modelrun", fmu_context=FmuContext.REALIZATION)
+    assert "restart_from" not in fmu_restart._metadata["iteration"]
 
 
-def test_fmuprovider_no_restart_env(fmurun_w_casemetadata, fmurun_pred, edataobj1):
+def test_fmuprovider_no_restart_env(monkeypatch, fmurun_w_casemetadata, fmurun_pred):
     """Testing the scenario without RESTART_FROM_PATH environment variable
 
     The iteration metadata will not contain restart_from key
     """
-
-    edataobj1._rootpath = fmurun_w_casemetadata
     os.chdir(fmurun_w_casemetadata)
-    fmu_restart_from = _FmuProvider(edataobj1)
-    fmu_restart_from.detect_provider()
 
-    edataobj1._rootpath = fmurun_pred
+    _ = FmuProvider(model="Model with restart", fmu_context=FmuContext.REALIZATION)
+
+    monkeypatch.setenv(RESTART_PATH_ENVNAME, "/path/to/somewhere/invalid")
+    monkeypatch.delenv(RESTART_PATH_ENVNAME)
+
     os.chdir(fmurun_pred)
-    fmu_restart = _FmuProvider(edataobj1)
-    with pytest.warns(UserWarning, match="ERT2 is found but no case metadata"):
-        fmu_restart.detect_provider()
-    assert "restart_from" not in fmu_restart.metadata["iteration"]
+    fmu_restart = FmuProvider(model="Modelrun", fmu_context=FmuContext.REALIZATION)
+    assert "restart_from" not in fmu_restart._metadata["iteration"]
 
 
-def test_fmuprovider_detect_case_has_metadata(fmurun_w_casemetadata, edataobj1):
-    """Testing the case metadata file which is found here"""
-    edataobj1._rootpath = fmurun_w_casemetadata
-    os.chdir(fmurun_w_casemetadata)
-    myfmu = _FmuProvider(edataobj1)
-    myfmu.detect_provider()
-    assert myfmu.case_name == "ertrun1"
-    assert myfmu.real_name == "realization-0"
-    assert myfmu.real_id == 0
-    assert "fmu_case" in str(myfmu.case_metafile)
-    assert (
-        myfmu.case_metadata["fmu"]["case"]["uuid"]
-        == "a40b05e8-e47f-47b1-8fee-f52a5116bd37"
-    )
-
-
-def test_fmuprovider_workflow_reference(fmurun_w_casemetadata, edataobj1):
+def test_fmuprovider_workflow_reference(fmurun_w_casemetadata):
     """Testing the handling of workflow reference input.
 
     Metadata definitions of fmu.workflow is that it is a dictionary with 'reference'
@@ -238,32 +243,23 @@ def test_fmuprovider_workflow_reference(fmurun_w_casemetadata, edataobj1):
     it shall always produce valid metadata.
 
     """
-    edataobj1._rootpath = fmurun_w_casemetadata
     os.chdir(fmurun_w_casemetadata)
 
     # workflow input is a string
-    edataobj1.workflow = "my workflow"
-    myfmu = _FmuProvider(edataobj1)
-    myfmu.detect_provider()
-    assert "workflow" in myfmu.metadata
-    assert myfmu.metadata["workflow"] == {"reference": "my workflow"}
+    myfmu = FmuProvider(workflow="workflow as string")
+    assert "workflow" in myfmu._metadata
+    assert myfmu._metadata["workflow"] == {"reference": "workflow as string"}
 
     # workflow input is a correct dict
-    edataobj1.workflow = {"reference": "my workflow"}
-    myfmu = _FmuProvider(edataobj1)
     with pytest.warns(PendingDeprecationWarning, match="The 'workflow' argument"):
-        myfmu.detect_provider()
-    assert "workflow" in myfmu.metadata
-    assert myfmu.metadata["workflow"] == {"reference": "my workflow"}
+        myfmu = FmuProvider(workflow={"reference": "workflow as dict"})
+    assert "workflow" in myfmu._metadata
+    assert myfmu._metadata["workflow"] == {"reference": "workflow as dict"}
 
     # workflow input is non-correct dict
-    edataobj1.workflow = {"something": "something"}
-    myfmu = _FmuProvider(edataobj1)
     with pytest.raises(ValueError):
-        myfmu.detect_provider()
+        myfmu = FmuProvider(workflow={"wrong": "workflow as dict"})
 
     # workflow input is other types - shall fail
-    edataobj1.workflow = 123.4
-    myfmu = _FmuProvider(edataobj1)
     with pytest.raises(TypeError):
-        myfmu.detect_provider()
+        myfmu = FmuProvider(workflow=123.4)

--- a/tests/test_units/test_rms_context.py
+++ b/tests/test_units/test_rms_context.py
@@ -187,7 +187,7 @@ def test_regsurf_metadata_with_timedata_legacy(rmssetup, rmsglobalconfig, regsur
 def test_regsurf_export_file_fmurun(
     rmsrun_fmu_w_casemetadata, rmsglobalconfig, regsurf
 ):
-    """Being in RMS and in an active FMU ERT2 run with case metadata present.
+    """Being in RMS and in an active FMU ERT run with case metadata present.
 
     Export the regular surface to file with correct metadata and name.
     """


### PR DESCRIPTION
This is a bigger PR where we go from parsing file paths in order to detect "running in FMU", to look for defined environment variables from ERT runs.

In doing so, some refactorisering is done, in particular for the _FmuProvider class (renamed to FmuProvider) to have a cleaner interface with the calling metadata.py module.

Resolves: https://github.com/equinor/fmu-dataio/issues/368