### PR TITLE
CLN: Use pydantic for internal MetaData 

### DIFF
--- a/src/fmu/dataio/_metadata.py
+++ b/src/fmu/dataio/_metadata.py
@@ -2,7 +2,6 @@
 
 This contains the _MetaData class which collects and holds all relevant metadata
 """
-# https://realpython.com/python-data-classes/#basic-data-classes
 
 from __future__ import annotations
 
@@ -10,7 +9,6 @@ import datetime
 import getpass
 import os
 import platform
-from dataclasses import dataclass, field
 from datetime import timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Final
@@ -26,7 +24,6 @@ from ._utils import (
     read_metadata_from_file,
 )
 from .datastructure._internal import internal
-from .datastructure.configuration import global_configuration
 from .datastructure.meta import meta
 from .providers._filedata import FileDataProvider
 from .providers._fmu import FmuProvider
@@ -35,23 +32,9 @@ from .version import __version__
 
 if TYPE_CHECKING:
     from .dataio import ExportData
-    from .providers._objectdata_base import ObjectDataProvider
+    from .providers.objectdata._base import ObjectDataProvider
 
 logger: Final = null_logger(__name__)
-
-
-# Generic, being resused several places:
-
-
-def default_meta_dollars() -> dict[str, str]:
-    return internal.JsonSchemaMetadata(
-        schema_=TypeAdapter(AnyHttpUrl).validate_strings(SCHEMA),  # type: ignore[call-arg]
-        version=VERSION,
-        source=SOURCE,
-    ).model_dump(
-        mode="json",
-        by_alias=True,
-    )
 
 
 def generate_meta_tracklog() -> list[meta.TracklogEvent]:
@@ -78,9 +61,77 @@ def generate_meta_tracklog() -> list[meta.TracklogEvent]:
     ]
 
 
-@dataclass
-class MetaData:
-    """Class for sampling, process and holding all metadata in an ExportData instance.
+def _get_objectdata_provider(
+    obj: types.Inferrable, dataio: ExportData, meta_existing: dict | None = None
+) -> ObjectDataProvider:
+    """Derive metadata for the object. Reuse metadata if existing"""
+    objdata = objectdata_provider_factory(obj, dataio, meta_existing)
+    objdata.derive_metadata()
+    return objdata
+
+
+def _get_filedata_provider(
+    dataio: ExportData,
+    obj: types.Inferrable,
+    objdata: ObjectDataProvider,
+    fmudata: FmuProvider | None,
+    compute_md5: bool,
+) -> FileDataProvider:
+    """Derive metadata for the file."""
+    return FileDataProvider(
+        dataio=dataio,
+        objdata=objdata,
+        rootpath=dataio._rootpath,  # has been updated to case_path if fmurun
+        itername=fmudata.get_iter_name() if fmudata else "",
+        realname=fmudata.get_real_name() if fmudata else "",
+        obj=obj,
+        compute_md5=compute_md5,
+    )
+
+
+def _get_meta_objectdata(
+    objdata: ObjectDataProvider,
+) -> meta.content.AnyContent | internal.UnsetAnyContent:
+    return (
+        internal.UnsetAnyContent.model_validate(objdata.metadata)
+        if objdata.metadata["content"] == "unset"
+        else meta.content.AnyContent.model_validate(objdata.metadata)
+    )
+
+
+def _get_meta_access(access: dict) -> meta.SsdlAccess:
+    return meta.SsdlAccess.model_validate(access)
+
+
+def _get_meta_masterdata(masterdata: dict) -> meta.Masterdata:
+    return meta.Masterdata.model_validate(masterdata)
+
+
+def _get_meta_fmu(fmudata: FmuProvider) -> internal.FMUClassMetaData:
+    return internal.FMUClassMetaData.model_validate(fmudata.get_metadata())
+
+
+def _get_meta_display(dataio: ExportData, objdata: ObjectDataProvider) -> meta.Display:
+    return meta.Display(name=dataio.display_name or objdata.name)
+
+
+def _get_meta_preprocessed_info(dataio: ExportData) -> internal.PreprocessedInfo:
+    return internal.PreprocessedInfo(
+        name=dataio.name,
+        tagname=dataio.tagname,
+        subfolder=dataio.subfolder,
+    )
+
+
+def generate_export_metadata(
+    obj: types.Inferrable,
+    dataio: ExportData,
+    fmudata: FmuProvider | None = None,
+    compute_md5: bool = True,
+    skip_null: bool = True,
+) -> dict:  # TODO! -> skip_null?
+    """
+    Main function to generate the full metadata
 
     Metadata has basically these different providers:
 
@@ -106,215 +157,39 @@ class MetaData:
 
     """
 
-    # input variables
-    obj: types.Inferrable
-    dataio: ExportData
-    compute_md5: bool = True
+    meta_existing = None
+    if isinstance(obj, (str, Path)) and dataio._reuse_metadata:
+        logger.info("Partially reuse existing metadata from %s", obj)
+        meta_existing = read_metadata_from_file(obj)
 
-    # storage state variables
-    objdata: ObjectDataProvider | None = field(default=None, init=False)
-    fmudata: FmuProvider | None = field(default=None, init=False)
-    iter_name: str = field(default="", init=False)
-    real_name: str = field(default="", init=False)
+    objdata = _get_objectdata_provider(obj, dataio, meta_existing)
+    filedata = _get_filedata_provider(dataio, obj, objdata, fmudata, compute_md5)
 
