### PR TITLE
TST: Fix inproper environment framework

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,6 +74,21 @@ def _fmu_run1_env_variables(monkeypatch, usepath="", case_only=False):
         logger.debug("Setting env %s as %s", key, env_value)
 
 
+def remove_ert_env(monkeypatch):
+    for key in ERTRUN_ENV_FULLRUN:
+        monkeypatch.delenv(key, raising=False)
+
+
+def set_ert_env_forward(monkeypatch):
+    for key, val in ERTRUN_ENV_FORWARD.items():
+        monkeypatch.setenv(key, val)
+
+
+def set_ert_env_prehook(monkeypatch):
+    for key, val in ERTRUN_ENV_PREHOOK.items():
+        monkeypatch.setenv(key, val)
+
+
 @pytest.fixture(scope="function")
 def fmurun(tmp_path_factory, monkeypatch, rootpath):
     """A tmp folder structure for testing; here a new fmurun without case metadata."""

--- a/tests/test_units/test_rms_context.py
+++ b/tests/test_units/test_rms_context.py
@@ -13,6 +13,7 @@ import fmu.dataio.dataio as dataio
 import fmu.dataio.readers as readers
 import pandas as pd
 import pytest
+from fmu.dataio._definitions import FmuContext
 from fmu.dataio._utils import prettyprint_dict
 from fmu.dataio.dataio import ValidationError
 
@@ -373,7 +374,7 @@ def test_cube_export_file_set_name_as_observation_forcefolder(
 def test_cube_export_as_case(rmssetup, rmsglobalconfig, cube):
     """Export the cube to file with correct metadata and name, is_observation.
 
-    In addition, try fmu_conext=case
+    In addition try fmu_context=case; when inside rms this should be reset to "non-fmu"
     """
     logger.info("Active folder is %s", rmssetup)
     os.chdir(rmssetup)
@@ -390,7 +391,7 @@ def test_cube_export_as_case(rmssetup, rmsglobalconfig, cube):
         is_observation=True,
     )
     logger.info("Output %s", output)
-
+    assert edata.fmu_context == FmuContext.NON_FMU
     assert str(output) == str(
         (edata._rootpath / "share/observations/cubes/mycube.segy").resolve()
     )
@@ -503,7 +504,6 @@ def test_cube_export_as_observation_forcefolder_w_subfolder_case(
             cube,
             name="MyCube",
             is_observation=True,
-            fmu_context="case",
             forcefolder="seismic/xxx",
         )
     logger.info("Output after force is %s", output)


### PR DESCRIPTION
PR that closes #646  
(or at least tried to identify all **obvious** cases where inproper test setup occured 😄) 

Added some helper functions to be able to reset and set the ERT environment, to aid in the cases where we want to change this dynamically inside a test e.g. mocking running inside RMS interactively, and then running pre-sim workflow in ERT to re-export preprocessed data.  
