### PR TITLE
MAINT: Refactor AllowedContent

### DIFF
--- a/src/fmu/dataio/aggregation.py
+++ b/src/fmu/dataio/aggregation.py
@@ -234,16 +234,15 @@ class AggregatedData:
         # next, the new object will trigger update of: 'file', 'data' (some fields) and
         # 'tracklog'.
 
-        # Get content and make a temporary config from template to be allowed to
+        # Make a temporary config from template to be allowed to
         # initialize a temporary ExportData without warnings so that we can get to the
         # objectdata_provider
-        content = template["data"]["content"]
         config = {
             "access": template["access"],
             "masterdata": template["masterdata"],
             "model": template["fmu"]["model"],
         }
-        etemp = dataio.ExportData(config=config, name=self.name, content=content)
+        etemp = dataio.ExportData(config=config, name=self.name)
         objdata = objectdata_provider_factory(obj=obj, dataio=etemp).get_objectdata()
 
         template["tracklog"] = [generate_meta_tracklog()[0].model_dump(mode="json")]

--- a/src/fmu/dataio/datastructure/meta/enums.py
+++ b/src/fmu/dataio/datastructure/meta/enums.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
 from enum import Enum, IntEnum
+from typing import Type
 
 
 class ContentEnum(str, Enum):
-    # NB! See also AllowedContent in internal.py
-
     depth = "depth"
     facies_thickness = "facies_thickness"
     fault_lines = "fault_lines"
@@ -32,6 +31,12 @@ class ContentEnum(str, Enum):
     velocity = "velocity"
     volumes = "volumes"
     wellpicks = "wellpicks"
+
+    @classmethod
+    def _missing_(cls: Type[ContentEnum], value: object) -> None:
+        raise ValueError(
+            f"Invalid 'content' {value=}. Valid entries are {[m.value for m in cls]}"
+        )
 
 
 class FMUClassEnum(str, Enum):

--- a/tests/test_schema/test_pydantic_logic.py
+++ b/tests/test_schema/test_pydantic_logic.py
@@ -4,9 +4,7 @@ import logging
 from copy import deepcopy
 
 import pytest
-from fmu.dataio.datastructure._internal.internal import AllowedContent
 from fmu.dataio.datastructure.meta import Root
-from fmu.dataio.datastructure.meta.enums import ContentEnum
 from pydantic import ValidationError
 
 from ..utils import _metadata_examples
@@ -379,12 +377,3 @@ def test_content_whitelist(metadata_examples):
     example_surface["data"]["content"] = "not_valid_content"
     with pytest.raises(ValidationError):
         Root.model_validate(example_surface)
-
-
-@pytest.mark.parametrize("allowed_content", AllowedContent.model_fields.keys())
-def test_schema_content_synch_with_code(allowed_content):
-    """Currently, the whitelist for content is maintained both in the schema
-    and in the code. This test asserts that list used in the code is in synch
-    with schema. Note! This is one-way, and will not fail if additional
-    elements are added to the schema only."""
-    assert allowed_content in {v.name for v in ContentEnum}

--- a/tests/test_units/test_contents.py
+++ b/tests/test_units/test_contents.py
@@ -133,6 +133,33 @@ def test_content_property(gridproperty, globalconfig2):
     assert meta["data"]["content"] == "property"
 
 
+def test_content_property_as_dict(gridproperty, globalconfig2):
+    """Test export of the property content."""
+    content_specifc = {"attribute": "porosity", "is_discrete": False}
+    meta = ExportData(
+        config=globalconfig2,
+        name="MyName",
+        content={"property": content_specifc},
+    ).generate_metadata(gridproperty)
+
+    assert meta["data"]["content"] == "property"
+    # TODO: add next line when schema defines content_specific for property
+    # assert meta["data"]["property"] == content_specifc
+
+
+def test_content_seismic_as_dict(gridproperty, globalconfig2):
+    """Test export of the property content."""
+    content_specifc = {"attribute": "amplitude", "calculation": "mean"}
+    meta = ExportData(
+        config=globalconfig2,
+        name="MyName",
+        content={"seismic": content_specifc},
+    ).generate_metadata(gridproperty)
+
+    assert meta["data"]["content"] == "seismic"
+    assert meta["data"]["seismic"] == content_specifc
+
+
 def test_content_pvt(dataframe, globalconfig2):
     """Test export of the pvt content."""
     meta = ExportData(

--- a/tests/test_units/test_prerealization_surfaces.py
+++ b/tests/test_units/test_prerealization_surfaces.py
@@ -120,6 +120,8 @@ def test_regsurf_preprocessed_observation(
         assert metadata["data"]["name"] == "VOLANTIS GP. Top"
         assert "TopVolantis" in metadata["data"]["alias"]
         assert "_preprocessed" not in metadata
+        # check that content comes from the existing metadata
+        assert metadata["data"]["content"] == "depth"
 
         # do the actual export (which will copy data to case/share/observations/...)
         edata.export(


### PR DESCRIPTION
PR to refactor `AllowedContent`

- Change to doing most validation of `content` inside Pydantic
- Use the pydantic models for the schema for content that requires extra information inside `AllowedContent`.
- Get away from needing to keep `AllowedContent` and `ContentEnum` in sync
- Start requiring `content="seismic"` as dictionary with extra input - adresses #598
  - keep deprecation warning for `content="property"` without extra info longer. Turned out that it is allowed in the schema.
