### PR TITLE
BUG: Handle content that requires extra info in AggregatedData

### DIFF
--- a/src/fmu/dataio/_utils.py
+++ b/src/fmu/dataio/_utils.py
@@ -10,6 +10,7 @@ import shutil
 import uuid
 from copy import deepcopy
 from pathlib import Path
+from tempfile import NamedTemporaryFile
 from typing import Any, Final, Literal
 
 import numpy as np
@@ -190,6 +191,20 @@ def export_file_compute_checksum_md5(
     """Export and compute checksum"""
     export_file(obj, filename, flag=flag)
     return md5sum(filename)
+
+
+def compute_md5_using_temp_file(
+    obj: types.Inferrable, extension: str, flag: str = ""
+) -> str:
+    """Compute an MD5 sum using a temporary file."""
+    if not extension.startswith("."):
+        raise ValueError("An extension must start with '.'")
+
+    with NamedTemporaryFile(buffering=0, suffix=extension) as tf:
+        logger.info("Compute MD5 sum for tmp file...: %s", tf.name)
+        return export_file_compute_checksum_md5(
+            obj=obj, filename=Path(tf.name), flag=flag
+        )
 
 
 def create_symlink(source: str, target: str) -> None:

--- a/src/fmu/dataio/providers/_filedata.py
+++ b/src/fmu/dataio/providers/_filedata.py
@@ -9,13 +9,14 @@ from __future__ import annotations
 from copy import deepcopy
 from dataclasses import dataclass, field
 from pathlib import Path
-from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING, Final, Optional
 from warnings import warn
 
 from fmu.dataio._definitions import FmuContext
 from fmu.dataio._logging import null_logger
-from fmu.dataio._utils import export_file_compute_checksum_md5
+from fmu.dataio._utils import (
+    compute_md5_using_temp_file,
+)
 from fmu.dataio.datastructure.meta import meta
 
 logger: Final = null_logger(__name__)
@@ -110,14 +111,9 @@ class FileDataProvider:
         """Compute an MD5 sum using a temporary file."""
         if self.obj is None:
             raise ValueError("Can't compute MD5 sum without an object.")
-        if not self.objdata.extension.startswith("."):
-            raise ValueError("An extension must start with '.'")
-
-        with NamedTemporaryFile(buffering=0, suffix=self.objdata.extension) as tf:
-            logger.info("Compute MD5 sum for tmp file...: %s", tf.name)
-            return export_file_compute_checksum_md5(
-                obj=self.obj, filename=Path(tf.name), flag=self.dataio._usefmtflag
-            )
+        return compute_md5_using_temp_file(
+            self.obj, self.objdata.extension, self.dataio._usefmtflag
+        )
 
     def _get_filestem(self) -> str:
         """Construct the file"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -474,17 +474,11 @@ def fixture_arrowtable():
         return None
 
 
-@pytest.fixture(name="aggr_surfs_mean", scope="function")
-def fixture_aggr_surfs_mean(fmurun_w_casemetadata, rmsglobalconfig, regsurf):
-    """Create aggregated surfaces, and return aggr. mean surface + lists of metadata"""
-    logger.debug("Ran %s", _current_function_name())
-
-    origfolder = os.getcwd()
-    os.chdir(fmurun_w_casemetadata)
-
+# helper function for the two fixtures below
+def _create_aggregated_surface_dataset(rmsglobalconfig, regsurf, content):
     edata = dio.ExportData(
         config=rmsglobalconfig,  # read from global config
-        content="depth",
+        content=content,
     )
 
     aggs = []
@@ -505,6 +499,42 @@ def fixture_aggr_surfs_mean(fmurun_w_casemetadata, rmsglobalconfig, regsurf):
 
         metas.append(meta)
         surfs.append([surf])
+    return surfs, metas
+
+
+@pytest.fixture(name="aggr_sesimic_surfs_mean", scope="function")
+def fixture_aggr_seismic_surfs_mean(fmurun_w_casemetadata, rmsglobalconfig, regsurf):
+    """Create aggregated surfaces, and return aggr. mean surface + lists of metadata"""
+    logger.debug("Ran %s", _current_function_name())
+
+    origfolder = os.getcwd()
+    os.chdir(fmurun_w_casemetadata)
+
+    surfs, metas = _create_aggregated_surface_dataset(
+        rmsglobalconfig, regsurf, content={"seismic": {"attribute": "amplitude"}}
+    )
+
+    aggregated = surfs.statistics()
+    logger.debug(
+        "Aggr. mean is %s", aggregated["mean"].values.mean()
+    )  # shall be 1238.5
+
+    os.chdir(origfolder)
+
+    return (aggregated["mean"], metas)
+
+
+@pytest.fixture(name="aggr_surfs_mean", scope="function")
+def fixture_aggr_surfs_mean(fmurun_w_casemetadata, rmsglobalconfig, regsurf):
+    """Create aggregated surfaces, and return aggr. mean surface + lists of metadata"""
+    logger.debug("Ran %s", _current_function_name())
+
+    origfolder = os.getcwd()
+    os.chdir(fmurun_w_casemetadata)
+
+    surfs, metas = _create_aggregated_surface_dataset(
+        rmsglobalconfig, regsurf, content="depth"
+    )
 
     aggregated = surfs.statistics()
     logger.debug(

--- a/tests/test_units/test_aggregated_surfaces.py
+++ b/tests/test_units/test_aggregated_surfaces.py
@@ -32,6 +32,32 @@ def test_regsurf_aggregated(fmurun_w_casemetadata, aggr_surfs_mean):
     assert newmeta["fmu"]["context"]["stage"] == "iteration"
 
 
+def test_regsurf_aggregated_content_seismic(
+    fmurun_w_casemetadata, aggr_sesimic_surfs_mean
+):
+    """
+    Test generating aggragated metadata for a surface, where the content is seismic
+    which will require more info.
+    """
+    logger.info("Active folder is %s", fmurun_w_casemetadata)
+
+    os.chdir(fmurun_w_casemetadata)
+
+    aggr_mean, metas = aggr_sesimic_surfs_mean  # xtgeo_object, list-of-metadata-dicts
+    logger.info("Aggr. mean is %s", aggr_mean.values.mean())
+
+    aggdata = dataio.AggregatedData(
+        source_metadata=metas,
+        operation="mean",
+        name="myaggrd",
+        aggregation_id="1234",
+    )
+    newmeta = aggdata.generate_metadata(aggr_mean)
+    logger.debug("New metadata:\n%s", utils.prettyprint_dict(newmeta))
+    assert newmeta["fmu"]["aggregation"]["id"] == "1234"
+    assert newmeta["fmu"]["context"]["stage"] == "iteration"
+
+
 def test_regsurf_aggregated_export(fmurun_w_casemetadata, aggr_surfs_mean):
     """Test generating aggragated metadata, now with export method.
 


### PR DESCRIPTION
PR that fixes a bug in `AggregatedData` where data that requires extra info would fail in the pydantic validation.
Closes #597

Ideally I wanted to remove the Initialization of ExportData to extract metadata, and instead use more direct method calls to populate the necessary fields. I was not able to do that fully at this moment since the `objectdata_provider` takes an `ExportData` instance as argument.

This `AggregatedData` class would need some attention in the future. e.g. adding pydantic models for aggregated data, and adding more tests as all of our tests are only targeting the datatype surface. 