### PR TITLE
ENH: add data.geometry for option to link to geometry

### DIFF
--- a/schema/definitions/0.8.0/schema/fmu_meta.json
+++ b/schema/definitions/0.8.0/schema/fmu_meta.json
@@ -3293,7 +3293,7 @@
         },
         "relative_path": {
           "examples": [
-            "../some/relative/path/mygrid.roff"
+            "some/relative/path/mygrid.roff"
           ],
           "title": "Relative Path",
           "type": "string"

--- a/schema/definitions/0.8.0/schema/fmu_meta.json
+++ b/schema/definitions/0.8.0/schema/fmu_meta.json
@@ -643,6 +643,17 @@
           "title": "Format",
           "type": "string"
         },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "grid_model": {
           "anyOf": [
             {
@@ -1323,6 +1334,17 @@
           "title": "Format",
           "type": "string"
         },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "grid_model": {
           "anyOf": [
             {
@@ -1608,6 +1630,17 @@
           "title": "Format",
           "type": "string"
         },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "grid_model": {
           "anyOf": [
             {
@@ -1892,6 +1925,17 @@
           ],
           "title": "Format",
           "type": "string"
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "grid_model": {
           "anyOf": [
@@ -2279,6 +2323,17 @@
           "title": "Format",
           "type": "string"
         },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "grid_model": {
           "anyOf": [
             {
@@ -2582,6 +2637,17 @@
           ],
           "title": "Format",
           "type": "string"
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "grid_model": {
           "anyOf": [
@@ -2988,6 +3054,17 @@
           "title": "Format",
           "type": "string"
         },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "grid_model": {
           "anyOf": [
             {
@@ -3205,6 +3282,30 @@
       "title": "FluidContactContent",
       "type": "object"
     },
+    "Geometry": {
+      "properties": {
+        "name": {
+          "examples": [
+            "MyGrid"
+          ],
+          "title": "Name",
+          "type": "string"
+        },
+        "relative_path": {
+          "examples": [
+            "../some/relative/path/mygrid.roff"
+          ],
+          "title": "Relative Path",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "relative_path"
+      ],
+      "title": "Geometry",
+      "type": "object"
+    },
     "GridModel": {
       "properties": {
         "name": {
@@ -3289,6 +3390,17 @@
           ],
           "title": "Format",
           "type": "string"
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "grid_model": {
           "anyOf": [
@@ -3631,6 +3743,17 @@
           "title": "Format",
           "type": "string"
         },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "grid_model": {
           "anyOf": [
             {
@@ -3944,6 +4067,17 @@
           "title": "Format",
           "type": "string"
         },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "grid_model": {
           "anyOf": [
             {
@@ -4240,6 +4374,17 @@
           ],
           "title": "Format",
           "type": "string"
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "grid_model": {
           "anyOf": [
@@ -4546,6 +4691,17 @@
           "title": "Format",
           "type": "string"
         },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "grid_model": {
           "anyOf": [
             {
@@ -4830,6 +4986,17 @@
           ],
           "title": "Format",
           "type": "string"
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "grid_model": {
           "anyOf": [
@@ -5164,6 +5331,17 @@
           "title": "Format",
           "type": "string"
         },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "grid_model": {
           "anyOf": [
             {
@@ -5448,6 +5626,17 @@
           ],
           "title": "Format",
           "type": "string"
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "grid_model": {
           "anyOf": [
@@ -5789,6 +5978,17 @@
           "title": "Format",
           "type": "string"
         },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "grid_model": {
           "anyOf": [
             {
@@ -6073,6 +6273,17 @@
           ],
           "title": "Format",
           "type": "string"
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "grid_model": {
           "anyOf": [
@@ -6446,6 +6657,17 @@
           ],
           "title": "Format",
           "type": "string"
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "grid_model": {
           "anyOf": [
@@ -6845,6 +7067,17 @@
           ],
           "title": "Format",
           "type": "string"
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "grid_model": {
           "anyOf": [
@@ -7322,6 +7555,17 @@
           "title": "Format",
           "type": "string"
         },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "grid_model": {
           "anyOf": [
             {
@@ -7635,6 +7879,17 @@
           "title": "Format",
           "type": "string"
         },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "grid_model": {
           "anyOf": [
             {
@@ -7919,6 +8174,17 @@
           ],
           "title": "Format",
           "type": "string"
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "grid_model": {
           "anyOf": [
@@ -8263,6 +8529,17 @@
           "title": "Format",
           "type": "string"
         },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "grid_model": {
           "anyOf": [
             {
@@ -8561,6 +8838,17 @@
           "title": "Format",
           "type": "string"
         },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "grid_model": {
           "anyOf": [
             {
@@ -8846,6 +9134,17 @@
           "title": "Format",
           "type": "string"
         },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "grid_model": {
           "anyOf": [
             {
@@ -9130,6 +9429,17 @@
           ],
           "title": "Format",
           "type": "string"
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "grid_model": {
           "anyOf": [

--- a/src/fmu/dataio/_utils.py
+++ b/src/fmu/dataio/_utils.py
@@ -463,3 +463,35 @@ def glue_metadata_preprocessed(
     meta["tracklog"].extend(newmeta["tracklog"])
 
     return meta
+
+
+def get_geometry_ref(geometrypath: str, obj: Any) -> dict[str]:
+    """Get a reference to a geometry.
+
+    Read the metadata file for an already exported file, and returns info like this
+    for the data block:
+
+    data:
+      geometry:
+        name: somename
+        relative_path: some_relative/path/geometry.roff
+
+    This means that the geometry may be 'located' both on disk (relative path) and in
+    SUMO
+    """
+    if not geometrypath:
+        return {}
+
+    gmeta = read_metadata_from_file(geometrypath)
+
+    # some basic checks (may be exteneded to e.g. match on NCOL, NROW, ...?)
+    if isinstance(obj, xtgeo.GridProperty) and gmeta["class"] != "cpgrid":
+        raise ValueError("The geometry for a grid property must be a grid")
+
+    if isinstance(obj, xtgeo.RegularSurface) and gmeta["class"] != "surface":
+        raise ValueError("The geometry for a surface must be another surface")
+
+    geom_name = gmeta["data"].get("name", "")
+    relpath = gmeta["file"]["relative_path"]
+
+    return {"name": geom_name, "relative_path": relpath}

--- a/src/fmu/dataio/_utils.py
+++ b/src/fmu/dataio/_utils.py
@@ -465,7 +465,7 @@ def glue_metadata_preprocessed(
     return meta
 
 
-def get_geometry_ref(geometrypath: str, obj: Any) -> dict[str]:
+def get_geometry_ref(geometrypath: str | None, obj: Any) -> dict[str, str]:
     """Get a reference to a geometry.
 
     Read the metadata file for an already exported file, and returns info like this

--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -300,6 +300,12 @@ class ExportData:
             possible! (*) For absolute paths, the class variable
             allow_forcefolder_absolute must set to True.
 
+        geometry: Optional, and for some data types only, like grid properties and
+            surface(s), may need a reference to geometry (a 3D grid for grid
+            properties, a surface in depth or time for a surface). The
+            value shall point to an existing file which is already exported with
+            dataio, and hence has an assosiated metadata file.
+
         grid_model: Currently allowed but planned for deprecation
 
         table_index: This applies to Pandas (table) data only, and is a list of the
@@ -416,6 +422,7 @@ class ExportData:
     display_name: Optional[str] = None
     fmu_context: Optional[str] = None
     forcefolder: str = ""
+    geometry: Optional[str] = None
     grid_model: Optional[str] = None
     is_observation: bool = False
     is_prediction: bool = True

--- a/src/fmu/dataio/datastructure/meta/content.py
+++ b/src/fmu/dataio/datastructure/meta/content.py
@@ -97,6 +97,11 @@ class FieldRegion(BaseModel):
     )
 
 
+class Geometry(BaseModel):
+    name: str = Field(examples=["MyGrid"])
+    relative_path: str = Field(examples=["some/relative/path/mygrid.roff"])
+
+
 class GridModel(BaseModel):
     name: str = Field(examples=["MyGrid"])
 
@@ -165,6 +170,8 @@ class Content(BaseModel):
     format: str = Field(
         examples=["irap_binary"],
     )
+
+    geometry: Optional[Geometry] = Field(default=None)
 
     grid_model: Optional[GridModel] = Field(default=None)
     is_observation: bool = Field(

--- a/src/fmu/dataio/providers/objectdata/_base.py
+++ b/src/fmu/dataio/providers/objectdata/_base.py
@@ -32,6 +32,7 @@ class DerivedObjectDescriptor:
     extension: str
     spec: dict[str, Any] | None
     bbox: dict[str, Any] | None
+    geometry: dict[str, Any] | None
     table_index: list[str] | None
 
 
@@ -299,6 +300,7 @@ class ObjectDataProvider(ABC):
             meta[self.dataio._usecontent] = content_spesific
 
         meta["tagname"] = self.dataio.tagname
+        meta["geometry"] = objres.geometry
         meta["format"] = objres.fmt
         meta["layout"] = objres.layout
         meta["unit"] = self.dataio.unit

--- a/src/fmu/dataio/providers/objectdata/_faultroom.py
+++ b/src/fmu/dataio/providers/objectdata/_faultroom.py
@@ -63,5 +63,6 @@ class FaultRoomSurfaceProvider(ObjectDataProvider):
             spec=self.get_spec(),
             bbox=self.get_bbox(),
             extension=self._validate_get_ext(fmt, "JSON", ValidFormats().dictionary),
+            geometry=None,
             table_index=None,
         )

--- a/src/fmu/dataio/providers/objectdata/_provider.py
+++ b/src/fmu/dataio/providers/objectdata/_provider.py
@@ -186,6 +186,7 @@ class ExistingDataProvider(ObjectDataProvider):
             extension=self.extension,
             spec=self.get_spec(),
             bbox=self.get_bbox(),
+            geometry=None,
             table_index=None,
         )
 
@@ -220,5 +221,6 @@ class DictionaryDataProvider(ObjectDataProvider):
             extension=self._validate_get_ext(fmt, "JSON", ValidFormats().dictionary),
             spec=self.get_spec() or None,
             bbox=self.get_bbox() or None,
+            geometry=None,
             table_index=None,
         )

--- a/src/fmu/dataio/providers/objectdata/_tables.py
+++ b/src/fmu/dataio/providers/objectdata/_tables.py
@@ -88,6 +88,7 @@ class DataFrameDataProvider(ObjectDataProvider):
             extension=self._validate_get_ext(fmt, "DataFrame", ValidFormats().table),
             spec=self.get_spec(),
             bbox=self.get_bbox() or None,
+            geometry=None,
             table_index=table_index,
         )
 
@@ -125,5 +126,6 @@ class ArrowTableDataProvider(ObjectDataProvider):
             extension=self._validate_get_ext(fmt, "ArrowTable", ValidFormats().table),
             spec=self.get_spec(),
             bbox=self.get_bbox() or None,
+            geometry=None,
             table_index=table_index,
         )

--- a/src/fmu/dataio/providers/objectdata/_xtgeo.py
+++ b/src/fmu/dataio/providers/objectdata/_xtgeo.py
@@ -9,7 +9,7 @@ import xtgeo
 
 from fmu.dataio._definitions import ValidFormats
 from fmu.dataio._logging import null_logger
-from fmu.dataio._utils import npfloat_to_float
+from fmu.dataio._utils import get_geometry_ref, npfloat_to_float
 from fmu.dataio.datastructure.meta import meta, specification
 
 from ._base import (
@@ -76,6 +76,7 @@ class RegularSurfaceDataProvider(ObjectDataProvider):
             extension=self._validate_get_ext(
                 fmt, "RegularSurface", ValidFormats().surface
             ),
+            geometry=get_geometry_ref(self.dataio.geometry, self.obj) or None,
             table_index=None,
         )
 
@@ -125,6 +126,7 @@ class PolygonsDataProvider(ObjectDataProvider):
             extension=self._validate_get_ext(fmt, "Polygons", ValidFormats().polygons),
             spec=self.get_spec(),
             bbox=self.get_bbox(),
+            geometry=None,
             table_index=None,
         )
 
@@ -179,6 +181,7 @@ class PointsDataProvider(ObjectDataProvider):
             extension=self._validate_get_ext(fmt, "Points", ValidFormats().points),
             spec=self.get_spec(),
             bbox=self.get_bbox(),
+            geometry=None,
             table_index=None,
         )
 
@@ -255,6 +258,7 @@ class CubeDataProvider(ObjectDataProvider):
             extension=self._validate_get_ext(fmt, "RegularCube", ValidFormats().cube),
             spec=self.get_spec(),
             bbox=self.get_bbox(),
+            geometry=None,
             table_index=None,
         )
 
@@ -315,6 +319,7 @@ class CPGridDataProvider(ObjectDataProvider):
             extension=self._validate_get_ext(fmt, "CPGrid", ValidFormats().grid),
             spec=self.get_spec(),
             bbox=self.get_bbox(),
+            geometry=None,
             table_index=None,
         )
 
@@ -354,5 +359,6 @@ class CPGridPropertyDataProvider(ObjectDataProvider):
             ),
             spec=self.get_spec(),
             bbox=self.get_bbox() or None,
+            geometry=get_geometry_ref(self.dataio.geometry, self.obj) or None,
             table_index=None,
         )


### PR DESCRIPTION
Replaces older un-merged PR #528 (but see discussion there).

This is particularly useful for a GridProperty, so we can refer to the grid object. But it can also be used for e.g. surfaces when wanting to link e.g. a property to a depth surface, for "draping" in WebViz.

Example stubs

```
gridfile = edata.export(grid_object)

porofile = edata.export(poro_object, geometry=gridfile)
```

It will then create in the metadata:

```
data:
   geometry:
      name: "mygrid"
      relative_path: "some/path/to/grid.roff"

```