-    meta_class: str = field(default="", init=False)
-    meta_masterdata: dict = field(default_factory=dict, init=False)
-    meta_objectdata: dict = field(default_factory=dict, init=False)
-    meta_dollars: dict = field(default_factory=default_meta_dollars, init=False)
-    meta_access: dict = field(default_factory=dict, init=False)
-    meta_file: dict = field(default_factory=dict, init=False)
-    meta_tracklog: list = field(default_factory=list, init=False)
-    meta_fmu: dict = field(default_factory=dict, init=False)
-    # temporary storage for preprocessed data:
-    meta_xpreprocessed: dict = field(default_factory=dict, init=False)
+    masterdata = dataio.config.get("masterdata")
+    access = dataio.config.get("access")
 
-    # relevant when ERT* fmu_context; same as rootpath in the ExportData class!:
-    rootpath: str = field(default="", init=False)
+    metadata = internal.DataClassMeta(
+        schema_=TypeAdapter(AnyHttpUrl).validate_strings(SCHEMA),  # type: ignore[call-arg]
+        version=VERSION,
+        source=SOURCE,
+        class_=objdata.classname,
+        fmu=_get_meta_fmu(fmudata) if fmudata else None,
+        masterdata=_get_meta_masterdata(masterdata) if masterdata else None,
+        access=_get_meta_access(access) if access else None,
+        data=_get_meta_objectdata(objdata),
+        file=filedata.get_metadata(),
+        tracklog=generate_meta_tracklog(),
+        display=_get_meta_display(dataio, objdata),
+        preprocessed=_get_meta_preprocessed_info(dataio)
+        if dataio.fmu_context == FmuContext.PREPROCESSED
+        else None,
+    ).model_dump(mode="json", exclude_none=True, by_alias=True)
 
-    # if re-using existing metadata
-    meta_existing: dict = field(default_factory=dict, init=False)
+    if skip_null:
+        metadata = drop_nones(metadata)
 
-    def __post_init__(self) -> None:
-        logger.info("Initialize _MetaData instance.")
-
-        # one special case is that obj is a file path.
-        # In this case we read the existing metadata here and reuse parts
-        if isinstance(self.obj, (str, Path)) and self.dataio._reuse_metadata:
-            logger.info("Partially reuse existing metadata from %s", self.obj)
-            self.meta_existing = read_metadata_from_file(self.obj)
-
-        self.rootpath = str(self.dataio._rootpath.absolute())
-
-    def _populate_meta_objectdata(self) -> None:
-        """Analyze the actual object together with input settings.
-
-        This will provide input to the ``data`` block of the metas but has also
-        valuable settings which are needed when providing filedata etc.
-
-        Hence this must be ran early or first.
-        """
-        self.objdata = objectdata_provider_factory(
-            self.obj, self.dataio, self.meta_existing
-        )
-        self.objdata.derive_metadata()
-        self.meta_objectdata = self.objdata.metadata
-
-    def _populate_meta_fmu(self) -> None:
-        """Populate the fmu block in the metadata.
-
-        This block may be missing in case the client is not within a FMU run, e.g.
-        it runs from RMS interactive
-
-        The _FmuDataProvider is ran to provide this information
-        """
-        fmudata = FmuProvider(
-            model=self.dataio.config.get("model", None),
-            fmu_context=FmuContext.get(self.dataio.fmu_context),
-            casepath_proposed=self.dataio.casepath or "",
-            include_ertjobs=self.dataio.include_ertjobs,
-            forced_realization=self.dataio.realization,
-            workflow=self.dataio.workflow,
-        )
-        logger.info("FMU provider is %s", fmudata.get_provider())
-
-        self.meta_fmu = fmudata.get_metadata()
-        self.rootpath = fmudata.get_casepath()
-        self.iter_name = fmudata.get_iter_name()
-        self.real_name = fmudata.get_real_name()
-
-        logger.debug("Rootpath is now %s", self.rootpath)
-
-    def _populate_meta_file(self) -> None:
-        """Populate the file block in the metadata.
-
-        The file block also contains all needed info for doing the actual file export.
-
-        It requires that the _ObjectDataProvider is ran first -> self.objdata
-
-        - relative_path, seen from rootpath
-        - absolute_path, as above but full path
-        - checksum_md5, if required (a bit special treatment of this)
-
-        In additional _optional_ symlink adresses
-        - relative_path_symlink, seen from rootpath
-        - absolute_path_symlink, as above but full path
-        """
-
-        assert self.objdata is not None
-
-        fdata = FileDataProvider(
-            dataio=self.dataio,
-            obj=self.obj,
-            objdata=self.objdata,
-            rootpath=Path(self.rootpath),
-            itername=self.iter_name,
-            realname=self.real_name,
-            compute_md5=self.compute_md5,
-        )
-        self.meta_file = fdata.get_metadata().model_dump(mode="json", exclude_none=True)
-
-    def _populate_meta_class(self) -> None:
-        """Get the general class which is a simple string."""
-        assert self.objdata is not None
-        self.meta_class = self.objdata.classname
-
-    def _populate_meta_tracklog(self) -> None:
-        """Create the tracklog metadata, which here assumes 'created' only."""
-        self.meta_tracklog = [
-            x.model_dump(mode="json", exclude_none=True, by_alias=True)
-            for x in generate_meta_tracklog()
-        ]
-
-    def _populate_meta_masterdata(self) -> None:
-        """Populate metadata from masterdata section in config."""
-        self.meta_masterdata = self.dataio.config.get("masterdata", {})
-
-    def _populate_meta_access(self) -> None:
-        """Populate metadata overall from access section in config + allowed keys.
-
-        Access should be possible to change per object, based on user input.
-        This is done through the access_ssdl input argument.
-
-        The "asset" field shall come from the config. This is static information.
-
-        The "ssdl" field can come from the config, or be explicitly given through
-        the "access_ssdl" input argument. If the access_ssdl input argument is present,
-        its contents shall take presedence.
-
-        """
-        self.meta_access = (
-            global_configuration.Access.model_validate(
-                self.dataio.config["access"]
-            ).model_dump(mode="json", exclude_none=True)
-            if self.dataio._config_is_valid
-            else {}
-        )
-
-    def _populate_meta_display(self) -> None:
-        """Populate the display block."""
-
-        # display.name
-        if self.dataio.display_name is not None:
-            display_name = self.dataio.display_name
-        else:
-            assert self.objdata is not None
-            display_name = self.objdata.name
-
-        self.meta_display = {"name": display_name}
-
-    def _populate_meta_xpreprocessed(self) -> None:
-        """Populate a few necessary 'tmp' metadata needed for preprocessed data."""
-        if self.dataio.fmu_context == FmuContext.PREPROCESSED:
-            self.meta_xpreprocessed["name"] = self.dataio.name
-            self.meta_xpreprocessed["tagname"] = self.dataio.tagname
-            self.meta_xpreprocessed["subfolder"] = self.dataio.subfolder
-
-    def _reuse_existing_metadata(self, meta: dict) -> dict:
-        """Perform a merge procedure if input is a file i.e. `_reuse_metadata=True`"""
-        if self.dataio._reuse_metadata:
-            return glue_metadata_preprocessed(
-                oldmeta=self.meta_existing, newmeta=meta.copy()
-            )
-        return meta
-
-    def generate_export_metadata(
-        self, skip_null: bool = True
-    ) -> dict:  # TODO! -> skip_null?
-        """Main function to generate the full metadata"""
-
-        # populate order matters, in particular objectdata provides input to class/file
-        self._populate_meta_masterdata()
-        self._populate_meta_access()
-
-        if self.dataio._fmurun:
-            self._populate_meta_fmu()
-
-        self._populate_meta_tracklog()
-        self._populate_meta_objectdata()
-        self._populate_meta_class()
-        self._populate_meta_file()
-        self._populate_meta_display()
-        self._populate_meta_xpreprocessed()
-
-        # glue together metadata, order is as legacy code (but will be screwed if reuse
-        # of existing metadata...)
-        meta = self.meta_dollars.copy()
-        meta["tracklog"] = self.meta_tracklog
-        meta["class"] = self.meta_class
-
-        meta["fmu"] = self.meta_fmu
-        meta["file"] = self.meta_file
-
-        meta["data"] = self.meta_objectdata
-        meta["display"] = self.meta_display
-
-        meta["access"] = self.meta_access
-        meta["masterdata"] = self.meta_masterdata
-
-        if self.dataio.fmu_context == FmuContext.PREPROCESSED:
-            meta["_preprocessed"] = self.meta_xpreprocessed
-
-        if skip_null:
-            meta = drop_nones(meta)
-
-        return self._reuse_existing_metadata(meta)
+    return (
+        metadata
+        if not meta_existing
+        else glue_metadata_preprocessed(oldmeta=meta_existing, newmeta=metadata.copy())
+    )

