### PR TITLE
WIP: Deprecating access_ssdl argument

### DIFF
--- a/tests/test_units/test_dataio.py
+++ b/tests/test_units/test_dataio.py
@@ -162,6 +162,11 @@ def test_update_check_settings_shall_fail(globalconfig1):
             "some",
             r"The 'grid_model' key has currently no function",
         ),
+        (
+            "access_ssdl",
+            {"rep_include": False, "access_level": "internal"},
+            r"The 'access_ssdl' key is deprecated",
+        ),
     ],
 )
 def test_deprecated_keys(globalconfig1, regsurf, key, value, expected_msg):
@@ -176,6 +181,31 @@ def test_deprecated_keys(globalconfig1, regsurf, key, value, expected_msg):
     with pytest.warns(PendingDeprecationWarning, match=expected_msg):
         edata = ExportData(config=globalconfig1, content="depth")
         edata.generate_metadata(regsurf, **kval)
+
+
+def test_validate_access_ssdl_arguments():
+    """Test that failes when access_ssdl is given together with replacements."""
+
+    # We are deprecating the 'access_ssdl' argument in favor of 'classification' and
+    # 'rep_include'. While deprecated, we allow the argument, but not conflicts.
+
+    with pytest.raises(ValueError):
+        ExportData(
+            access_ssdl={"access_level": "restricted"}, classification="internal"
+        )
+
+    # fail also when they are identical
+    with pytest.raises(ValueError):
+        ExportData(access_ssdl={"access_level": "internal"}, classification="internal")
+
+    with pytest.raises(ValueError):
+        ExportData(access_ssdl={"rep_include": True}, rep_include=True)
+
+    # allow only new arguments
+    ExportData(rep_include=True, classification="internal")
+
+    # allow (for now) only old argument, but give warning
+    ExportData(access_ssdl={"access_level": "internal", "rep_include": True})
 
 
 def test_content_not_given(globalconfig1, regsurf):

--- a/tests/test_units/test_metadata_class.py
+++ b/tests/test_units/test_metadata_class.py
@@ -199,7 +199,7 @@ def test_metadata_populate_access_ok_config(edataobj2):
     }
 
 
-def test_metadata_populate_from_argument(globalconfig1):
+def test_metadata_populate_from_legacy_argument(globalconfig1):
     """Testing the access part, now with ok config and a change in access."""
 
     # test assumptions
@@ -208,6 +208,29 @@ def test_metadata_populate_from_argument(globalconfig1):
     edata = dio.ExportData(
         config=globalconfig1,
         access_ssdl={"access_level": "restricted", "rep_include": True},
+        content="depth",
+    )
+    mymeta = MetaData("dummy", edata)
+
+    mymeta._populate_meta_access()
+    assert mymeta.meta_access == {
+        "asset": {"name": "Test"},
+        "ssdl": {"access_level": "restricted", "rep_include": True},
+        "classification": "restricted",  # mirroring ssdl.access_level
+    }
+
+
+def test_metadata_populate_from_argument(globalconfig1):
+    """Testing the access part, now with ok config and a change in access using
+    the classification keyword."""
+
+    # test assumptions
+    assert globalconfig1["access"]["ssdl"]["access_level"] == "internal"
+
+    edata = dio.ExportData(
+        config=globalconfig1,
+        classification="restricted",
+        rep_include=True,
         content="depth",
     )
     mymeta = MetaData("dummy", edata)


### PR DESCRIPTION
Ref discussion related to #540 and other issues

This is still very much just drafting, but proposing to deprecate the `access_ssdl` input argument in favor of `classification` and `rep_include`. 

Purpose:
- Make the `classification` argument a bit more intuitive and readable
- Remove impression that this is something specific to `SSDL` when it is in fact not.

History:
Initially, the `access.ssdl` block was specific to `SSDL` and inherited from early versions of metadata when SSDL defined the FMU metadata (largely). Then, the `access.ssdl.access_level` was used also for access control outside SSDL (i.e. Sumo). Then, we decided to deprecate it - but only go half-way there, because of multiple challenges. Essentially, it stopped after adding `access.classification` to outgoing metadata (temporarily synchronized with `access.ssdl.access_level`.

The (milestone) goal should be to remove `access.ssdl.access_level` completely in favor of `access.classification` and then us this also in the config.

Complicating factors:
- We still need the `rep_include` parameter, so the `access.ssdl` block will remain for now
- We allow missing or non-valid config, and must handle that throughout fmu-dataio. This complicates things.
- We make changes to the config during runtime, which complicates things.
- We allow arguments to be given both to the initialization of ExportData _and_ to the call to `.generate_metadata()`. This makes it a bit tricky to keep things in synch, particularly when we change things as we check them. (And then check them again later.)

Todo:
- [ ] Discussion, and some more discussion
- [ ] Rewrite tests to primarily use the updated pattern (classification)
- [ ] Something something related to Pydantic??

⚠️ This is work in progress, and not ready for merging.