### PR TITLE
ENH: Add classification and rep_include argument

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -281,10 +281,8 @@ def fixture_globalconfig1():
         ),
         access=global_configuration.Access(
             asset=global_configuration.Asset(name="Test"),
-            ssdl=global_configuration.Ssdl(
-                access_level=global_configuration.enums.AccessLevel.internal,
-                rep_include=False,
-            ),
+            ssdl=global_configuration.Ssdl(rep_include=False),
+            classification=global_configuration.enums.AccessLevel.internal,
         ),
         model=global_configuration.Model(
             name="Test",
@@ -299,7 +297,7 @@ def fixture_globalconfig1():
                 )
             }
         ),
-    ).model_dump()
+    ).model_dump(exclude_none=True)
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
PR that adds a two new arguments, `classification`  and `rep_include`, and deprecates the `ssdl_access` argument.

Kudos to @perolavsvendsen for describing the issue, and doing the groundwork in his PR https://github.com/equinor/fmu-dataio/pull/575

closes #601
closes #595
closes #540 

**Note:**
This PR does not solve the issue with state of classification being stored within the ExportData instance, and we should focus on #525 next to minimize the logic around classification.