--- a/src/fmu/dataio/case.py
+++ b/src/fmu/dataio/case.py
@@ -13,6 +13,7 @@ from . import _metadata, _utils
 from ._logging import null_logger
 from .datastructure._internal import internal
 from .datastructure.configuration import global_configuration
+from .datastructure.meta import meta
 
 logger: Final = null_logger(__name__)
 
@@ -116,9 +117,9 @@ class InitializeCase:  # pylint: disable=too-few-public-methods
             warnings.warn(exists_warning, UserWarning)
             return {}
 
-        meta = internal.CaseSchema(
-            masterdata=internal.Masterdata.model_validate(self.config["masterdata"]),
-            access=internal.Access.model_validate(self.config["access"]),
+        case_meta = internal.CaseSchema(
+            masterdata=meta.Masterdata.model_validate(self.config["masterdata"]),
+            access=meta.Access.model_validate(self.config["access"]),
             fmu=internal.FMUModel(
                 model=global_configuration.Model.model_validate(
                     self.config["model"],
@@ -126,7 +127,7 @@ class InitializeCase:  # pylint: disable=too-few-public-methods
                 case=internal.CaseMetadata(
                     name=self.casename,
                     uuid=str(self._case_uuid()),
-                    user=internal.User(id=self.caseuser),
+                    user=meta.User(id=self.caseuser),
                 ),
             ),
             tracklog=_metadata.generate_meta_tracklog(),
@@ -137,7 +138,7 @@ class InitializeCase:  # pylint: disable=too-few-public-methods
             by_alias=True,
         )
 
-        self._metadata = _utils.drop_nones(meta)
+        self._metadata = _utils.drop_nones(case_meta)
 
         logger.info("The case metadata are now ready!")
         return copy.deepcopy(self._metadata)

--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -16,12 +16,13 @@ from warnings import warn
 import pandas as pd
 from pydantic import ValidationError as PydanticValidationError
 
-from . import _metadata, types
+from . import types
 from ._definitions import (
     FmuContext,
     ValidationError,
 )
 from ._logging import null_logger
+from ._metadata import generate_export_metadata
 from ._utils import (
     create_symlink,
     detect_inside_rms,  # dataio_examples,
@@ -37,7 +38,7 @@ from .datastructure._internal.internal import (
     AllowedContent,
 )
 from .datastructure.configuration import global_configuration
-from .providers._fmu import FmuEnv
+from .providers._fmu import FmuEnv, FmuProvider
 
 # DATAIO_EXAMPLES: Final = dataio_examples()
 INSIDE_RMS: Final = detect_inside_rms()
@@ -641,17 +642,23 @@ class ExportData:
                     "missing in the metadata. A possible solution is to rerun the"
                     "preprocessed export."
                 )
+            preprocessed = currentmeta["_preprocessed"]
 
-            if not self.name and currentmeta["_preprocessed"].get("name", ""):
-                self.name = currentmeta["_preprocessed"]["name"]
-
-            if not self.tagname and currentmeta["_preprocessed"].get("tagname", ""):
-                self.tagname = currentmeta["_preprocessed"]["tagname"]
-
-            if not self.subfolder and currentmeta["_preprocessed"].get("subfolder", ""):
-                self.subfolder = currentmeta["_preprocessed"]["subfolder"]
+            self.name = self.name or preprocessed.get("name", "")
+            self.tagname = self.tagname or preprocessed.get("tagname", "")
+            self.subfolder = self.subfolder or preprocessed.get("subfolder", "")
 
         return obj
+
+    def _get_fmu_provider(self) -> FmuProvider:
+        return FmuProvider(
+            model=self.config.get("model", None),
+            fmu_context=FmuContext.get(self.fmu_context),
+            casepath_proposed=self.casepath or "",
+            include_ertjobs=self.include_ertjobs,
+            forced_realization=self.realization,
+            workflow=self.workflow,
+        )
 
     # ==================================================================================
     # Public methods:
@@ -708,10 +715,19 @@ class ExportData:
         self._validate_content_key()
         self._update_fmt_flag()
 
-        metaobj = _metadata.MetaData(obj, self, compute_md5=compute_md5)
-        self._metadata = metaobj.generate_export_metadata()
+        fmudata = self._get_fmu_provider() if self._fmurun else None
 
-        self._rootpath = Path(metaobj.rootpath)
+        # update rootpath based on fmurun or not
+        # TODO: Move to ExportData init when/if users are
+        # disallowed to update class settings on the export.
+        self._rootpath = Path(
+            fmudata.get_casepath() if fmudata else str(self._rootpath.absolute())
+        )
+        logger.debug("Rootpath is now %s", self._rootpath)
+
+        self._metadata = generate_export_metadata(
+            obj, self, fmudata, compute_md5=compute_md5
+        )
 
         logger.info("The metadata are now ready!")
 

--- a/src/fmu/dataio/providers/objectdata/_base.py
+++ b/src/fmu/dataio/providers/objectdata/_base.py
@@ -67,8 +67,8 @@ class DerivedObjectDescriptor:
     )
     fmt: str
     extension: str
-    spec: Dict[str, Any]
-    bbox: Dict[str, Any]
+    spec: Dict[str, Any] | None
+    bbox: Dict[str, Any] | None
     table_index: Optional[list[str]]
 
 
@@ -80,7 +80,7 @@ class DerivedNamedStratigraphy:
     stratigraphic: bool
     stratigraphic_alias: list[str]
 
-    offset: int | None
+    offset: int
     base: str | None
     top: str | None
 
@@ -178,7 +178,7 @@ class ObjectDataProvider(ABC):
             stratigraphic_alias=[]
             if no_start_or_missing_name
             else strat[name].get("stratigraphic_alias"),
-            offset=None if no_start_or_missing_name else strat[name].get("offset"),
+            offset=0.0 if no_start_or_missing_name else strat[name].get("offset", 0.0),
             top=None if no_start_or_missing_name else strat[name].get("top"),
             base=None if no_start_or_missing_name else strat[name].get("base"),
         )

