### PR TITLE
CLN: Simplify `InitializeCase`

### DIFF
--- a/src/fmu/dataio/scripts/create_case_metadata.py
+++ b/src/fmu/dataio/scripts/create_case_metadata.py
@@ -115,19 +115,12 @@ def create_metadata(args: argparse.Namespace) -> str:
     ) as f:
         global_variables = yaml.safe_load(f)
 
-    # fmu.dataio.InitializeCase class is scheduled to be renamed.
-    case = InitializeCase(config=global_variables)
-    case_metadata_path = case.export(
+    return InitializeCase(
+        config=global_variables,
         rootfolder=args.ert_caseroot,
         casename=args.ert_casename,
         caseuser=args.ert_username,
-        description=None,  # type: ignore
-        # BUG(JB): description must be str accoring to dataclass
-    )
-
-    logger.info("Case metadata has been made: %s", case_metadata_path)
-    assert case_metadata_path is not None
-    return case_metadata_path
+    ).export()
 
 
 def register_on_sumo(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,21 +20,21 @@ from .utils import _metadata_examples
 
 logger = logging.getLogger(__name__)
 
-RUN1 = "tests/data/drogon/ertrun1/realization-0/iter-0"
-RUN2 = "tests/data/drogon/ertrun1"
-RUN_PRED = "tests/data/drogon/ertrun1/realization-0/pred"
+ERTRUN = "tests/data/drogon/ertrun1"
+ERTRUN_REAL0_ITER0 = f"{ERTRUN}/realization-0/iter-0"
+ERTRUN_PRED = f"{ERTRUN}/realization-0/pred"
 
-RUN1_ENV_PREHOOK = {
+ERTRUN_ENV_PREHOOK = {
     f"_ERT_{FmuEnv.EXPERIMENT_ID.name}": "6a8e1e0f-9315-46bb-9648-8de87151f4c7",
     f"_ERT_{FmuEnv.ENSEMBLE_ID.name}": "b027f225-c45d-477d-8f33-73695217ba14",
     f"_ERT_{FmuEnv.SIMULATION_MODE.name}": "test_run",
 }
-RUN1_ENV_FORWARD = {
+ERTRUN_ENV_FORWARD = {
     f"_ERT_{FmuEnv.ITERATION_NUMBER.name}": "0",
     f"_ERT_{FmuEnv.REALIZATION_NUMBER.name}": "0",
     f"_ERT_{FmuEnv.RUNPATH.name}": "---",  # set dynamically due to pytest tmp rotation
 }
-RUN1_ENV_FULLRUN = {**RUN1_ENV_PREHOOK, **RUN1_ENV_FORWARD}
+ERTRUN_ENV_FULLRUN = {**ERTRUN_ENV_PREHOOK, **ERTRUN_ENV_FORWARD}
 
 ERT_RUNPATH = f"_ERT_{FmuEnv.RUNPATH.name}"
 
@@ -65,19 +65,19 @@ def _fmu_run1_env_variables(monkeypatch, usepath="", case_only=False):
     Will here monkeypatch the ENV variables, with a particular setting for RUNPATH
     (trough `usepath`) which may vary dynamically due to pytest tmp area rotation.
     """
-    env = RUN1_ENV_FULLRUN if not case_only else RUN1_ENV_PREHOOK
+    env = ERTRUN_ENV_FULLRUN if not case_only else ERTRUN_ENV_PREHOOK
     for key, value in env.items():
         env_value = str(usepath) if "RUNPATH" in key else value
         monkeypatch.setenv(key, env_value)
         logger.debug("Setting env %s as %s", key, env_value)
 
 
-@pytest.fixture(name="fmurun", scope="function")
-def fixture_fmurun(tmp_path_factory, monkeypatch, rootpath):
+@pytest.fixture(scope="function")
+def fmurun(tmp_path_factory, monkeypatch, rootpath):
     """A tmp folder structure for testing; here a new fmurun without case metadata."""
     tmppath = tmp_path_factory.mktemp("data")
-    newpath = tmppath / RUN1
-    shutil.copytree(rootpath / RUN1, newpath)
+    newpath = tmppath / ERTRUN_REAL0_ITER0
+    shutil.copytree(rootpath / ERTRUN_REAL0_ITER0, newpath)
 
     _fmu_run1_env_variables(monkeypatch, usepath=newpath, case_only=False)
 
@@ -89,8 +89,8 @@ def fixture_fmurun(tmp_path_factory, monkeypatch, rootpath):
 def fixture_fmurun_prehook(tmp_path_factory, monkeypatch, rootpath):
     """A tmp folder structure for testing; here a new fmurun without case metadata."""
     tmppath = tmp_path_factory.mktemp("data")
-    newpath = tmppath / RUN2
-    shutil.copytree(rootpath / RUN2, newpath)
+    newpath = tmppath / ERTRUN
+    shutil.copytree(rootpath / ERTRUN, newpath)
 
     _fmu_run1_env_variables(monkeypatch, usepath=newpath, case_only=True)
 
@@ -102,8 +102,8 @@ def fixture_fmurun_prehook(tmp_path_factory, monkeypatch, rootpath):
 def fixture_fmurun_w_casemetadata(tmp_path_factory, monkeypatch, rootpath):
     """Create a tmp folder structure for testing; here existing fmurun w/ case meta!"""
     tmppath = tmp_path_factory.mktemp("data3")
-    newpath = tmppath / RUN2
-    shutil.copytree(rootpath / RUN2, newpath)
+    newpath = tmppath / ERTRUN
+    shutil.copytree(rootpath / ERTRUN, newpath)
     rootpath = newpath / "realization-0/iter-0"
 
     _fmu_run1_env_variables(monkeypatch, usepath=rootpath, case_only=False)
@@ -116,8 +116,8 @@ def fixture_fmurun_w_casemetadata(tmp_path_factory, monkeypatch, rootpath):
 def fixture_fmurun_w_casemetadata_pred(tmp_path_factory, monkeypatch, rootpath):
     """Create a tmp folder structure for testing; here existing fmurun w/ case meta!"""
     tmppath = tmp_path_factory.mktemp("data3")
-    newpath = tmppath / RUN2
-    shutil.copytree(rootpath / RUN2, newpath)
+    newpath = tmppath / ERTRUN
+    shutil.copytree(rootpath / ERTRUN, newpath)
     rootpath = newpath / "realization-0/pred"
 
     _fmu_run1_env_variables(monkeypatch, usepath=rootpath, case_only=False)
@@ -130,8 +130,8 @@ def fixture_fmurun_w_casemetadata_pred(tmp_path_factory, monkeypatch, rootpath):
 def fixture_fmurun_pred(tmp_path_factory, rootpath):
     """Create a tmp folder structure for testing; here a new fmurun for prediction."""
     tmppath = tmp_path_factory.mktemp("data_pred")
-    newpath = tmppath / RUN_PRED
-    shutil.copytree(rootpath / RUN_PRED, newpath)
+    newpath = tmppath / ERTRUN_PRED
+    shutil.copytree(rootpath / ERTRUN_PRED, newpath)
     logger.debug("Ran %s", _current_function_name())
     return newpath
 
@@ -144,8 +144,8 @@ def fixture_rmsrun_fmu_w_casemetadata(tmp_path_factory, rootpath):
     in a FMU setup where case metadata are present
     """
     tmppath = tmp_path_factory.mktemp("data3")
-    newpath = tmppath / RUN2
-    shutil.copytree(rootpath / RUN2, newpath)
+    newpath = tmppath / ERTRUN
+    shutil.copytree(rootpath / ERTRUN, newpath)
     rmspath = newpath / "realization-0/iter-0/rms/model"
     rmspath.mkdir(parents=True, exist_ok=True)
     logger.debug("Active folder is %s", rmspath)

--- a/tests/test_units/test_fmuprovider_class.py
+++ b/tests/test_units/test_fmuprovider_class.py
@@ -123,25 +123,25 @@ def test_fmuprovider_prehook_case(tmp_path, globalconfig2, fmurun_prehook):
     I *may* be that this behaviour can be removed in near future, since the ERT env
     variables now will tell us that this is an active ERT run.
     """
-
-    icase = dataio.InitializeCase(config=globalconfig2)
-
     caseroot = tmp_path / "prehook"
     caseroot.mkdir(parents=True)
-
     os.chdir(caseroot)
 
-    exp = icase.export(
+    icase = dataio.InitializeCase(
+        config=globalconfig2,
         rootfolder=caseroot,
         casename="MyCaseName",
         caseuser="MyUser",
         description="Some description",
     )
+    exp = icase.export()
+
     casemetafile = caseroot / "share/metadata/fmu_case.yml"
+
     assert casemetafile.is_file()
     assert exp == str(casemetafile.resolve())
-    os.chdir(fmurun_prehook)
 
+    os.chdir(fmurun_prehook)
     logger.debug("Case root proposed is: %s", caseroot)
     myfmu = FmuProvider(
         model="Model567",


### PR DESCRIPTION
Resolves #264 

This class had functionality built into it that did not end up being used or may have been undesirable to allow users to use (hence was not used). This functionality was cleaned up, the tests adjusted, and some other tweaks and adjustments.

The items removed that were marked deprecated should be OK to delete as they were relevant only to the create_case_data.py workflow job and not used or imported by users. The workflow job did not use these items.