### PR TITLE
MAINT: Simplify rootpath establishment

### DIFF
--- a/src/fmu/dataio/providers/_fmu.py
+++ b/src/fmu/dataio/providers/_fmu.py
@@ -122,6 +122,8 @@ class FmuProvider:
         logger.debug("Case path is initially <%s>...", self.casepath_proposed)
 
         self._runpath = self._get_runpath_from_env()
+        logger.debug("Runpath is %s", self._runpath)
+
         self._real_id = (
             int(iter_num) if (iter_num := FmuEnv.REALIZATION_NUMBER.value) else 0
         )

--- a/tests/test_units/test_dataio.py
+++ b/tests/test_units/test_dataio.py
@@ -543,9 +543,15 @@ def test_fmu_context_not_given_fetch_from_env_case(fmurun_prehook, rmsglobalconf
     assert FmuEnv.RUNPATH.value is None
     assert FmuEnv.EXPERIMENT_ID.value is not None
 
-    edata = ExportData(config=rmsglobalconfig, content="depth")
+    # will give error when casepath not provided
+    with pytest.raises(ValueError, match="Could not auto detect"):
+        edata = ExportData(config=rmsglobalconfig, content="depth")
+
+    # test that it runs properly when casepath is provided
+    edata = ExportData(config=rmsglobalconfig, content="depth", casepath=fmurun_prehook)
     assert edata._fmurun is True
     assert edata.fmu_context == FmuContext.CASE
+    assert edata._rootpath == fmurun_prehook
 
 
 def test_fmu_context_not_given_fetch_from_env_nonfmu(rmsglobalconfig):
@@ -641,7 +647,7 @@ def test_norwegian_letters_globalconfig_as_json(
     ExportData.meta_format = "yaml"  # reset
 
 
-def test_establish_pwd_runpath(tmp_path, globalconfig2):
+def test_establish_runpath(tmp_path, globalconfig2):
     """Testing pwd and rootpath from RMS"""
     rmspath = tmp_path / "rms" / "model"
     rmspath.mkdir(parents=True, exist_ok=True)
@@ -649,7 +655,7 @@ def test_establish_pwd_runpath(tmp_path, globalconfig2):
 
     ExportData._inside_rms = True
     edata = ExportData(config=globalconfig2, content="depth")
-    edata._establish_pwd_rootpath()
+    edata._establish_rootpath()
 
     assert edata._rootpath == rmspath.parent.parent
 

--- a/tests/test_units/test_objectdataprovider_class.py
+++ b/tests/test_units/test_objectdataprovider_class.py
@@ -169,11 +169,9 @@ def test_regsurf_preprocessed_observation(
             fmu_context="case",
             content=None,
             is_observation=True,
-        )
-        return edata.generate_metadata(
-            surfacepath,
             casepath=casepath,
         )
+        return edata.generate_metadata(surfacepath)
 
     # run two stage process
     edata, mysurf = _export_data_from_rms(rmssetup, rmsglobalconfig, regsurf)

--- a/tests/test_units/test_prerealization_surfaces.py
+++ b/tests/test_units/test_prerealization_surfaces.py
@@ -105,11 +105,9 @@ def test_regsurf_preprocessed_observation(
             fmu_context="case",
             content=None,  # shall be accepted without warning here in this context
             is_observation=True,
-        )
-        metadata = edata.generate_metadata(
-            surfacepath,
             casepath=casepath,
         )
+        metadata = edata.generate_metadata(surfacepath)
         logger.info("Casepath folder is now %s", casepath)
         logger.debug("\n%s", utils.prettyprint_dict(metadata))
         assert (
@@ -124,10 +122,7 @@ def test_regsurf_preprocessed_observation(
         assert metadata["data"]["content"] == "depth"
 
         # do the actual export (which will copy data to case/share/observations/...)
-        edata.export(
-            surfacepath,
-            casepath=casepath,
-        )
+        edata.export(surfacepath)
         assert (
             casepath
             / "share"


### PR DESCRIPTION
PR to collect the establishment of the `dataio._rootpath` in the ExportData initialization, to make it easier to understand how this important variable is set, and avoid overriding the state of the _roothpath later.

1. Use` ERT casepath` if in FMU context
2. Use` rms/model/../../.` if inside RMS and outside FMU
3. Use `pwd` if not inside RMS or running in FMU context

In order to do this it was needed to disallow updating `casepath` inside `export/generate_metadata`.