### PR TITLE
CLN: Move readers/writers to `readers`/`writers`

### DIFF
--- a/src/fmu/dataio/_metadata.py
+++ b/src/fmu/dataio/_metadata.py
@@ -21,13 +21,13 @@ from ._logging import null_logger
 from ._utils import (
     drop_nones,
     glue_metadata_preprocessed,
-    read_metadata_from_file,
 )
 from .datastructure._internal import internal
 from .datastructure.meta import meta
 from .providers._filedata import FileDataProvider
 from .providers._fmu import FmuProvider
 from .providers.objectdata._provider import objectdata_provider_factory
+from .readers import read_metadata_from_file
 from .version import __version__
 
 if TYPE_CHECKING:

--- a/src/fmu/dataio/_utils.py
+++ b/src/fmu/dataio/_utils.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from typing import Any, Final
 
 import numpy as np
-import xtgeo
 
 from fmu.config import utilities as ut
 
@@ -78,29 +77,6 @@ def md5sum(fname: Path) -> str:
     return hash_md5.hexdigest()
 
 
-def create_symlink(source: str, target: str) -> None:
-    """Create a symlinked file with some checks."""
-
-    thesource = Path(source)
-    if not thesource.exists():
-        raise OSError(f"Cannot symlink: Source file {thesource} does not exist.")
-
-    thetarget = Path(target)
-
-    if thetarget.exists() and not thetarget.is_symlink():
-        raise OSError(f"Target file {thetarget} exists already as a normal file.")
-
-    os.symlink(source, target)
-
-    if not (thetarget.exists() and thetarget.is_symlink()):
-        raise OSError(f"Target file {thesource} does not exist or is not a symlink.")
-
-
-def size(fname: str) -> int:
-    """Size of file, in bytes"""
-    return Path(fname).stat().st_size
-
-
 def uuid_from_string(string: str) -> uuid.UUID:
     """Produce valid and repeteable UUID4 as a hash of given string"""
     return uuid.UUID(hashlib.md5(string.encode("utf-8")).hexdigest())
@@ -148,39 +124,6 @@ def check_if_number(value: str | None) -> int | float | str | None:
     return value
 
 
-def get_object_name(obj: Path) -> str | None:
-    """Get the name of the object.
-
-    If not possible, return None.
-    If result is 'unknown', return None (XTgeo defaults)
-    If object is a polygon, and object name is 'poly', return None (XTgeo defaults)
-    If object is a grid, and object name is 'noname', return None (XTgeo defaults)
-
-    """
-
-    logger.debug("Getting name from the data object itself")
-
-    try:
-        name = obj.name
-    except AttributeError:
-        logger.info("display.name could not be set")
-        return None
-
-    if isinstance(obj, xtgeo.RegularSurface) and name == "unknown":
-        logger.debug("Got 'unknown' as name from a surface object, returning None")
-        return None
-
-    if isinstance(obj, xtgeo.Polygons) and name == "poly":
-        logger.debug("Got 'poly' as name from a polygons object, returning None")
-        return None
-
-    if isinstance(obj, xtgeo.Grid) and name == "noname":
-        logger.debug("Got 'noname' as name from grids object, returning None")
-        return None
-
-    return name
-
-
 def prettyprint_dict(inp: dict) -> str:
     """Prettyprint a dict into as string variable (for python logging e.g)"""
     return str(json.dumps(inp, indent=2, default=str, ensure_ascii=False))
@@ -204,11 +147,6 @@ def some_config_from_env(envvar: str = "FMU_GLOBAL_CONFIG") -> dict | None:
             f"{envvar} = {os.environ[envvar]}. "
             f"The environment variable {envvar} must point to a valid yaml file."
         ) from e
-
-
-def read_named_envvar(envvar: str) -> str | None:
-    """Read a specific (named) environment variable."""
-    return os.environ.get(envvar, None)
 
 
 def filter_validate_metadata(metadata_in: dict) -> dict:

--- a/src/fmu/dataio/aggregation.py
+++ b/src/fmu/dataio/aggregation.py
@@ -12,6 +12,11 @@ from . import _utils, dataio, types
 from ._logging import null_logger
 from ._metadata import generate_meta_tracklog
 from .providers.objectdata._provider import objectdata_provider_factory
