### PR TITLE
FIX: Remove discriminator mappings

### DIFF
--- a/schema/definitions/0.8.0/schema/fmu_meta.json
+++ b/schema/definitions/0.8.0/schema/fmu_meta.json
@@ -129,33 +129,6 @@
         }
       },
       "discriminator": {
-        "mapping": {
-          "depth": "#/$defs/DepthContent",
-          "facies_thickness": "#/$defs/FaciesThicknessContent",
-          "fault_lines": "#/$defs/FaultLinesContent",
-          "field_outline": "#/$defs/FieldOutlineContent",
-          "field_region": "#/$defs/FieldRegionContent",
-          "fluid_contact": "#/$defs/FluidContactContent",
-          "inplace_volumes": "#/$defs/InplaceVolumesContent",
-          "khproduct": "#/$defs/KPProductContent",
-          "lift_curves": "#/$defs/LiftCurvesContent",
-          "parameters": "#/$defs/ParametersContent",
-          "pinchout": "#/$defs/PinchoutContent",
-          "property": "#/$defs/PropertyContent",
-          "pvt": "#/$defs/PVTContent",
-          "regions": "#/$defs/RegionsContent",
-          "relperm": "#/$defs/RelpermContent",
-          "rft": "#/$defs/RFTContent",
-          "seismic": "#/$defs/SeismicContent",
-          "subcrop": "#/$defs/SubcropContent",
-          "thickness": "#/$defs/ThicknessContent",
-          "time": "#/$defs/TimeContent",
-          "timeseries": "#/$defs/TimeSeriesContent",
-          "velocity": "#/$defs/VelocityContent",
-          "volumes": "#/$defs/VolumesContent",
-          "volumetrics": "#/$defs/VolumetricsContent",
-          "wellpicks": "#/$defs/WellPicksContent"
-        },
         "propertyName": "content"
       },
       "oneOf": [
@@ -8409,18 +8382,6 @@
   "$id": "fmu_meta.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "discriminator": {
-    "mapping": {
-      "case": "#/$defs/FMUCaseClassMeta",
-      "cpgrid": "#/$defs/FMUDataClassMeta",
-      "cpgrid_property": "#/$defs/FMUDataClassMeta",
-      "cube": "#/$defs/FMUDataClassMeta",
-      "dictionary": "#/$defs/FMUDataClassMeta",
-      "points": "#/$defs/FMUDataClassMeta",
-      "polygons": "#/$defs/FMUDataClassMeta",
-      "surface": "#/$defs/FMUDataClassMeta",
-      "table": "#/$defs/FMUDataClassMeta",
-      "well": "#/$defs/FMUDataClassMeta"
-    },
     "propertyName": "class"
   },
   "if": {

--- a/src/fmu/dataio/datastructure/meta/meta.py
+++ b/src/fmu/dataio/datastructure/meta/meta.py
@@ -469,6 +469,19 @@ class Root(
         return json_schema
 
 
+def _remove_discriminator_mapping(obj: Dict) -> Dict:
+    """
+    Modifies a provided JSON schema object by specifically
+    removing the `discriminator.mapping` fields. This alteration aims
+    to ensure compatibility with the AJV Validator by addressing and
+    resolving schema validation errors that previously led to startup
+    failures in applications like `sumo-core`.
+    """
+    del obj["discriminator"]["mapping"]
+    del obj["$defs"]["AnyContent"]["discriminator"]["mapping"]
+    return obj
+
+
 def dump() -> Dict:
     # ruff: noqa: E501
     """
@@ -487,50 +500,53 @@ def dump() -> Dict:
             them to maintain schema consistency.
     """
 
-    return dict(
-        ChainMap(
-            {
-                "$contractual": [
-                    "class",
-                    "source",
-                    "version",
-                    "tracklog",
-                    "data.format",
-                    "data.name",
-                    "data.stratigraphic",
-                    "data.alias",
-                    "data.stratigraphic_alias",
-                    "data.offset",
-                    "data.content",
-                    "data.tagname",
-                    "data.vertical_domain",
-                    "data.grid_model",
-                    "data.bbox",
-                    "data.time",
-                    "data.is_prediction",
-                    "data.is_observation",
-                    "data.seismic.attribute",
-                    "data.spec.columns",
-                    "access",
-                    "masterdata",
-                    "fmu.model",
-                    "fmu.workflow",
-                    "fmu.case",
-                    "fmu.iteration.name",
-                    "fmu.iteration.uuid",
-                    "fmu.realization.name",
-                    "fmu.realization.id",
-                    "fmu.realization.uuid",
-                    "fmu.aggregation.operation",
-                    "fmu.aggregation.realization_ids",
-                    "fmu.context.stage",
-                    "file.relative_path",
-                    "file.checksum_md5",
-                    "file.size_bytes",
-                ],
-                "$schema": "https://json-schema.org/draft/2020-12/schema",
-                "$id": "fmu_meta.json",
-            },
-            Root.model_json_schema(),
+    return _remove_discriminator_mapping(
+        dict(
+            ChainMap(
+                {
+                    "$contractual": [
+                        "class",
+                        "source",
+                        "version",
+                        "tracklog",
+                        "data.format",
+                        "data.name",
+                        "data.stratigraphic",
+                        "data.alias",
+                        "data.stratigraphic_alias",
+                        "data.offset",
+                        "data.content",
+                        "data.tagname",
+                        "data.vertical_domain",
+                        "data.grid_model",
+                        "data.bbox",
+                        "data.time",
+                        "data.is_prediction",
+                        "data.is_observation",
+                        "data.seismic.attribute",
+                        "data.spec.columns",
+                        "access",
+                        "masterdata",
+                        "fmu.model",
+                        "fmu.workflow",
+                        "fmu.case",
+                        "fmu.iteration.name",
+                        "fmu.iteration.uuid",
+                        "fmu.realization.name",
+                        "fmu.realization.id",
+                        "fmu.realization.uuid",
+                        "fmu.aggregation.operation",
+                        "fmu.aggregation.realization_ids",
+                        "fmu.context.stage",
+                        "file.relative_path",
+                        "file.checksum_md5",
+                        "file.size_bytes",
+                    ],
+                    # schema must be present for "dependencies" key to work.
+                    "$schema": "https://json-schema.org/draft/2020-12/schema",
+                    "$id": "fmu_meta.json",
+                },
+                Root.model_json_schema(),
+            )
         )
     )


### PR DESCRIPTION
Extends: #423 

## Summary
The PR addresses compatibility issues with our JSON schema by removing the `discriminator.mapping` field. This change is necessary to resolve startup failures in `sumo-core` due to schema validation errors with our current JSON schema validator (AJV Validator).

## Change
- **Removed `discriminator.mapping`**: Eliminates validation issues, ensuring compatibility with AJV Validator and preventing `sumo-core` startup failures.

For details see: https://equinor.slack.com/archives/C06E3UTGTEV/p1710159496935799