--- a/src/fmu/dataio/providers/objectdata/_provider.py
+++ b/src/fmu/dataio/providers/objectdata/_provider.py
@@ -213,7 +213,7 @@ class DictionaryDataProvider(ObjectDataProvider):
             efolder="dictionaries",
             fmt=(fmt := self.dataio.dict_fformat),
             extension=self._validate_get_ext(fmt, "JSON", ValidFormats().dictionary),
-            spec=self.get_spec(),
-            bbox=self.get_bbox(),
+            spec=self.get_spec() or None,
+            bbox=self.get_bbox() or None,
             table_index=None,
         )

--- a/src/fmu/dataio/providers/objectdata/_tables.py
+++ b/src/fmu/dataio/providers/objectdata/_tables.py
@@ -86,7 +86,7 @@ class DataFrameDataProvider(ObjectDataProvider):
             fmt=(fmt := self.dataio.table_fformat),
             extension=self._validate_get_ext(fmt, "DataFrame", ValidFormats().table),
             spec=self.get_spec(),
-            bbox=self.get_bbox(),
+            bbox=self.get_bbox() or None,
             table_index=table_index,
         )
 
@@ -123,6 +123,6 @@ class ArrowTableDataProvider(ObjectDataProvider):
             fmt=(fmt := self.dataio.arrow_fformat),
             extension=self._validate_get_ext(fmt, "ArrowTable", ValidFormats().table),
             spec=self.get_spec(),
-            bbox=self.get_bbox(),
+            bbox=self.get_bbox() or None,
             table_index=table_index,
         )

--- a/src/fmu/dataio/providers/objectdata/_xtgeo.py
+++ b/src/fmu/dataio/providers/objectdata/_xtgeo.py
@@ -352,6 +352,6 @@ class CPGridPropertyDataProvider(ObjectDataProvider):
                 fmt, "CPGridProperty", ValidFormats().grid
             ),
             spec=self.get_spec(),
-            bbox=self.get_bbox(),
+            bbox=self.get_bbox() or None,
             table_index=None,
         )

--- a/tests/test_units/test_dataio.py
+++ b/tests/test_units/test_dataio.py
@@ -6,6 +6,7 @@ import pathlib
 import sys
 from copy import deepcopy
 
+import pydantic
 import pytest
 import yaml
 from fmu.dataio._definitions import FmuContext
@@ -213,10 +214,16 @@ def test_content_invalid_dict(globalconfig1):
 
 
 def test_content_valid_string(regsurf, globalconfig2):
