### PR TITLE
FIX: Add missing description to global_configuration.Model

### DIFF
--- a/src/fmu/dataio/datastructure/configuration/global_configuration.py
+++ b/src/fmu/dataio/datastructure/configuration/global_configuration.py
@@ -45,6 +45,7 @@ class Model(BaseModel):
 
     name: str
     revision: str
+    description: Optional[List[str]] = Field(default=None)
 
 
 class Ssdl(BaseModel):


### PR DESCRIPTION
PR to add the missing `description` field to `global_configuration.Model`.

The current implementation would just ignore the provided description information in the global_config file (if any).
