### PR TITLE
CLN: Use FMUCase model from schema in CaseSchema

### DIFF
--- a/src/fmu/dataio/case.py
+++ b/src/fmu/dataio/case.py
@@ -124,10 +124,11 @@ class InitializeCase:  # pylint: disable=too-few-public-methods
                 model=global_configuration.Model.model_validate(
                     self.config["model"],
                 ),
-                case=internal.CaseMetadata(
+                case=meta.FMUCase(
                     name=self.casename,
-                    uuid=str(self._case_uuid()),
+                    uuid=self._case_uuid(),
                     user=meta.User(id=self.caseuser),
+                    description=None,
                 ),
             ),
             tracklog=_metadata.generate_meta_tracklog(),

--- a/src/fmu/dataio/datastructure/_internal/internal.py
+++ b/src/fmu/dataio/datastructure/_internal/internal.py
@@ -152,15 +152,9 @@ class JsonSchemaMetadata(BaseModel, populate_by_name=True):
     source: str = Field(default=SOURCE)
 
 
-class CaseMetadata(BaseModel):
-    name: str
-    uuid: str
-    user: meta.User
-
-
 class FMUModel(BaseModel):
     model: GlobalConfigurationModel
-    case: CaseMetadata
+    case: meta.FMUCase
 
 
 class PreprocessedInfo(BaseModel):


### PR DESCRIPTION
PR to remove pydantic model `CaseMetadata` from datastructure internal to use the one for the schema `meta.FMUCase` .

They were identical except for  `meta.FMUCase` having:
- an optional description key
- uuid defined as type `UUID`
