### PR TITLE
FIX: Add display to schema

### DIFF
--- a/schema/definitions/0.8.0/schema/fmu_meta.json
+++ b/schema/definitions/0.8.0/schema/fmu_meta.json
@@ -877,6 +877,24 @@
       "title": "DiscoveryItem",
       "type": "object"
     },
+    "Display": {
+      "properties": {
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Name"
+        }
+      },
+      "title": "Display",
+      "type": "object"
+    },
     "FMUCase": {
       "properties": {
         "description": {
@@ -1092,6 +1110,9 @@
         "data": {
           "$ref": "#/$defs/AnyContent"
         },
+        "display": {
+          "$ref": "#/$defs/Display"
+        },
         "file": {
           "$ref": "#/$defs/File"
         },
@@ -1127,7 +1148,8 @@
         "fmu",
         "access",
         "data",
-        "file"
+        "file",
+        "display"
       ],
       "title": "FMUDataClassMeta",
       "type": "object"

--- a/src/fmu/dataio/datastructure/meta/meta.py
+++ b/src/fmu/dataio/datastructure/meta/meta.py
@@ -324,6 +324,10 @@ class TracklogEvent(BaseModel):
     )
 
 
+class Display(BaseModel):
+    name: Optional[str] = Field(default=None)
+
+
 class Context(BaseModel):
     """The internal FMU context in which this data object was produced"""
 
@@ -430,6 +434,7 @@ class FMUDataClassMeta(ClassMeta):
     access: SsdlAccess
     data: content.AnyContent
     file: File
+    display: Display
 
 
 class Root(


### PR DESCRIPTION
Resolves #554
`display.name` is always populated upon creation of the metadata. Either from user input argument, or as the object.name. This object.name probably can be None, so I kept it Optional.