-    eobj = ExportData(config=globalconfig2, name="TopVolantis", content="seismic")
+    eobj = ExportData(config=globalconfig2, name="TopVolantis", content="depth")
     mymeta = eobj.generate_metadata(regsurf)
-    assert mymeta["data"]["content"] == "seismic"
-    assert "seismic" not in mymeta["data"]
+    assert mymeta["data"]["content"] == "depth"
+    assert "depth" not in mymeta["data"]
+
+
+def test_seismic_content_require_seismic_data(regsurf, globalconfig2):
+    eobj = ExportData(config=globalconfig2, content="seismic")
+    with pytest.raises(pydantic.ValidationError, match="Field required "):
+        eobj.generate_metadata(regsurf)
 
 
 def test_content_valid_dict(regsurf, globalconfig2):

--- a/tests/test_units/test_metadata_class.py
+++ b/tests/test_units/test_metadata_class.py
@@ -5,12 +5,19 @@ from copy import deepcopy
 
 import fmu.dataio as dio
 import pytest
-from fmu.dataio._metadata import SCHEMA, SOURCE, VERSION, MetaData
+from fmu.dataio._metadata import (
+    SCHEMA,
+    SOURCE,
+    VERSION,
+    _get_objectdata_provider,
+    generate_export_metadata,
+)
 from fmu.dataio._utils import prettyprint_dict
 from fmu.dataio.datastructure.meta.meta import (
     SystemInformationOperatingSystem,
     TracklogEvent,
 )
+from pydantic import ValidationError
 
 # pylint: disable=no-member
 
@@ -21,14 +28,14 @@ logger = logging.getLogger(__name__)
 # --------------------------------------------------------------------------------------
 
 
-def test_metadata_dollars(edataobj1):
+def test_metadata_dollars(edataobj1, regsurf):
     """Testing the dollars part which is hard set."""
 
-    mymeta = MetaData("dummy", edataobj1)
+    mymeta = edataobj1.generate_metadata(obj=regsurf)
 
-    assert mymeta.meta_dollars["version"] == VERSION
-    assert mymeta.meta_dollars["$schema"] == SCHEMA
-    assert mymeta.meta_dollars["source"] == SOURCE
+    assert mymeta["version"] == VERSION
+    assert mymeta["$schema"] == SCHEMA
+    assert mymeta["source"] == SOURCE
 
 
 # --------------------------------------------------------------------------------------
@@ -36,10 +43,9 @@ def test_metadata_dollars(edataobj1):
 # --------------------------------------------------------------------------------------
 
 
-def test_generate_meta_tracklog_fmu_dataio_version(edataobj1):
-    mymeta = MetaData("dummy", edataobj1)
-    mymeta._populate_meta_tracklog()
-    tracklog = mymeta.meta_tracklog
+def test_generate_meta_tracklog_fmu_dataio_version(regsurf, edataobj1):
+    mymeta = generate_export_metadata(regsurf, edataobj1)
+    tracklog = mymeta["tracklog"]
 
     assert isinstance(tracklog, list)
     assert len(tracklog) == 1  # assume "created"
@@ -57,13 +63,12 @@ def test_generate_meta_tracklog_fmu_dataio_version(edataobj1):
     assert parsed.sysinfo.fmu_dataio.version is not None
 
 
-def test_generate_meta_tracklog_komodo_version(edataobj1, monkeypatch):
+def test_generate_meta_tracklog_komodo_version(edataobj1, regsurf, monkeypatch):
     fake_komodo_release = "<FAKE_KOMODO_RELEASE_VERSION>"
     monkeypatch.setenv("KOMODO_RELEASE", fake_komodo_release)
 
-    mymeta = MetaData("dummy", edataobj1)
-    mymeta._populate_meta_tracklog()
-    tracklog = mymeta.meta_tracklog
+    mymeta = generate_export_metadata(regsurf, edataobj1)
+    tracklog = mymeta["tracklog"]
 
     assert isinstance(tracklog, list)
     assert len(tracklog) == 1  # assume "created"
@@ -81,10 +86,9 @@ def test_generate_meta_tracklog_komodo_version(edataobj1, monkeypatch):
     assert parsed.sysinfo.komodo.version == fake_komodo_release
 
 
-def test_generate_meta_tracklog_operating_system(edataobj1):
-    mymeta = MetaData("dummy", edataobj1)
-    mymeta._populate_meta_tracklog()
-    tracklog = mymeta.meta_tracklog
+def test_generate_meta_tracklog_operating_system(edataobj1, regsurf):
+    mymeta = generate_export_metadata(regsurf, edataobj1)
+    tracklog = mymeta["tracklog"]
 
     assert isinstance(tracklog, list)
     assert len(tracklog) == 1  # assume "created"
@@ -102,9 +106,12 @@ def test_generate_meta_tracklog_operating_system(edataobj1):
 
 
 def test_populate_meta_objectdata(regsurf, edataobj2):
-    mymeta = MetaData(regsurf, edataobj2)
-    mymeta._populate_meta_objectdata()
-    assert mymeta.objdata.name == "VOLANTIS GP. Top"
+    mymeta = generate_export_metadata(regsurf, edataobj2)
+    objdata = _get_objectdata_provider(regsurf, edataobj2)
+
+    assert objdata.name == "VOLANTIS GP. Top"
+    assert mymeta["display"]["name"] == objdata.name
+    assert edataobj2.name == "TopVolantis"
 
 
 def test_populate_meta_undef_is_zero(regsurf, globalconfig2):
@@ -140,30 +147,27 @@ def test_populate_meta_undef_is_zero(regsurf, globalconfig2):
 # --------------------------------------------------------------------------------------
 
 
