### PR TITLE
CLN: Change to Path inside FileDataProvider

### DIFF
--- a/src/fmu/dataio/_metadata.py
+++ b/src/fmu/dataio/_metadata.py
@@ -232,15 +232,11 @@ class MetaData:
             checksum_md5 = None
 
         self.meta_file = meta.File(
-            absolute_path=Path(fdata.absolute_path),
-            relative_path=Path(fdata.relative_path),
+            absolute_path=fdata.absolute_path,
+            relative_path=fdata.relative_path,
             checksum_md5=checksum_md5,
-            relative_path_symlink=Path(fdata.relative_path_symlink)
-            if fdata.relative_path_symlink
-            else None,
-            absolute_path_symlink=Path(fdata.absolute_path_symlink)
-            if fdata.absolute_path_symlink
-            else None,
+            relative_path_symlink=fdata.relative_path_symlink,
+            absolute_path_symlink=fdata.absolute_path_symlink,
         ).model_dump(
             mode="json",
             exclude_none=True,

--- a/src/fmu/dataio/providers/_filedata.py
+++ b/src/fmu/dataio/providers/_filedata.py
@@ -42,11 +42,11 @@ class FileDataProvider:
     realname: str = ""
 
     # storing results in these variables
-    relative_path: str = field(default="", init=False)
-    relative_path_symlink: Optional[str] = field(default="", init=False)
+    relative_path: Path = field(default_factory=Path)
+    relative_path_symlink: Optional[Path] = field(default=None)
 
-    absolute_path: str = field(default="", init=False)
-    absolute_path_symlink: Optional[str] = field(default="", init=False)
+    absolute_path: Path = field(default_factory=Path)
+    absolute_path_symlink: Optional[Path] = field(default=None)
 
     checksum_md5: Optional[str] = field(default="", init=False)
     forcefolder_is_absolute: bool = field(default=False, init=False)
@@ -68,7 +68,7 @@ class FileDataProvider:
 
         logger.info("Derived filedata")
 
-    def _derive_filedata_generic(self, inrelpath: Path) -> tuple[str, str]:
+    def _derive_filedata_generic(self, inrelpath: Path) -> tuple[Path, Path]:
         """This works with both normal data and symlinks."""
         stem = self._get_filestem()
 
@@ -104,7 +104,7 @@ class FileDataProvider:
             relpath = path.relative_to(self.rootpath)
 
         logger.info("Derived filedata")
-        return str(relpath), str(abspath)
+        return relpath, abspath
 
     def _get_filestem(self) -> str:
         """Construct the file"""

--- a/tests/test_units/test_filedataprovider_class.py
+++ b/tests/test_units/test_filedataprovider_class.py
@@ -227,8 +227,10 @@ def test_filedata_provider(regsurf, edataobj1, tmp_path):
     fdata.derive_filedata()
 
     print(fdata.relative_path)
-    assert fdata.relative_path == "share/results/efolder/parent--name--tag--t2_t1.ext"
-    absdata = str(tmp_path / "share/results/efolder/parent--name--tag--t2_t1.ext")
+    assert (
+        str(fdata.relative_path) == "share/results/efolder/parent--name--tag--t2_t1.ext"
+    )
+    absdata = tmp_path / "share/results/efolder/parent--name--tag--t2_t1.ext"
     assert fdata.absolute_path == absdata
 
 


### PR DESCRIPTION
Return `Path` instead of strings in the `FileDataProvider`. The meta.File pydantic model expects Path as input. 