### PR TITLE
CLN: Silence pydantic url str warning

### DIFF
--- a/src/fmu/dataio/datastructure/_internal/internal.py
+++ b/src/fmu/dataio/datastructure/_internal/internal.py
@@ -17,7 +17,7 @@ from fmu.dataio.datastructure.configuration.global_configuration import (
     Model as GlobalConfigurationModel,
 )
 from fmu.dataio.datastructure.meta.meta import Access, Masterdata, TracklogEvent, User
-from pydantic import AnyHttpUrl, BaseModel, Field, model_validator
+from pydantic import AnyHttpUrl, BaseModel, Field, TypeAdapter, model_validator
 
 
 def seismic_warn() -> None:
@@ -143,7 +143,10 @@ class AllowedContent(BaseModel):
 
 
 class JsonSchemaMetadata(BaseModel, populate_by_name=True):
-    schema_: AnyHttpUrl = Field(alias="$schema", default=SCHEMA)
+    schema_: AnyHttpUrl = Field(
+        alias="$schema",
+        default=TypeAdapter(AnyHttpUrl).validate_python(SCHEMA),
+    )
     version: str = Field(default=VERSION)
     source: str = Field(default=SOURCE)
 


### PR DESCRIPTION
Rebase and merge after: https://github.com/equinor/fmu-dataio/pull/519

```bash
======================================== warnings summary =========================================
tests/test_units/test_fmuprovider_class.py::test_fmuprovider_prehook_case
  /Users/JLOV/.pyenv/versions/3.10.13/envs/dataio/lib/python3.10/site-packages/pydantic/main.py:314: UserWarning: Pydantic serializer warnings:
    Expected `url` but got `str` - serialized value may not be as expected
    return self.__pydantic_serializer__.to_python(
```