-def test_metadata_populate_masterdata_is_empty(globalconfig1):
+def test_metadata_populate_masterdata_is_empty(globalconfig1, regsurf):
     """Testing the masterdata part, first with no settings."""
     config = deepcopy(globalconfig1)
     del config["masterdata"]  # to force missing masterdata
 
     some = dio.ExportData(config=config, content="depth")
+
     assert not some._config_is_valid
 
-    mymeta = MetaData("dummy", some)
-
-    mymeta._populate_meta_masterdata()
-    assert not mymeta.meta_masterdata
+    mymeta = generate_export_metadata(regsurf, some)
+    assert "masterdata" not in mymeta
 
 
-def test_metadata_populate_masterdata_is_present_ok(edataobj1, edataobj2):
+def test_metadata_populate_masterdata_is_present_ok(edataobj1, edataobj2, regsurf):
     """Testing the masterdata part with OK metdata."""
 
-    mymeta = MetaData("dummy", edataobj1)
-    mymeta._populate_meta_masterdata()
-    assert mymeta.meta_masterdata == edataobj1.config["masterdata"]
+    mymeta = generate_export_metadata(regsurf, edataobj1)
+    assert mymeta["masterdata"] == edataobj1.config["masterdata"]
 
-    mymeta = MetaData("dummy", edataobj2)
-    mymeta._populate_meta_masterdata()
-    assert mymeta.meta_masterdata == edataobj2.config["masterdata"]
+    mymeta = generate_export_metadata(regsurf, edataobj2)
+    assert mymeta["masterdata"] == edataobj2.config["masterdata"]
 
 
 # --------------------------------------------------------------------------------------
@@ -171,35 +175,31 @@ def test_metadata_populate_masterdata_is_present_ok(edataobj1, edataobj2):
 # --------------------------------------------------------------------------------------
 
 
-def test_metadata_populate_access_miss_config_access(globalconfig1):
+def test_metadata_populate_access_miss_config_access(globalconfig1, regsurf):
     """Testing the access part, now with config missing access."""
 
     cfg1_edited = deepcopy(globalconfig1)
     del cfg1_edited["access"]
 
     edata = dio.ExportData(config=cfg1_edited, content="depth")
-
     assert not edata._config_is_valid
 
-    mymeta = MetaData("dummy", edata)
-    mymeta._populate_meta_access()
-    assert not mymeta.meta_access
+    mymeta = generate_export_metadata(regsurf, edata)
+    assert "access" not in mymeta
 
 
-def test_metadata_populate_access_ok_config(edataobj2):
+def test_metadata_populate_access_ok_config(edataobj2, regsurf):
     """Testing the access part, now with config ok access."""
 
-    mymeta = MetaData("dummy", edataobj2)
-
-    mymeta._populate_meta_access()
-    assert mymeta.meta_access == {
+    mymeta = generate_export_metadata(regsurf, edataobj2)
+    assert mymeta["access"] == {
         "asset": {"name": "Drogon"},
         "ssdl": {"access_level": "internal", "rep_include": True},
         "classification": "internal",
     }
 
 
-def test_metadata_populate_from_argument(globalconfig1):
+def test_metadata_populate_from_argument(globalconfig1, regsurf):
     """Testing the access part, now with ok config and a change in access."""
 
     # test assumptions
@@ -210,17 +210,16 @@ def test_metadata_populate_from_argument(globalconfig1):
         access_ssdl={"access_level": "restricted", "rep_include": True},
         content="depth",
     )
-    mymeta = MetaData("dummy", edata)
+    mymeta = generate_export_metadata(regsurf, edata)
 
-    mymeta._populate_meta_access()
-    assert mymeta.meta_access == {
+    assert mymeta["access"] == {
         "asset": {"name": "Test"},
         "ssdl": {"access_level": "restricted", "rep_include": True},
         "classification": "restricted",  # mirroring ssdl.access_level
     }
 
 
-def test_metadata_populate_partial_access_ssdl(globalconfig1):
+def test_metadata_populate_partial_access_ssdl(globalconfig1, regsurf):
     """Test what happens if ssdl_access argument is partial."""
 
     # test assumptions
@@ -232,11 +231,10 @@ def test_metadata_populate_partial_access_ssdl(globalconfig1):
         config=globalconfig1, access_ssdl={"rep_include": True}, content="depth"
     )
 
-    mymeta = MetaData("dummy", edata)
-    mymeta._populate_meta_access()
-    assert mymeta.meta_access["ssdl"]["rep_include"] is True
-    assert mymeta.meta_access["ssdl"]["access_level"] == "internal"  # default
-    assert mymeta.meta_access["classification"] == "internal"  # default
+    mymeta = generate_export_metadata(regsurf, edata)
+    assert mymeta["access"]["ssdl"]["rep_include"] is True
+    assert mymeta["access"]["ssdl"]["access_level"] == "internal"  # default
+    assert mymeta["access"]["classification"] == "internal"  # default
 
     # access_level only, but in config
     edata = dio.ExportData(
@@ -244,14 +242,13 @@ def test_metadata_populate_partial_access_ssdl(globalconfig1):
         access_ssdl={"access_level": "restricted"},
         content="depth",
     )
-    mymeta = MetaData("dummy", edata)
-    mymeta._populate_meta_access()
-    assert mymeta.meta_access["ssdl"]["rep_include"] is False  # default
-    assert mymeta.meta_access["ssdl"]["access_level"] == "restricted"
-    assert mymeta.meta_access["classification"] == "restricted"
+    mymeta = generate_export_metadata(regsurf, edata)
+    assert mymeta["access"]["ssdl"]["rep_include"] is False  # default
+    assert mymeta["access"]["ssdl"]["access_level"] == "restricted"
+    assert mymeta["access"]["classification"] == "restricted"
 
 
-def test_metadata_populate_wrong_config(globalconfig1):
+def test_metadata_populate_wrong_config(globalconfig1, regsurf):
     """Test error in access_ssdl in config."""
 
     # test assumptions
