### PR TITLE
TST: Add additional create_case_metadata tests

### DIFF
--- a/.github/workflows/ci-fmudataio.yml
+++ b/.github/workflows/ci-fmudataio.yml
@@ -28,5 +28,11 @@ jobs:
           pip install pip -U
           pip install .[dev]
 
+      - name: Install fmu-sumo-uploader
+        if: matrix.python-version != '3.12'
+        run:
+          pip install \
+            "fmu-sumo-uploader @ git+https://github.com/equinor/fmu-sumo-uploader.git"
+
       - name: Full test
         run: pytest -v

--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -904,7 +904,7 @@ class InitializeCase:  # pylint: disable=too-few-public-methods
         logger.info("Set PWD (case): %s", str(self._pwd))
         logger.info("Set rootpath (case): %s", str(self._casepath))
 
-    def _check_already_metadata_or_create_folder(self, force: bool = False) -> bool:
+    def _establish_new_case_metadata(self, force: bool = False) -> bool:
         if not self._casepath.exists():
             self._casepath.mkdir(parents=True, exist_ok=True)
             logger.info("Created rootpath (case) %s", self._casepath)
@@ -946,18 +946,16 @@ class InitializeCase:  # pylint: disable=too-few-public-methods
             A dictionary with case metadata or None
         """
         self._update_settings(kwargs)
-
         self._establish_pwd_casepath()
-        status = self._check_already_metadata_or_create_folder(force=force)
 
-        if status is False:
-            logger.warning("The metadatafile already exists!")
-            warn(
-                "The metadata file already exist! Keep this file instead! "
-                "To make a new case metadata file, delete the old case or use the "
-                "'force' option",
-                UserWarning,
+        if not self._establish_new_case_metadata(force=force):
+            exists_warning = (
+                "The case metadata file already exists and will not be overwritten."
+                "To make new case metadata delete the old case or run on a different "
+                "runpath."
             )
+            logger.warning(exists_warning)
+            warn(exists_warning, UserWarning)
             return None
 
         meta = _metadata.default_meta_dollars()
@@ -1020,12 +1018,6 @@ class InitializeCase:  # pylint: disable=too-few-public-methods
                 self._metafile, self._metadata, savefmt=self.meta_format
             )
             logger.info("METAFILE %s", self._metafile)
-        else:
-            warn(
-                "The metadatafile exists already. use 'force' or delete the "
-                "current case folder if a new metadata are requested.",
-                UserWarning,
-            )
         return str(self._metafile)
 
 

--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -904,7 +904,7 @@ class InitializeCase:  # pylint: disable=too-few-public-methods
         logger.info("Set PWD (case): %s", str(self._pwd))
         logger.info("Set rootpath (case): %s", str(self._casepath))
 
-    def _establish_new_case_metadata(self, force: bool = False) -> bool:
+    def _establish_case_metadata(self, force: bool = False) -> bool:
         if not self._casepath.exists():
             self._casepath.mkdir(parents=True, exist_ok=True)
             logger.info("Created rootpath (case) %s", self._casepath)
@@ -948,9 +948,9 @@ class InitializeCase:  # pylint: disable=too-few-public-methods
         self._update_settings(kwargs)
         self._establish_pwd_casepath()
 
-        if not self._establish_new_case_metadata(force=force):
+        if not self._establish_case_metadata(force=force):
             exists_warning = (
-                "The case metadata file already exists and will not be overwritten."
+                "The case metadata file already exists and will not be overwritten. "
                 "To make new case metadata delete the old case or run on a different "
                 "runpath."
             )
@@ -960,7 +960,6 @@ class InitializeCase:  # pylint: disable=too-few-public-methods
 
         meta = _metadata.default_meta_dollars()
         meta["class"] = "case"
-
         meta["masterdata"] = _metadata.generate_meta_masterdata(self.config)
 
         # only asset, not ssdl

--- a/tests/test_integration/conftest.py
+++ b/tests/test_integration/conftest.py
@@ -1,7 +1,9 @@
+import contextlib
 import os
 import pathlib
 import shutil
 from textwrap import dedent
+from unittest.mock import patch
 
 import pytest
 
@@ -60,3 +62,21 @@ def fmu_snakeoil_project(tmp_path, monkeypatch, base_ert_config, global_config2_
     )
 
     return tmp_path
+
+
+@pytest.fixture
+def mock_sumo_uploader():
+    def register_side_effect(*args, **kwargs):
+        with open("sumo_case_id", "w", encoding="utf-8") as f:
+            f.write("1")
+        return 1
+
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(patch("fmu.sumo.uploader.SumoConnection", spec=True))
+        stack.enter_context(
+            patch(
+                "fmu.sumo.uploader.CaseOnDisk.register",
+                side_effect=register_side_effect,
+            )
+        )
+        yield

--- a/tests/test_integration/test_wf_create_case_metadata.py
+++ b/tests/test_integration/test_wf_create_case_metadata.py
@@ -1,21 +1,32 @@
-import subprocess
+import getpass
+import os
+import sys
 
+import ert.__main__
+import pytest
 import yaml
 
 
-def test_create_case_metadata_runs_successfully(fmu_snakeoil_project, monkeypatch):
-    monkeypatch.chdir(fmu_snakeoil_project / "ert/model")
-    with open("snakeoil.ert", "a", encoding="utf-8") as f:
+def _add_create_case_workflow(filepath):
+    with open(filepath, "a", encoding="utf-8") as f:
         f.writelines(
             [
                 "LOAD_WORKFLOW ../bin/workflows/xhook_create_case_metadata\n"
                 "HOOK_WORKFLOW xhook_create_case_metadata PRE_SIMULATION\n"
             ]
         )
-    run_result = subprocess.run(
-        ["ert", "test_run", "snakeoil.ert", "--disable-monitoring"],
+
+
+def test_create_case_metadata_runs_successfully(
+    fmu_snakeoil_project, monkeypatch, mocker
+):
+    monkeypatch.chdir(fmu_snakeoil_project / "ert/model")
+    _add_create_case_workflow("snakeoil.ert")
+
+    mocker.patch(
+        "sys.argv", ["ert", "test_run", "snakeoil.ert", "--disable-monitoring"]
     )
-    assert run_result.returncode == 0
+    ert.__main__.main()
 
     fmu_case_yml = (
         fmu_snakeoil_project / "scratch/user/snakeoil/share/metadata/fmu_case.yml"
@@ -24,6 +35,66 @@ def test_create_case_metadata_runs_successfully(fmu_snakeoil_project, monkeypatc
 
     with open(fmu_case_yml, encoding="utf-8") as f:
         fmu_case = yaml.safe_load(f)
+
     assert fmu_case["fmu"]["case"]["name"] == "snakeoil"
     assert fmu_case["fmu"]["case"]["user"]["id"] == "user"
     assert fmu_case["source"] == "fmu"
+    assert len(fmu_case["tracklog"]) == 1
+    assert fmu_case["tracklog"][0]["user"]["id"] == getpass.getuser()
+
+
+def test_create_case_metadata_warns_without_overwriting(
+    fmu_snakeoil_project, monkeypatch, mocker
+):
+    monkeypatch.chdir(fmu_snakeoil_project / "ert/model")
+    _add_create_case_workflow("snakeoil.ert")
+
+    share_metadata = fmu_snakeoil_project / "scratch/user/snakeoil/share/metadata"
+    fmu_case_yml = share_metadata / "fmu_case.yml"
+
+    mocker.patch(
+        "sys.argv", ["ert", "test_run", "snakeoil.ert", "--disable-monitoring"]
+    )
+    ert.__main__.main()
+
+    assert fmu_case_yml.exists()
+    with open(fmu_case_yml, encoding="utf-8") as f:
+        first_run = yaml.safe_load(f)
+
+    with pytest.warns(UserWarning, match="The case metadata file already exists"):
+        ert.__main__.main()
+
+    ls_share_metadata = os.listdir(share_metadata)
+    assert ls_share_metadata == ["fmu_case.yml"]
+
+    with open(fmu_case_yml, encoding="utf-8") as f:
+        second_run = yaml.safe_load(f)
+
+    assert first_run == second_run
+
+
+@pytest.mark.skipif(
+    sys.version_info[:2] == (3, 12),
+    reason="fmu-sumo-uploader not compatible with Python 3.12",
+)
+def test_create_case_metadata_enable_mocked_sumo(
+    fmu_snakeoil_project, monkeypatch, mocker, mock_sumo_uploader
+):
+    with open(
+        fmu_snakeoil_project / "ert/bin/workflows/xhook_create_case_metadata",
+        "a",
+        encoding="utf-8",
+    ) as f:
+        f.write(' "--sumo" "--sumo_env" <SUMO_ENV>')
+
+    monkeypatch.chdir(fmu_snakeoil_project / "ert/model")
+    _add_create_case_workflow("snakeoil.ert")
+
+    mocker.patch(
+        "sys.argv", ["ert", "test_run", "snakeoil.ert", "--disable-monitoring"]
+    )
+    ert.__main__.main()
+
+    # Verifies case.register() was run
+    with open("sumo_case_id", encoding="utf-8") as f:
+        assert f.read() == "1"

--- a/tests/test_units/test_initialize_case.py
+++ b/tests/test_units/test_initialize_case.py
@@ -145,7 +145,7 @@ def test_inicase_generate_case_metadata_exists_so_fails(
     casemetafolder = fmurun_w_casemetadata.parent.parent
 
     icase = InitializeCase(globalconfig2)
-    with pytest.warns(UserWarning, match=r"The metadata file already exist!"):
+    with pytest.warns(UserWarning, match=r"The case metadata file already exists"):
         icase.generate_case_metadata(rootfolder=casemetafolder)
 
 


### PR DESCRIPTION
Adds to #263 

Running ERT is slow, may be advantageous to add pytest-xdist at some point soon -- but I don't think we're over the threshold where it would make things faster yet.

fmu-sumo-uploader cannot be installed on Python 3.12 due to a dependency on openvds, which does not support Python 3.12, and apparently installation conditions cannot be applied from optional dependencies. This is complicated by fmu-sumo-uploader not being available on PyPI.

So the options are
- Skip adding it to optional dev dependencies and conditional handling in CI, incurring a manual installation
- Skip testing on Python 3.12 in CI