### PR TITLE
FIX: Unpin pydantic lt. 2.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "numpy",
     "pandas",
     "pyarrow",
-    "pydantic>=2.5.0,<=2.6.0",
+    "pydantic>=2.5.0",
     "PyYAML",
     "xtgeo>=2.16",
 ]


### PR DESCRIPTION
Can be unpined due to https://github.com/pydantic/pydantic/issues/8665 is closed/fixed.