@@ -263,12 +260,11 @@ def test_metadata_populate_wrong_config(globalconfig1):
 
     assert not edata._config_is_valid
 
-    mymeta = MetaData("dummy", edata)
-    mymeta._populate_meta_access()
-    assert not mymeta.meta_access
+    with pytest.raises(ValidationError, match="ssdl.access_level"):
+        generate_export_metadata(regsurf, edata)
 
 
-def test_metadata_populate_wrong_argument(globalconfig1):
+def test_metadata_populate_wrong_argument(globalconfig1, regsurf):
     """Test error in access_ssdl in arguments."""
 
     with pytest.warns(UserWarning):
@@ -279,12 +275,11 @@ def test_metadata_populate_wrong_argument(globalconfig1):
         )
     assert not edata._config_is_valid
 
-    mymeta = MetaData("dummy", edata)
-    mymeta._populate_meta_access()
-    assert not mymeta.meta_access
+    with pytest.raises(ValidationError, match="ssdl.access_level"):
+        generate_export_metadata(regsurf, edata)
 
 
-def test_metadata_access_correct_input(globalconfig1):
+def test_metadata_access_correct_input(globalconfig1, regsurf):
     """Test giving correct input."""
     # Input is "restricted" and False - correct use, shall work
     edata = dio.ExportData(
@@ -292,11 +287,10 @@ def test_metadata_access_correct_input(globalconfig1):
         content="depth",
         access_ssdl={"access_level": "restricted", "rep_include": False},
     )
-    mymeta = MetaData("dummy", edata)
-    mymeta._populate_meta_access()
-    assert mymeta.meta_access["ssdl"]["rep_include"] is False
-    assert mymeta.meta_access["ssdl"]["access_level"] == "restricted"
-    assert mymeta.meta_access["classification"] == "restricted"
+    mymeta = generate_export_metadata(regsurf, edata)
+    assert mymeta["access"]["ssdl"]["rep_include"] is False
+    assert mymeta["access"]["ssdl"]["access_level"] == "restricted"
+    assert mymeta["access"]["classification"] == "restricted"
 
     # Input is "internal" and True - correct use, shall work
     edata = dio.ExportData(
@@ -304,14 +298,13 @@ def test_metadata_access_correct_input(globalconfig1):
         content="depth",
         access_ssdl={"access_level": "internal", "rep_include": True},
     )
-    mymeta = MetaData("dummy", edata)
-    mymeta._populate_meta_access()
-    assert mymeta.meta_access["ssdl"]["rep_include"] is True
-    assert mymeta.meta_access["ssdl"]["access_level"] == "internal"
-    assert mymeta.meta_access["classification"] == "internal"
+    mymeta = generate_export_metadata(regsurf, edata)
+    assert mymeta["access"]["ssdl"]["rep_include"] is True
+    assert mymeta["access"]["ssdl"]["access_level"] == "internal"
+    assert mymeta["access"]["classification"] == "internal"
 
 
-def test_metadata_access_deprecated_input(globalconfig1):
+def test_metadata_access_deprecated_input(globalconfig1, regsurf):
     """Test giving deprecated input."""
     # Input is "asset". Is deprecated, shall work with warning.
     # Output shall be "restricted".
@@ -326,13 +319,12 @@ def test_metadata_access_deprecated_input(globalconfig1):
         )
     assert edata._config_is_valid
 
-    mymeta = MetaData("dummy", edata)
-    mymeta._populate_meta_access()
-    assert mymeta.meta_access["ssdl"]["access_level"] == "restricted"
-    assert mymeta.meta_access["classification"] == "restricted"
+    mymeta = generate_export_metadata(regsurf, edata)
+    assert mymeta["access"]["ssdl"]["access_level"] == "restricted"
+    assert mymeta["access"]["classification"] == "restricted"
 
 
-def test_metadata_access_illegal_input(globalconfig1):
+def test_metadata_access_illegal_input(globalconfig1, regsurf):
     """Test giving illegal input, should provide empty access field"""
 
     # Input is "secret"
@@ -344,9 +336,8 @@ def test_metadata_access_illegal_input(globalconfig1):
         )
     assert not edata._config_is_valid
 
-    mymeta = MetaData("dummy", edata)
-    mymeta._populate_meta_access()
-    assert not mymeta.meta_access
+    with pytest.raises(ValidationError, match="ssdl.access_level"):
+        generate_export_metadata(regsurf, edata)
 
     # Input is "open". Not allowed, shall fail.
     with pytest.warns(UserWarning):
@@ -356,12 +347,11 @@ def test_metadata_access_illegal_input(globalconfig1):
             content="depth",
         )
     assert not edata._config_is_valid
-    mymeta = MetaData("dummy", edata)
-    mymeta._populate_meta_access()
-    assert not mymeta.meta_access
+    with pytest.raises(ValidationError, match="ssdl.access_level"):
+        generate_export_metadata(regsurf, edata)
 
 
-def test_metadata_access_no_input(globalconfig1):
+def test_metadata_access_no_input(globalconfig1, regsurf):
     """Test not giving any input arguments."""
 
     # No input, revert to config
@@ -369,22 +359,20 @@ def test_metadata_access_no_input(globalconfig1):
     configcopy["access"]["ssdl"]["access_level"] = "restricted"
     configcopy["access"]["ssdl"]["rep_include"] = True
     edata = dio.ExportData(config=configcopy, content="depth")
