### PR TITLE
CLN: Remove superfluous underscore prefix

### DIFF
--- a/src/fmu/dataio/_definitions.py
+++ b/src/fmu/dataio/_definitions.py
@@ -17,7 +17,7 @@ class ValidationError(ValueError, KeyError):
 
 
 @dataclass
-class _ValidFormats:
+class ValidFormats:
     surface: dict[str, str] = field(
         default_factory=lambda: {
             "irap_binary": ".gri",

--- a/src/fmu/dataio/_filedata_provider.py
+++ b/src/fmu/dataio/_filedata_provider.py
@@ -18,7 +18,7 @@ logger: Final = null_logger(__name__)
 
 
 @dataclass
-class _FileDataProvider:
+class FileDataProvider:
     """Class for providing metadata for the 'files' block in fmu-dataio.
 
     Example::

--- a/src/fmu/dataio/_metadata.py
+++ b/src/fmu/dataio/_metadata.py
@@ -19,9 +19,9 @@ from warnings import warn
 
 from fmu import dataio
 from fmu.dataio._definitions import SCHEMA, SOURCE, VERSION
-from fmu.dataio._filedata_provider import _FileDataProvider
+from fmu.dataio._filedata_provider import FileDataProvider
 from fmu.dataio._fmu_provider import FmuProvider
-from fmu.dataio._objectdata_provider import _ObjectDataProvider
+from fmu.dataio._objectdata_provider import ObjectDataProvider
 from fmu.dataio._utils import (
     drop_nones,
     export_file_compute_checksum_md5,
@@ -196,7 +196,7 @@ def generate_meta_access(config: dict) -> dict | None:
 
 
 @dataclass
-class _MetaData:
+class MetaData:
     """Class for sampling, process and holding all metadata in an ExportData instance.
 
     Metadata has basically these different providers:
@@ -271,7 +271,7 @@ class _MetaData:
 
         Hence this must be ran early or first.
         """
-        self.objdata = _ObjectDataProvider(self.obj, self.dataio, self.meta_existing)
+        self.objdata = ObjectDataProvider(self.obj, self.dataio, self.meta_existing)
         self.objdata.derive_metadata()
         self.meta_objectdata = self.objdata.metadata
 
@@ -332,7 +332,7 @@ class _MetaData:
         - absolute_path_symlink, as above but full path
         """
 
-        fdata = _FileDataProvider(
+        fdata = FileDataProvider(
             self.dataio,
             self.objdata,
             Path(self.rootpath),

--- a/src/fmu/dataio/_objectdata_provider.py
+++ b/src/fmu/dataio/_objectdata_provider.py
@@ -95,7 +95,7 @@ import numpy as np
 import pandas as pd
 import xtgeo
 
-from ._definitions import ALLOWED_CONTENTS, STANDARD_TABLE_INDEX_COLUMNS, _ValidFormats
+from ._definitions import ALLOWED_CONTENTS, STANDARD_TABLE_INDEX_COLUMNS, ValidFormats
 from ._logging import null_logger
 from ._utils import generate_description, parse_timedata
 from .datastructure.meta import meta, specification
@@ -202,7 +202,7 @@ class DerivedNamedStratigraphy:
 
 
 @dataclass
-class _ObjectDataProvider:
+class ObjectDataProvider:
     """Class for providing metadata for data objects in fmu-dataio, e.g. a surface.
 
     The metadata for the 'data' are constructed by:
@@ -300,7 +300,7 @@ class _ObjectDataProvider:
                 spec=spec,
                 bbox=bbox,
                 extension=self._validate_get_ext(
-                    fmt, "RegularSurface", _ValidFormats().surface
+                    fmt, "RegularSurface", ValidFormats().surface
                 ),
                 table_index=None,
             )
@@ -314,7 +314,7 @@ class _ObjectDataProvider:
                 efolder="polygons",
                 fmt=(fmt := self.dataio.polygons_fformat),
                 extension=self._validate_get_ext(
-                    fmt, "Polygons", _ValidFormats().polygons
+                    fmt, "Polygons", ValidFormats().polygons
                 ),
                 spec=spec,
                 bbox=bbox,
@@ -329,7 +329,7 @@ class _ObjectDataProvider:
                 layout="unset",
                 efolder="points",
                 fmt=(fmt := self.dataio.points_fformat),
-                extension=self._validate_get_ext(fmt, "Points", _ValidFormats().points),
+                extension=self._validate_get_ext(fmt, "Points", ValidFormats().points),
                 spec=spec,
                 bbox=bbox,
                 table_index=None,
@@ -344,7 +344,7 @@ class _ObjectDataProvider:
                 efolder="cubes",
                 fmt=(fmt := self.dataio.cube_fformat),
                 extension=self._validate_get_ext(
-                    fmt, "RegularCube", _ValidFormats().cube
+                    fmt, "RegularCube", ValidFormats().cube
                 ),
                 spec=spec,
                 bbox=bbox,
@@ -359,7 +359,7 @@ class _ObjectDataProvider:
                 layout="cornerpoint",
                 efolder="grids",
                 fmt=(fmt := self.dataio.grid_fformat),
-                extension=self._validate_get_ext(fmt, "CPGrid", _ValidFormats().grid),
+                extension=self._validate_get_ext(fmt, "CPGrid", ValidFormats().grid),
                 spec=spec,
                 bbox=bbox,
                 table_index=None,
@@ -374,7 +374,7 @@ class _ObjectDataProvider:
                 efolder="grids",
                 fmt=(fmt := self.dataio.grid_fformat),
                 extension=self._validate_get_ext(
-                    fmt, "CPGridProperty", _ValidFormats().grid
+                    fmt, "CPGridProperty", ValidFormats().grid
                 ),
                 spec=spec,
                 bbox=bbox,
@@ -390,7 +390,7 @@ class _ObjectDataProvider:
                 efolder="tables",
                 fmt=(fmt := self.dataio.table_fformat),
                 extension=self._validate_get_ext(
-                    fmt, "DataFrame", _ValidFormats().table
+                    fmt, "DataFrame", ValidFormats().table
                 ),
                 spec=spec,
                 bbox=bbox,
@@ -406,7 +406,7 @@ class _ObjectDataProvider:
                 efolder="dictionaries",
                 fmt=(fmt := self.dataio.dict_fformat),
                 extension=self._validate_get_ext(
-                    fmt, "JSON", _ValidFormats().dictionary
+                    fmt, "JSON", ValidFormats().dictionary
                 ),
                 spec=spec,
                 bbox=bbox,
@@ -426,7 +426,7 @@ class _ObjectDataProvider:
                     efolder="tables",
                     fmt=(fmt := self.dataio.arrow_fformat),
                     extension=self._validate_get_ext(
-                        fmt, "ArrowTable", _ValidFormats().table
+                        fmt, "ArrowTable", ValidFormats().table
                     ),
                     spec=spec,
                     bbox=bbox,

--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -753,7 +753,7 @@ class ExportData:
         self._validate_content_key()
         self._update_fmt_flag()
 
-        metaobj = _metadata._MetaData(obj, self, compute_md5=compute_md5)
+        metaobj = _metadata.MetaData(obj, self, compute_md5=compute_md5)
         self._metadata = metaobj.generate_export_metadata()
 
         self._rootpath = Path(metaobj.rootpath)

--- a/tests/test_units/test_filedataprovider_class.py
+++ b/tests/test_units/test_filedataprovider_class.py
@@ -3,8 +3,8 @@ import os
 from pathlib import Path
 
 import pytest
-from fmu.dataio._filedata_provider import _FileDataProvider
-from fmu.dataio._objectdata_provider import _ObjectDataProvider
+from fmu.dataio._filedata_provider import FileDataProvider
+from fmu.dataio._objectdata_provider import ObjectDataProvider
 
 
 @pytest.mark.parametrize(
@@ -95,7 +95,7 @@ def test_get_filestem(
     expected,
 ):
     """Testing the private _get_filestem method."""
-    objdata = _ObjectDataProvider(regsurf, edataobj1)
+    objdata = ObjectDataProvider(regsurf, edataobj1)
     objdata.name = name
     # time0 is always the oldest
     objdata.time0 = time0
@@ -105,7 +105,7 @@ def test_get_filestem(
     edataobj1.parent = parentname
     edataobj1.name = ""
 
-    fdata = _FileDataProvider(
+    fdata = FileDataProvider(
         edataobj1,
         objdata,
     )
@@ -146,7 +146,7 @@ def test_get_filestem_shall_fail(
     message,
 ):
     """Testing the private _get_filestem method when it shall fail."""
-    objdata = _ObjectDataProvider(regsurf, edataobj1)
+    objdata = ObjectDataProvider(regsurf, edataobj1)
     objdata.name = name
     objdata.time0 = time0
     objdata.time1 = time1
@@ -155,7 +155,7 @@ def test_get_filestem_shall_fail(
     edataobj1.parent = parentname
     edataobj1.name = ""
 
-    fdata = _FileDataProvider(edataobj1, objdata)
+    fdata = FileDataProvider(edataobj1, objdata)
 
     with pytest.raises(ValueError) as msg:
         _ = fdata._get_filestem()
@@ -171,11 +171,11 @@ def test_get_paths_path_exists_already(regsurf, edataobj1, tmp_path):
 
     edataobj1.name = "some"
 
-    objdata = _ObjectDataProvider(regsurf, edataobj1)
+    objdata = ObjectDataProvider(regsurf, edataobj1)
     objdata.name = "some"
     objdata.efolder = "efolder"
 
-    fdata = _FileDataProvider(edataobj1, objdata)
+    fdata = FileDataProvider(edataobj1, objdata)
 
     path, linkpath = fdata._get_path()
     assert str(path) == "share/results/efolder"
@@ -187,7 +187,7 @@ def test_get_paths_not_exists_so_create(regsurf, edataobj1, tmp_path):
 
     os.chdir(tmp_path)
 
-    objdata = _ObjectDataProvider(regsurf, edataobj1)
+    objdata = ObjectDataProvider(regsurf, edataobj1)
     objdata.name = "some"
     objdata.efolder = "efolder"
     cfg = edataobj1
@@ -195,7 +195,7 @@ def test_get_paths_not_exists_so_create(regsurf, edataobj1, tmp_path):
     cfg.createfolder = True
     cfg._rootpath = Path(".")
 
-    fdata = _FileDataProvider(cfg, objdata)
+    fdata = FileDataProvider(cfg, objdata)
 
     path, _ = fdata._get_path()
     assert str(path) == "share/results/efolder"
@@ -211,14 +211,14 @@ def test_filedata_provider(regsurf, edataobj1, tmp_path):
     cfg._rootpath = Path(".")
     cfg.name = ""
 
-    objdata = _ObjectDataProvider(regsurf, edataobj1)
+    objdata = ObjectDataProvider(regsurf, edataobj1)
     objdata.name = "name"
     objdata.efolder = "efolder"
     objdata.extension = ".ext"
     objdata.time0 = "t1"
     objdata.time1 = "t2"
 
-    fdata = _FileDataProvider(cfg, objdata)
+    fdata = FileDataProvider(cfg, objdata)
     fdata.derive_filedata()
 
     print(fdata.relative_path)
@@ -237,13 +237,13 @@ def test_filedata_has_nonascii_letters(regsurf, edataobj1, tmp_path):
     cfg._rootpath = Path(".")
     cfg.name = "mynõme"
 
-    objdata = _ObjectDataProvider(regsurf, edataobj1)
+    objdata = ObjectDataProvider(regsurf, edataobj1)
     objdata.name = "anynõme"
     objdata.efolder = "efolder"
     objdata.extension = ".ext"
     objdata.time0 = "t1"
     objdata.time1 = "t2"
 
-    fdata = _FileDataProvider(cfg, objdata)
+    fdata = FileDataProvider(cfg, objdata)
     with pytest.raises(UnicodeEncodeError, match=r"codec can't encode character"):
         fdata.derive_filedata()

--- a/tests/test_units/test_metadata_class.py
+++ b/tests/test_units/test_metadata_class.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 
 import fmu.dataio as dio
 import pytest
-from fmu.dataio._metadata import SCHEMA, SOURCE, VERSION, ConfigurationError, _MetaData
+from fmu.dataio._metadata import SCHEMA, SOURCE, VERSION, ConfigurationError, MetaData
 from fmu.dataio._utils import prettyprint_dict
 from fmu.dataio.datastructure.meta.meta import (
     SystemInformationOperatingSystem,
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 def test_metadata_dollars(edataobj1):
     """Testing the dollars part which is hard set."""
 
-    mymeta = _MetaData("dummy", edataobj1)
+    mymeta = MetaData("dummy", edataobj1)
 
     assert mymeta.meta_dollars["version"] == VERSION
     assert mymeta.meta_dollars["$schema"] == SCHEMA
@@ -36,7 +36,7 @@ def test_metadata_dollars(edataobj1):
 
 
 def test_generate_meta_tracklog_fmu_dataio_version(edataobj1):
-    mymeta = _MetaData("dummy", edataobj1)
+    mymeta = MetaData("dummy", edataobj1)
     mymeta._populate_meta_tracklog()
     tracklog = mymeta.meta_tracklog
 
@@ -60,7 +60,7 @@ def test_generate_meta_tracklog_komodo_version(edataobj1, monkeypatch):
     fake_komodo_release = "<FAKE_KOMODO_RELEASE_VERSION>"
     monkeypatch.setenv("KOMODO_RELEASE", fake_komodo_release)
 
-    mymeta = _MetaData("dummy", edataobj1)
+    mymeta = MetaData("dummy", edataobj1)
     mymeta._populate_meta_tracklog()
     tracklog = mymeta.meta_tracklog
 
@@ -81,7 +81,7 @@ def test_generate_meta_tracklog_komodo_version(edataobj1, monkeypatch):
 
 
 def test_generate_meta_tracklog_operating_system(edataobj1):
-    mymeta = _MetaData("dummy", edataobj1)
+    mymeta = MetaData("dummy", edataobj1)
     mymeta._populate_meta_tracklog()
     tracklog = mymeta.meta_tracklog
 
@@ -101,7 +101,7 @@ def test_generate_meta_tracklog_operating_system(edataobj1):
 
 
 def test_populate_meta_objectdata(regsurf, edataobj2):
-    mymeta = _MetaData(regsurf, edataobj2)
+    mymeta = MetaData(regsurf, edataobj2)
     mymeta._populate_meta_objectdata()
     assert mymeta.objdata.name == "VOLANTIS GP. Top"
 
@@ -145,7 +145,7 @@ def test_metadata_populate_masterdata_is_empty(globalconfig1):
     some = dio.ExportData(config=globalconfig1, content="depth")
     del some.config["masterdata"]  # to force missing masterdata
 
-    mymeta = _MetaData("dummy", some)
+    mymeta = MetaData("dummy", some)
 
     with pytest.raises(ValueError, match="A config exists, but 'masterdata' are not"):
         mymeta._populate_meta_masterdata()
@@ -154,11 +154,11 @@ def test_metadata_populate_masterdata_is_empty(globalconfig1):
 def test_metadata_populate_masterdata_is_present_ok(edataobj1, edataobj2):
     """Testing the masterdata part with OK metdata."""
 
-    mymeta = _MetaData("dummy", edataobj1)
+    mymeta = MetaData("dummy", edataobj1)
     mymeta._populate_meta_masterdata()
     assert mymeta.meta_masterdata == edataobj1.config["masterdata"]
 
-    mymeta = _MetaData("dummy", edataobj2)
+    mymeta = MetaData("dummy", edataobj2)
     mymeta._populate_meta_masterdata()
     assert mymeta.meta_masterdata == edataobj2.config["masterdata"]
 
@@ -174,7 +174,7 @@ def test_metadata_populate_access_miss_config_access(edataobj1):
     cfg1_edited = deepcopy(edataobj1)
     del cfg1_edited.config["access"]
 
-    mymeta = _MetaData("dummy", cfg1_edited)
+    mymeta = MetaData("dummy", cfg1_edited)
 
     with pytest.raises(ConfigurationError):
         mymeta._populate_meta_access()
@@ -183,7 +183,7 @@ def test_metadata_populate_access_miss_config_access(edataobj1):
 def test_metadata_populate_access_ok_config(edataobj2):
     """Testing the access part, now with config ok access."""
 
-    mymeta = _MetaData("dummy", edataobj2)
+    mymeta = MetaData("dummy", edataobj2)
 
     mymeta._populate_meta_access()
     assert mymeta.meta_access == {
@@ -204,7 +204,7 @@ def test_metadata_populate_from_argument(globalconfig1):
         access_ssdl={"access_level": "restricted", "rep_include": True},
         content="depth",
     )
-    mymeta = _MetaData("dummy", edata)
+    mymeta = MetaData("dummy", edata)
 
     mymeta._populate_meta_access()
     assert mymeta.meta_access == {
@@ -225,7 +225,7 @@ def test_metadata_populate_partial_access_ssdl(globalconfig1):
     edata = dio.ExportData(
         config=globalconfig1, access_ssdl={"rep_include": True}, content="depth"
     )
-    mymeta = _MetaData("dummy", edata)
+    mymeta = MetaData("dummy", edata)
     mymeta._populate_meta_access()
     assert mymeta.meta_access["ssdl"]["rep_include"] is True
     assert mymeta.meta_access["ssdl"]["access_level"] == "internal"  # default
@@ -237,7 +237,7 @@ def test_metadata_populate_partial_access_ssdl(globalconfig1):
         access_ssdl={"access_level": "restricted"},
         content="depth",
     )
-    mymeta = _MetaData("dummy", edata)
+    mymeta = MetaData("dummy", edata)
     mymeta._populate_meta_access()
     assert mymeta.meta_access["ssdl"]["rep_include"] is False  # default
     assert mymeta.meta_access["ssdl"]["access_level"] == "restricted"
@@ -254,7 +254,7 @@ def test_metadata_populate_wrong_config(globalconfig1):
     with pytest.warns(UserWarning):
         edata = dio.ExportData(config=_config, content="depth")
 
-    mymeta = _MetaData("dummy", edata)
+    mymeta = MetaData("dummy", edata)
     with pytest.raises(ConfigurationError, match="Illegal value for access"):
         mymeta._populate_meta_access()
 
@@ -268,7 +268,7 @@ def test_metadata_populate_wrong_argument(globalconfig1):
             access_ssdl={"access_level": "wrong"},
             content="depth",
         )
-    mymeta = _MetaData("dummy", edata)
+    mymeta = MetaData("dummy", edata)
     with pytest.raises(ConfigurationError, match="Illegal value for access"):
         mymeta._populate_meta_access()
 
@@ -281,7 +281,7 @@ def test_metadata_access_correct_input(globalconfig1):
         content="depth",
         access_ssdl={"access_level": "restricted", "rep_include": False},
     )
-    mymeta = _MetaData("dummy", edata)
+    mymeta = MetaData("dummy", edata)
     mymeta._populate_meta_access()
     assert mymeta.meta_access["ssdl"]["rep_include"] is False
     assert mymeta.meta_access["ssdl"]["access_level"] == "restricted"
@@ -293,7 +293,7 @@ def test_metadata_access_correct_input(globalconfig1):
         content="depth",
         access_ssdl={"access_level": "internal", "rep_include": True},
     )
-    mymeta = _MetaData("dummy", edata)
+    mymeta = MetaData("dummy", edata)
     mymeta._populate_meta_access()
     assert mymeta.meta_access["ssdl"]["rep_include"] is True
     assert mymeta.meta_access["ssdl"]["access_level"] == "internal"
@@ -307,7 +307,7 @@ def test_metadata_access_deprecated_input(globalconfig1):
     edata = dio.ExportData(
         config=globalconfig1, access_ssdl={"access_level": "asset"}, content="depth"
     )
-    mymeta = _MetaData("dummy", edata)
+    mymeta = MetaData("dummy", edata)
     with pytest.warns(
         UserWarning,
         match="The value 'asset' for access.ssdl.access_level is deprec",
@@ -328,7 +328,7 @@ def test_metadata_access_illegal_input(globalconfig1):
             content="depth",
         )
 
-    mymeta = _MetaData("dummy", edata)
+    mymeta = MetaData("dummy", edata)
     with pytest.raises(ConfigurationError, match="Illegal value for access"):
         mymeta._populate_meta_access()
 
@@ -339,7 +339,7 @@ def test_metadata_access_illegal_input(globalconfig1):
             access_ssdl={"access_level": "open"},
             content="depth",
         )
-    mymeta = _MetaData("dummy", edata)
+    mymeta = MetaData("dummy", edata)
     with pytest.raises(ConfigurationError, match="Illegal value for access"):
         mymeta._populate_meta_access()
 
@@ -352,7 +352,7 @@ def test_metadata_access_no_input(globalconfig1):
     configcopy["access"]["ssdl"]["access_level"] = "restricted"
     configcopy["access"]["ssdl"]["rep_include"] = True
     edata = dio.ExportData(config=configcopy, content="depth")
-    mymeta = _MetaData("dummy", edata)
+    mymeta = MetaData("dummy", edata)
     mymeta._populate_meta_access()
     assert mymeta.meta_access["ssdl"]["rep_include"] is True
     assert mymeta.meta_access["ssdl"]["access_level"] == "restricted"
@@ -363,7 +363,7 @@ def test_metadata_access_no_input(globalconfig1):
     del configcopy["access"]["ssdl"]["access_level"]
     del configcopy["access"]["ssdl"]["rep_include"]
     edata = dio.ExportData(config=globalconfig1, content="depth")
-    mymeta = _MetaData("dummy", edata)
+    mymeta = MetaData("dummy", edata)
     mymeta._populate_meta_access()
     assert mymeta.meta_access["ssdl"]["rep_include"] is False  # default
     assert mymeta.meta_access["ssdl"]["access_level"] == "internal"  # default
@@ -378,7 +378,7 @@ def test_metadata_access_no_input(globalconfig1):
 def test_metadata_display_name_not_given(regsurf, edataobj2):
     """Test that display.name == data.name when not explicitly provided."""
 
-    mymeta = _MetaData(regsurf, edataobj2)
+    mymeta = MetaData(regsurf, edataobj2)
     mymeta._populate_meta_objectdata()
     mymeta._populate_meta_display()
 
@@ -389,7 +389,7 @@ def test_metadata_display_name_not_given(regsurf, edataobj2):
 def test_metadata_display_name_given(regsurf, edataobj2):
     """Test that display.name is set when explicitly given."""
 
-    mymeta = _MetaData(regsurf, edataobj2)
+    mymeta = MetaData(regsurf, edataobj2)
     edataobj2.display_name = "My Display Name"
     mymeta._populate_meta_objectdata()
     mymeta._populate_meta_display()
@@ -406,7 +406,7 @@ def test_metadata_display_name_given(regsurf, edataobj2):
 def test_generate_full_metadata(regsurf, edataobj2):
     """Generating the full metadata block for a xtgeo surface."""
 
-    mymeta = _MetaData(regsurf, edataobj2)
+    mymeta = MetaData(regsurf, edataobj2)
 
     metadata_result = mymeta.generate_export_metadata(
         skip_null=False

--- a/tests/test_units/test_objectdataprovider_class.py
+++ b/tests/test_units/test_objectdataprovider_class.py
@@ -1,7 +1,7 @@
 """Test the _ObjectData class from the _objectdata.py module"""
 import pytest
-from fmu.dataio._definitions import _ValidFormats
-from fmu.dataio._objectdata_provider import ConfigurationError, _ObjectDataProvider
+from fmu.dataio._definitions import ValidFormats
+from fmu.dataio._objectdata_provider import ConfigurationError, ObjectDataProvider
 
 # --------------------------------------------------------------------------------------
 # RegularSurface
@@ -11,7 +11,7 @@ from fmu.dataio._objectdata_provider import ConfigurationError, _ObjectDataProvi
 def test_objectdata_regularsurface_derive_name_stratigraphy(regsurf, edataobj1):
     """Get name and some stratigaphic keys for a valid RegularSurface object ."""
     # mimic the stripped parts of configuations for testing here
-    objdata = _ObjectDataProvider(regsurf, edataobj1)
+    objdata = ObjectDataProvider(regsurf, edataobj1)
 
     res = objdata._derive_name_stratigraphy()
 
@@ -23,7 +23,7 @@ def test_objectdata_regularsurface_derive_name_stratigraphy(regsurf, edataobj1):
 def test_objectdata_regularsurface_derive_name_stratigraphy_differ(regsurf, edataobj2):
     """Get name and some stratigaphic keys for a valid RegularSurface object ."""
     # mimic the stripped parts of configuations for testing here
-    objdata = _ObjectDataProvider(regsurf, edataobj2)
+    objdata = ObjectDataProvider(regsurf, edataobj2)
 
     res = objdata._derive_name_stratigraphy()
 
@@ -35,8 +35,8 @@ def test_objectdata_regularsurface_derive_name_stratigraphy_differ(regsurf, edat
 def test_objectdata_regularsurface_validate_extension(regsurf, edataobj1):
     """Test a valid extension for RegularSurface object."""
 
-    ext = _ObjectDataProvider(regsurf, edataobj1)._validate_get_ext(
-        "irap_binary", "RegularSurface", _ValidFormats().surface
+    ext = ObjectDataProvider(regsurf, edataobj1)._validate_get_ext(
+        "irap_binary", "RegularSurface", ValidFormats().surface
     )
 
     assert ext == ".gri"
@@ -46,15 +46,15 @@ def test_objectdata_regularsurface_validate_extension_shall_fail(regsurf, edatao
     """Test an invalid extension for RegularSurface object."""
 
     with pytest.raises(ConfigurationError):
-        _ = _ObjectDataProvider(regsurf, edataobj1)._validate_get_ext(
-            "some_invalid", "RegularSurface", _ValidFormats().surface
+        _ = ObjectDataProvider(regsurf, edataobj1)._validate_get_ext(
+            "some_invalid", "RegularSurface", ValidFormats().surface
         )
 
 
 def test_objectdata_regularsurface_spec_bbox(regsurf, edataobj1):
     """Derive specs and bbox for RegularSurface object."""
 
-    specs, bbox = _ObjectDataProvider(
+    specs, bbox = ObjectDataProvider(
         regsurf, edataobj1
     )._derive_spec_bbox_regularsurface()
 
@@ -66,7 +66,7 @@ def test_objectdata_regularsurface_spec_bbox(regsurf, edataobj1):
 def test_objectdata_regularsurface_derive_objectdata(regsurf, edataobj1):
     """Derive other properties."""
 
-    res = _ObjectDataProvider(regsurf, edataobj1)._derive_objectdata()
+    res = ObjectDataProvider(regsurf, edataobj1)._derive_objectdata()
 
     assert res.subtype == "RegularSurface"
     assert res.classname == "surface"
@@ -76,7 +76,7 @@ def test_objectdata_regularsurface_derive_objectdata(regsurf, edataobj1):
 def test_objectdata_regularsurface_derive_metadata(regsurf, edataobj1):
     """Derive all metadata for the 'data' block in fmu-dataio."""
 
-    myobj = _ObjectDataProvider(regsurf, edataobj1)
+    myobj = ObjectDataProvider(regsurf, edataobj1)
     myobj.derive_metadata()
     res = myobj.metadata
     assert res["content"] == "depth"

--- a/tests/test_units/test_table.py
+++ b/tests/test_units/test_table.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 from fmu.config.utilities import yaml_load
 from fmu.dataio import ExportData
-from fmu.dataio._objectdata_provider import _ObjectDataProvider
+from fmu.dataio._objectdata_provider import ObjectDataProvider
 
 
 def _read_dict(file_path):
@@ -137,7 +137,7 @@ def test_table_index_real_summary(edataobj3, drogon_summary):
         edataobj3 (dict): metadata
         drogon_summary (pd.Dataframe): dataframe with summary data from sumo
     """
-    objdata = _ObjectDataProvider(drogon_summary, edataobj3)
+    objdata = ObjectDataProvider(drogon_summary, edataobj3)
     res = objdata._derive_objectdata()
     assert res.table_index == ["DATE"], "Incorrect table index "
 


### PR DESCRIPTION
Since the modules already is prefixed with _, there is no need to add _ to class etc in those modules.