### PR TITLE
FIX: Move export folder creation to export method

### DIFF
--- a/src/fmu/dataio/providers/_filedata.py
+++ b/src/fmu/dataio/providers/_filedata.py
@@ -235,14 +235,4 @@ class FileDataProvider:
                     f"You cannot use forcefolder in combination with fmucontext={info}"
                 )
 
-        if self.dataio.subfolder:
-            dest = dest / self.dataio.subfolder
-
-        if self.dataio.createfolder:
-            dest.mkdir(parents=True, exist_ok=True)
-
-        # check that destination actually exists if verifyfolder is True
-        if self.dataio.verifyfolder and not dest.exists():
-            raise OSError(f"Folder {str(dest)} is not present.")
-
-        return dest
+        return dest if not self.dataio.subfolder else dest / self.dataio.subfolder

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -288,8 +288,6 @@ def fixture_edataobj1(globalconfig1):
         is_observation=False,
     )
     eobj.surface_fformat = "irap_binary"
-    eobj.createfolder = False
-    eobj.verifyfolder = False
 
     logger.debug(
         "Ran %s returning %s", inspect.currentframe().f_code.co_name, type(eobj)
@@ -323,8 +321,6 @@ def fixture_edataobj2(globalconfig2):
     )
 
     eobj.surface_fformat = "irap_binary"
-    eobj.createfolder = False
-    eobj.verifyfolder = False
     eobj.legacy_time_format = False
 
     eobj._rootpath = Path(".")

--- a/tests/test_units/test_filedataprovider_class.py
+++ b/tests/test_units/test_filedataprovider_class.py
@@ -198,7 +198,6 @@ def test_get_paths_not_exists_so_create(regsurf, edataobj1, tmp_path):
     objdata.efolder = "efolder"
     cfg = edataobj1
 
-    cfg.createfolder = True
     cfg._rootpath = Path(".")
 
     fdata = FileDataProvider(cfg, objdata)
@@ -213,7 +212,6 @@ def test_filedata_provider(regsurf, edataobj1, tmp_path):
     os.chdir(tmp_path)
 
     cfg = edataobj1
-    cfg.createfolder = True
     cfg._rootpath = Path(".")
     cfg.name = ""
 
@@ -242,7 +240,6 @@ def test_filedata_has_nonascii_letters(regsurf, edataobj1, tmp_path):
     os.chdir(tmp_path)
 
     cfg = edataobj1
-    cfg.createfolder = True
     cfg._rootpath = Path(".")
     cfg.name = "mynõme"
 


### PR DESCRIPTION
Previously export folders were created inside the `FileDataProvider`, hence leading to generation of folders when running the `ExportData.generate_metadata()`. 
This PR moves the creation of these folders to the `ExportData.export()` function instead, and removes the two class variables `ExportData.createfolder` and `ExportData.verifyfolder`. These class variables are no longer needed; when running export, folders needs to be created otherwise the export will fail.

Closes #579 