-    mymeta = MetaData("dummy", edata)
-    mymeta._populate_meta_access()
-    assert mymeta.meta_access["ssdl"]["rep_include"] is True
-    assert mymeta.meta_access["ssdl"]["access_level"] == "restricted"
-    assert mymeta.meta_access["classification"] == "restricted"  # mirrored
+    mymeta = generate_export_metadata(regsurf, edata)
+    assert mymeta["access"]["ssdl"]["rep_include"] is True
+    assert mymeta["access"]["ssdl"]["access_level"] == "restricted"
+    assert mymeta["access"]["classification"] == "restricted"  # mirrored
 
     # No input, no config, shall default to "internal" and False
     configcopy = deepcopy(globalconfig1)
     del configcopy["access"]["ssdl"]["access_level"]
     del configcopy["access"]["ssdl"]["rep_include"]
     edata = dio.ExportData(config=globalconfig1, content="depth")
-    mymeta = MetaData("dummy", edata)
-    mymeta._populate_meta_access()
-    assert mymeta.meta_access["ssdl"]["rep_include"] is False  # default
-    assert mymeta.meta_access["ssdl"]["access_level"] == "internal"  # default
-    assert mymeta.meta_access["classification"] == "internal"  # mirrored
+    mymeta = generate_export_metadata(regsurf, edata)
+    assert mymeta["access"]["ssdl"]["rep_include"] is False  # default
+    assert mymeta["access"]["ssdl"]["access_level"] == "internal"  # default
+    assert mymeta["access"]["classification"] == "internal"  # mirrored
 
 
 # --------------------------------------------------------------------------------------
@@ -395,24 +383,23 @@ def test_metadata_access_no_input(globalconfig1):
 def test_metadata_display_name_not_given(regsurf, edataobj2):
     """Test that display.name == data.name when not explicitly provided."""
 
-    mymeta = MetaData(regsurf, edataobj2)
-    mymeta._populate_meta_objectdata()
-    mymeta._populate_meta_display()
+    mymeta = generate_export_metadata(regsurf, edataobj2)
+    objdata = _get_objectdata_provider(regsurf, edataobj2)
 
-    assert "name" in mymeta.meta_display
-    assert mymeta.meta_display["name"] == mymeta.objdata.name
+    assert "name" in mymeta["display"]
+    assert mymeta["display"]["name"] == objdata.name
 
 
 def test_metadata_display_name_given(regsurf, edataobj2):
     """Test that display.name is set when explicitly given."""
 
-    mymeta = MetaData(regsurf, edataobj2)
     edataobj2.display_name = "My Display Name"
-    mymeta._populate_meta_objectdata()
-    mymeta._populate_meta_display()
 
-    assert mymeta.meta_display["name"] == "My Display Name"
-    assert mymeta.objdata.name == mymeta.meta_objectdata["name"] == "VOLANTIS GP. Top"
+    mymeta = generate_export_metadata(regsurf, edataobj2)
+    objdata = _get_objectdata_provider(regsurf, edataobj2)
+
+    assert mymeta["display"]["name"] == "My Display Name"
+    assert objdata.name == "VOLANTIS GP. Top"
 
 
 # --------------------------------------------------------------------------------------
@@ -423,10 +410,8 @@ def test_metadata_display_name_given(regsurf, edataobj2):
 def test_generate_full_metadata(regsurf, edataobj2):
     """Generating the full metadata block for a xtgeo surface."""
 
-    mymeta = MetaData(regsurf, edataobj2)
-
-    metadata_result = mymeta.generate_export_metadata(
-        skip_null=False
+    metadata_result = generate_export_metadata(
+        regsurf, edataobj2, skip_null=False
     )  # want to have None
 
     logger.debug("\n%s", prettyprint_dict(metadata_result))

--- a/tests/test_units/test_objectdataprovider_class.py
+++ b/tests/test_units/test_objectdataprovider_class.py
@@ -5,9 +5,7 @@ import os
 import pytest
 from fmu.dataio import dataio
 from fmu.dataio._definitions import ConfigurationError, ValidFormats
-from fmu.dataio._metadata import MetaData
 from fmu.dataio.providers.objectdata._provider import (
-    ExistingDataProvider,
     objectdata_provider_factory,
 )
 from fmu.dataio.providers.objectdata._xtgeo import RegularSurfaceDataProvider
@@ -144,17 +142,12 @@ def test_regsurf_preprocessed_observation(
             content=None,
             is_observation=True,
         )
-        _ = edata.generate_metadata(
+        return edata.generate_metadata(
             surfacepath,
             casepath=casepath,
         )
-        metaobj = MetaData(surfacepath, edata)
-        metaobj._populate_meta_objectdata()
-        assert isinstance(metaobj.objdata, ExistingDataProvider)
-        return metaobj
 
     # run two stage process
     edata, mysurf = _export_data_from_rms(rmssetup, rmsglobalconfig, regsurf)
-    metaobj = _run_case_fmu(fmurun_w_casemetadata, rmsglobalconfig, mysurf)
-    case_meta = metaobj.generate_export_metadata()
+    case_meta = _run_case_fmu(fmurun_w_casemetadata, rmsglobalconfig, mysurf)
     assert edata._metadata["data"] == case_meta["data"]


### PR DESCRIPTION
PR refactoring the `MetaData` class  into using a pydantic model for creating the internal metadata. Part of https://github.com/equinor/fmu-dataio/issues/457 
This enables early validation upon creation of the metadata, and detection of misalignment between the internal format and the schema.

Almost the entire pydantic model for the schema are reused for the internal meta format, however some adjustments were needed to support e.g. not being in a fmu setting or having invalid config. Going forward we should aim to get them more in sync, so that most metadata produced will be valid for SUMO upload (with exception of preprocessed data). 


