### PR TITLE
CI: Update actions using deprecated node.js

### DIFF
--- a/.github/workflows/ci-fmudataio.yml
+++ b/.github/workflows/ci-fmudataio.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/fmudataio-documention.yml
+++ b/.github/workflows/fmudataio-documention.yml
@@ -1,8 +1,6 @@
 # build and test some end points
 name: Build and deploy docs for fmu-dataio
 
-# on: [push, pull_request]
-
 on:
   pull_request:
     branches: [main]
@@ -10,21 +8,16 @@ on:
     branches: [main]
 
 jobs:
-  build_pywheels:
-    name: PY ${{ matrix.python-version }} on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        python-version: ["3.10"]
-        os: [ubuntu-latest]
+  build_docs:
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.10"
 
       - name: Install and build docs
         run: |
@@ -34,6 +27,7 @@ jobs:
           pip install git+https://github.com/equinor/fmu-config
           sh examples/run_examples.sh
           sphinx-build -b html docs build/docs/html
+
       - name: Update GitHub pages
         if: github.repository_owner == 'equinor' && github.ref == 'refs/heads/main'
         run: |

--- a/.github/workflows/fmudataio-publish-pypi.yml
+++ b/.github/workflows/fmudataio-publish-pypi.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -5,20 +5,24 @@ on: [push, pull_request]
 jobs:
   linting:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.10"]
+
     steps:
       - uses: actions/checkout@v4
+
       - name: Set up python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
       - name: Install dev-env.
         run: |
           pip install -U pip
           pip install ".[dev]"
+
       - name: Ruff check
         if: ${{ always() }}
         run: ruff check .
+
       - name: Ruff format
         if: ${{ always() }}
         run: ruff format . --check

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -8,11 +8,12 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.10"]
+
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/schemas-up-to-date.yml
+++ b/.github/workflows/schemas-up-to-date.yml
@@ -13,9 +13,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: "3.10"
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Resolves #562

Also removes some redundant matrix strategies with non-matrix setups, adds some formatting, and specifies an accidentally omitted Python version.

cf. https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/