### PR TITLE
CLN: Move fmu_context validation for non-fmu runs to ExportData

### DIFF
--- a/src/fmu/dataio/_fmu_provider.py
+++ b/src/fmu/dataio/_fmu_provider.py
@@ -114,6 +114,9 @@ class FmuProvider:
         logger.debug("FMU context is <%s>...", self.fmu_context)
 
         if not FmuEnv.ENSEMBLE_ID.value:
+            logger.debug(
+                "No ERT environment variables detected, provider will be empty"
+            )
             return  # not an FMU run
 
         self._provider = "ERT"

--- a/src/fmu/dataio/_metadata.py
+++ b/src/fmu/dataio/_metadata.py
@@ -292,26 +292,10 @@ class MetaData:
         )
         logger.info("FMU provider is %s", fmudata.get_provider())
 
-        if not fmudata.get_provider():  # e.g. run from RMS not in a FMU run
-            actual_context = (
-                FmuContext.PREPROCESSED
-                if self.dataio.fmu_context == FmuContext.PREPROCESSED
-                else FmuContext.get("non_fmu")
-            )
-            if self.dataio.fmu_context != actual_context:
-                logger.warning(
-                    "Requested fmu_context is <%s> but since this is detected as a non "
-                    "FMU run, the actual context is force set to <%s>",
-                    self.dataio.fmu_context,
-                    actual_context,
-                )
-                self.dataio.fmu_context = actual_context
-
-        else:
-            self.meta_fmu = fmudata.get_metadata()
-            self.rootpath = fmudata.get_casepath()
-            self.iter_name = fmudata.get_iter_name()
-            self.real_name = fmudata.get_real_name()
+        self.meta_fmu = fmudata.get_metadata()
+        self.rootpath = fmudata.get_casepath()
+        self.iter_name = fmudata.get_iter_name()
+        self.real_name = fmudata.get_real_name()
 
         logger.debug("Rootpath is now %s", self.rootpath)
 
@@ -449,10 +433,12 @@ class MetaData:
             self._populate_meta_masterdata()
             self._populate_meta_access()
 
+        if self.dataio._fmurun:
+            self._populate_meta_fmu()
+
         self._populate_meta_tracklog()
         self._populate_meta_objectdata()
         self._populate_meta_class()
-        self._populate_meta_fmu()
         self._populate_meta_file()
         self._populate_meta_display()
         self._populate_meta_xpreprocessed()


### PR DESCRIPTION
Resolves #529 and adds a `ExportData._fmurun` attribute to eliminate the need for initializing a FmuProvider to detect the run environment.