### PR TITLE
FIX: Avoid overwriting config from env if explicitly given

### DIFF
--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -474,8 +474,9 @@ class ExportData:
                 "disable this warning, remove the 'FMU_DATAIO_CONFIG' env.",
             )
 
-        # global config which may be given as env variable -> a file; will override
-        if GLOBAL_ENVNAME in os.environ:
+        # global config which may be given as env variable
+        # will only be used if not explicitly given as input
+        if not self.config and GLOBAL_ENVNAME in os.environ:
             self.config = some_config_from_env(GLOBAL_ENVNAME) or {}
 
         self._validate_content_key()

--- a/tests/test_units/test_dataio.py
+++ b/tests/test_units/test_dataio.py
@@ -325,11 +325,17 @@ def test_set_display_name(regsurf, globalconfig2):
     assert mymeta["display"]["name"] == "MyOtherDisplayName"
 
 
-def test_global_config_from_env(monkeypatch, global_config2_path):
+def test_global_config_from_env(monkeypatch, global_config2_path, globalconfig1):
     """Testing getting global config from a file"""
     monkeypatch.setenv("FMU_GLOBAL_CONFIG", str(global_config2_path))
+
     edata = ExportData(content="depth")  # the env variable will override this
     assert "smda" in edata.config["masterdata"]
+    assert edata.config["model"]["name"] == "ff"
+
+    # do not use global config from environment when explicitly given
+    edata = ExportData(config=globalconfig1, content="depth")
+    assert edata.config["model"]["name"] == "Test"
 
 
 def test_norwegian_letters_globalconfig(


### PR DESCRIPTION
Prevent overwriting config from environment variable if explicitly given as input argument to ExportData, to avoid confusing behavior for the user.