+from .writers import (
+    export_file_compute_checksum_md5,
+    export_metadata_file,
+    export_temp_file_compute_checksum_md5,
+)
 
 logger: Final = null_logger(__name__)
 
@@ -243,7 +248,7 @@ class AggregatedData:
             "absolute_path": str(abspath) if abspath else None,
         }
         if compute_md5:
-            template["file"]["checksum_md5"] = _utils.compute_md5_using_temp_file(
+            template["file"]["checksum_md5"] = export_temp_file_compute_checksum_md5(
                 obj, objdata.extension
             )
 
@@ -350,11 +355,11 @@ class AggregatedData:
 
         logger.info("Export to file and compute MD5 sum")
         # inject the computed md5 checksum in metadata
-        metadata["file"]["checksum_md5"] = _utils.export_file_compute_checksum_md5(
+        metadata["file"]["checksum_md5"] = export_file_compute_checksum_md5(
             obj, outfile
         )
 
-        _utils.export_metadata_file(metafile, metadata, savefmt=self.meta_format)
+        export_metadata_file(metafile, metadata, savefmt=self.meta_format)
         logger.info("Actual file is:   %s", outfile)
         logger.info("Metadata file is: %s", metafile)
 

--- a/src/fmu/dataio/case.py
+++ b/src/fmu/dataio/case.py
@@ -14,6 +14,7 @@ from ._logging import null_logger
 from .datastructure._internal import internal
 from .datastructure.configuration import global_configuration
 from .datastructure.meta import meta
+from .writers import export_metadata_file
 
 logger: Final = null_logger(__name__)
 
@@ -151,7 +152,7 @@ class InitializeCase:  # pylint: disable=too-few-public-methods
             Full path of metadata file.
         """
         if self.generate_metadata():
-            _utils.export_metadata_file(
+            export_metadata_file(
                 self._metafile, self._metadata, savefmt=self.meta_format
             )
             logger.info("METAFILE %s", self._metafile)

--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -24,10 +24,7 @@ from ._logging import null_logger
 from ._metadata import generate_export_metadata
 from ._utils import (
     detect_inside_rms,  # dataio_examples,
-    export_file,
-    export_metadata_file,
     prettyprint_dict,
-    read_metadata_from_file,
     some_config_from_env,
 )
 from .aggregation import AggregatedData
@@ -36,6 +33,8 @@ from .datastructure._internal.internal import AllowedContent
 from .datastructure.configuration import global_configuration
 from .datastructure.meta import meta
 from .providers._fmu import FmuProvider, get_fmu_context_from_environment
+from .readers import read_metadata_from_file
+from .writers import export_file, export_metadata_file
 
 # DATAIO_EXAMPLES: Final = dataio_examples()
 INSIDE_RMS: Final = detect_inside_rms()

--- a/src/fmu/dataio/providers/_filedata.py
+++ b/src/fmu/dataio/providers/_filedata.py
@@ -14,10 +14,8 @@ from warnings import warn
 
 from fmu.dataio._definitions import FmuContext
 from fmu.dataio._logging import null_logger
-from fmu.dataio._utils import (
-    compute_md5_using_temp_file,
-)
 from fmu.dataio.datastructure.meta import meta
+from fmu.dataio.writers import export_temp_file_compute_checksum_md5
 
 logger: Final = null_logger(__name__)
 
@@ -106,7 +104,7 @@ class FileDataProvider:
         """Compute an MD5 sum using a temporary file."""
         if self.obj is None:
             raise ValueError("Can't compute MD5 sum without an object.")
-        return compute_md5_using_temp_file(
+        return export_temp_file_compute_checksum_md5(
             self.obj, self.objdata.extension, self.dataio._usefmtflag
         )
 

--- a/src/fmu/dataio/providers/_fmu.py
+++ b/src/fmu/dataio/providers/_fmu.py
@@ -42,6 +42,7 @@ from fmu.dataio._definitions import FmuContext
 from fmu.dataio._logging import null_logger
 from fmu.dataio.datastructure._internal import internal
 from fmu.dataio.datastructure.meta import meta
+from fmu.dataio.readers import read_parameters_txt
 
 if TYPE_CHECKING:
     from uuid import UUID
@@ -254,7 +255,7 @@ class FmuProvider:
             warn("The parameters.txt file was not found", UserWarning)
             return None
 
-        params = _utils.read_parameters_txt(parameters_file)
+        params = read_parameters_txt(parameters_file)
         logger.debug("parameters.txt parsed.")
         # BUG(?): value can contain Nones, loop in fn. below
         # does contains check, will fail.

--- a/src/fmu/dataio/types.py
+++ b/src/fmu/dataio/types.py
@@ -5,8 +5,6 @@ from typing import TYPE_CHECKING, Literal, MutableMapping, Union
 
 from typing_extensions import Annotated, TypeAlias
 
-from .readers import FaultRoomSurface
-
 if TYPE_CHECKING:
     from pandas import DataFrame
     from pyarrow import Table
@@ -14,6 +12,8 @@ if TYPE_CHECKING:
     from xtgeo.grid3d import Grid, GridProperty
     from xtgeo.surface import RegularSurface
     from xtgeo.xyz import Points, Polygons
+
+    from .readers import FaultRoomSurface
 
     # Local proxies due to xtgeo at the time of writing
     # not having stubs/marked itself as a typed library.

--- a/src/fmu/dataio/writers.py
+++ b/src/fmu/dataio/writers.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import TYPE_CHECKING, Final, Literal
+
+import pandas as pd
+import xtgeo
+import yaml
+
+from ._logging import null_logger
+from ._utils import drop_nones, md5sum
+from .readers import FaultRoomSurface
+
+if TYPE_CHECKING:
+    from . import types
+
+logger: Final = null_logger(__name__)
+
+
+def export_metadata_file(
+    file: Path,
+    metadata: dict,
+    savefmt: Literal["yaml", "json"] = "yaml",
+) -> None:
+    """Export genericly and ordered to the complementary metadata file."""
+    if not metadata:
+        raise RuntimeError(
+            "Export of metadata was requested, but no metadata are present."
+        )
+
+    if savefmt == "yaml":
+        with open(file, "w", encoding="utf8") as stream:
+            stream.write(
+                yaml.safe_dump(
+                    drop_nones(metadata),
+                    allow_unicode=True,
+                )
+            )
+    else:
+        with open(file.replace(file.with_suffix(".json")), "w") as stream:
+            stream.write(
+                json.dumps(
+                    drop_nones(metadata),
+                    default=str,
+                    indent=2,
+                    ensure_ascii=False,
+                )
+            )
+
+    logger.info("Yaml file on: %s", file)
+
+
+def export_file(
+    obj: types.Inferrable,
+    filename: Path,
+    flag: str | None = None,
+) -> str:
+    """Export a valid object to file"""
+
+    if isinstance(obj, (Path, str)):
+        # special case when processing data which already has metadata
+        shutil.copy(obj, filename)
+    elif filename.suffix == ".gri" and isinstance(obj, xtgeo.RegularSurface):
+        obj.to_file(filename, fformat="irap_binary")
+    elif filename.suffix == ".csv" and isinstance(obj, (xtgeo.Polygons, xtgeo.Points)):
+        out = obj.copy()  # to not modify incoming instance!
+        assert flag is not None
+        if "xtgeo" not in flag:
+            out.xname = "X"
+            out.yname = "Y"
+            out.zname = "Z"
+            if isinstance(out, xtgeo.Polygons):
+                # out.pname = "ID"  not working
+                out.get_dataframe(copy=False).rename(
+                    columns={out.pname: "ID"}, inplace=True
+                )
+        out.get_dataframe(copy=False).to_csv(filename, index=False)
+    elif filename.suffix == ".pol" and isinstance(obj, (xtgeo.Polygons, xtgeo.Points)):
+        obj.to_file(filename)
+    elif filename.suffix == ".segy" and isinstance(obj, xtgeo.Cube):
+        obj.to_file(filename, fformat="segy")
+    elif filename.suffix == ".roff" and isinstance(
+        obj, (xtgeo.Grid, xtgeo.GridProperty)
+    ):
+        obj.to_file(filename, fformat="roff")
+    elif filename.suffix == ".csv" and isinstance(obj, pd.DataFrame):
+        logger.info(
+            "Exporting dataframe to csv. Note: index columns will not be "
+            "preserved unless calling 'reset_index()' on the dataframe."
+        )
+        obj.to_csv(filename, index=False)
+    elif filename.suffix == ".arrow":
+        from pyarrow import Table
+
+        if isinstance(obj, Table):
+            from pyarrow import feather
+
+            # comment taken from equinor/webviz_subsurface/smry2arrow.py
+            # Writing here is done through the feather import, but could also be
+            # done using pa.RecordBatchFileWriter.write_table() with a few
+            # pa.ipc.IpcWriteOptions(). It is convenient to use feather since it
+            # has ready configured defaults and the actual file format is the same
+            # (https://arrow.apache.org/docs/python/feather.html)
+
+            # Types in pyarrow-stubs package are wrong for the write_feather(...).
+            # https://arrow.apache.org/docs/python/generated/pyarrow.feather.write_feather.html#pyarrow.feather.write_feather
+            feather.write_feather(obj, dest=str(filename))  # type: ignore
+    elif filename.suffix == ".json" and isinstance(obj, FaultRoomSurface):
+        with open(filename, "w") as stream:
+            json.dump(obj.storage, stream, indent=4)
+    elif filename.suffix == ".json":
+        with open(filename, "w") as stream:
+            json.dump(obj, stream)
+    else:
+        raise TypeError(f"Exporting {filename.suffix} for {type(obj)} is not supported")
+
+    return str(filename)
+
+
+def export_file_compute_checksum_md5(
+    obj: types.Inferrable,
+    filename: Path,
+    flag: str | None = None,
+) -> str:
+    """Export and compute checksum"""
+    export_file(obj, filename, flag=flag)
+    return md5sum(filename)
+
+
+def export_temp_file_compute_checksum_md5(
+    obj: types.Inferrable, extension: str, flag: str = ""
+) -> str:
+    """Compute an MD5 sum using a temporary file."""
+    if not extension.startswith("."):
+        raise ValueError("An extension must start with '.'")
+
+    with NamedTemporaryFile(buffering=0, suffix=extension) as tf:
+        logger.info("Compute MD5 sum for tmp file...: %s", tf.name)
+        return export_file_compute_checksum_md5(
+            obj=obj, filename=Path(tf.name), flag=flag
+        )

--- a/tests/test_units/test_dictionary.py
+++ b/tests/test_units/test_dictionary.py
@@ -8,7 +8,8 @@ from tempfile import NamedTemporaryFile
 import pytest
 import yaml
 from fmu.dataio import ExportData
-from fmu.dataio._utils import nested_parameters_dict, read_parameters_txt
+from fmu.dataio._utils import nested_parameters_dict
+from fmu.dataio.readers import read_parameters_txt
 
 
 @pytest.fixture(name="direct_creation", scope="function")

--- a/tests/test_units/test_utils.py
+++ b/tests/test_units/test_utils.py
@@ -1,12 +1,7 @@
 """Test the utils module"""
 
-import os
-from tempfile import NamedTemporaryFile
-
-import numpy as np
 import pytest
 from fmu.dataio import _utils as utils
-from xtgeo import Grid, Polygons, RegularSurface
 
 from ..utils import inside_rms
 
@@ -33,53 +28,6 @@ def test_check_if_number(value, result):
     assert utils.check_if_number(value) == result
 
 
-def test_get_object_name():
-    assert utils.get_object_name(object()) is None
-
-    assert utils.get_object_name(RegularSurface(0, 0, 0, 0)) is None
-    assert utils.get_object_name(RegularSurface(0, 0, 0, 0, name="unknown")) is None
-    assert (
-        utils.get_object_name(RegularSurface(0, 0, 0, 0, name="Not ukn")) == "Not ukn"
-    )
-
-    assert utils.get_object_name(Polygons()) is None
-    assert utils.get_object_name(Polygons(name="poly")) is None
-    assert utils.get_object_name(Polygons(name="Not poly")) == "Not poly"
-
-    assert (
-        utils.get_object_name(
-            Grid(
-                np.random.randn(2, 2, 6).astype(np.float64),
-                np.random.randn(2, 2, 2, 4).astype(np.float32),
-                np.random.randn(1, 1, 1).astype(np.int32),
-            )
-        )
-        is None
-    )
-    assert (
-        utils.get_object_name(
-            Grid(
-                np.random.randn(2, 2, 6).astype(np.float64),
-                np.random.randn(2, 2, 2, 4).astype(np.float32),
-                np.random.randn(1, 1, 1).astype(np.int32),
-                name="noname",
-            )
-        )
-        is None
-    )
-    assert (
-        utils.get_object_name(
-            Grid(
-                np.random.randn(2, 2, 6).astype(np.float64),
-                np.random.randn(2, 2, 2, 4).astype(np.float32),
-                np.random.randn(1, 1, 1).astype(np.int32),
-                name="Not noname",
-            )
-        )
-        == "Not noname"
-    )
-
-
 @inside_rms
 def test_detect_inside_rms_decorator():
     assert utils.detect_inside_rms()
@@ -87,22 +35,6 @@ def test_detect_inside_rms_decorator():
 
 def test_detect_not_inside_rms():
     assert not utils.detect_inside_rms()
-
-
-def test_create_symlink():
-    with pytest.raises(OSError):
-        utils.create_symlink(
-            "hopefullythispathwillneverexist",
-            "norwillthispath",
-        )
-
-    with NamedTemporaryFile() as source, NamedTemporaryFile() as target, pytest.raises(
-        OSError
-    ):
-        utils.create_symlink(
-            source.name,
-            target.name,
-        )
 
 
 def test_generate_description():
@@ -118,10 +50,3 @@ def test_generate_description():
 
     with pytest.raises(ValueError):
         utils.generate_description(object())
-
-
-def test_read_named_envvar():
-    assert utils.read_named_envvar("DONTEXIST") is None
-
-    os.environ["MYTESTENV"] = "mytestvalue"
-    assert utils.read_named_envvar("MYTESTENV") == "mytestvalue"

--- a/tests/test_units/test_utils.py
+++ b/tests/test_units/test_utils.py
@@ -1,7 +1,6 @@
 """Test the utils module"""
 
 import os
-from pathlib import Path
 from tempfile import NamedTemporaryFile
 
 import numpy as np
@@ -88,27 +87,6 @@ def test_detect_inside_rms_decorator():
 
 def test_detect_not_inside_rms():
     assert not utils.detect_inside_rms()
-
-
-def test_non_metadata_export_metadata_file():
-    with NamedTemporaryFile(buffering=0, suffix=".yaml") as tf, pytest.raises(
-        RuntimeError
-    ):
-        utils.export_metadata_file(Path(tf.name), {}, savefmt="json")
-
-    with NamedTemporaryFile(buffering=0, suffix=".yaml") as tf, pytest.raises(
-        RuntimeError
-    ):
-        utils.export_metadata_file(Path(tf.name), {}, savefmt="yaml")
-
-
-def test_export_file_raises():
-    with NamedTemporaryFile() as tf, pytest.raises(TypeError):
-        utils.export_file(
-            object(),
-            Path(tf.name),
-            ".placeholder",
-        )
 
 
 def test_create_symlink():

--- a/tests/test_units/test_writers.py
+++ b/tests/test_units/test_writers.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+import pytest
+from fmu.dataio.writers import export_file, export_metadata_file
+
+
+def test_non_metadata_export_metadata_file():
+    with NamedTemporaryFile(buffering=0, suffix=".yaml") as tf, pytest.raises(
+        RuntimeError
+    ):
+        export_metadata_file(Path(tf.name), {}, savefmt="json")
+
+    with NamedTemporaryFile(buffering=0, suffix=".yaml") as tf, pytest.raises(
+        RuntimeError
+    ):
+        export_metadata_file(Path(tf.name), {}, savefmt="yaml")
+
+
+def test_export_file_raises():
+    with NamedTemporaryFile() as tf, pytest.raises(TypeError):
+        export_file(
+            object(),
+            Path(tf.name),
+            ".placeholder",
+        )


### PR DESCRIPTION
Cuts down the `_utils` module, separating io to their own modules.

Named `writers` to pair off with existing `readers`, but `export` (or `_export`) could be valid too.

Renaming and moving `compute_md5_using_temp_file` is mostly pragmatic to avoid circular dependencies between utils and writers.