### PR TITLE
REV: Support casepath argument outside of ExportData

### DIFF
--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -662,12 +662,6 @@ class ExportData:
         if "config" in newsettings:
             raise ValueError("Cannot have 'config' outside instance initialization")
 
-        if "casepath" in newsettings:
-            raise ValueError(
-                "Not possible to update 'casepath' on export/generate_metadata. "
-                "Use instead ExportData(casepath='mycasepath')"
-            )
-
         for setting, value in newsettings.items():
             if _validate_variable(setting, value, legals):
                 setattr(self, setting, value)
@@ -676,6 +670,7 @@ class ExportData:
         self._show_deprecations_or_notimplemented()
         self._validate_workflow_key()
         self._validate_and_establish_fmucontext()
+        self._rootpath = self._establish_rootpath()
 
     def _establish_rootpath(self) -> Path:
         """

--- a/src/fmu/dataio/providers/_fmu.py
+++ b/src/fmu/dataio/providers/_fmu.py
@@ -220,9 +220,9 @@ class FmuProvider:
                 return self._runpath.parent
 
         if self.fmu_context == FmuContext.CASE:
-            raise ValueError(
-                "Could not auto detect the casepath, please provide it as input."
-            )
+            # TODO: Change to ValueError when no longer kwargs are accepted in export()
+            warn("Could not auto detect the casepath, please provide it as input.")
+
         logger.debug("No case metadata, issue a warning!")
         warn("Case metadata does not exist, metadata will be empty!", UserWarning)
         return None

--- a/tests/test_units/test_fmuprovider_class.py
+++ b/tests/test_units/test_fmuprovider_class.py
@@ -223,7 +223,7 @@ def test_fmuprovider_case_run(fmurun_prehook):
     # make sure that no runpath environment value is present
     assert FmuEnv.RUNPATH.value is None
 
-    with pytest.raises(ValueError, match="Could not auto detect the casepath"):
+    with pytest.warns(UserWarning, match="Could not auto detect the casepath"):
         FmuProvider(
             model=GLOBAL_CONFIG_MODEL,
             fmu_context=FmuContext.CASE,


### PR DESCRIPTION
#643 Introduced a breaking change where `casepath` was not allowed to be updated outside `ExportData` initialization.
This was a bit premature and caused Drogon to fail. We need to have a deprecation period for this before removing the option.