### PR TITLE
DEP: Deprecate fmu_context='preprocessed'

### DIFF
--- a/src/fmu/dataio/_definitions.py
+++ b/src/fmu/dataio/_definitions.py
@@ -83,16 +83,15 @@ class FmuContext(str, Enum):
     Use a Enum class for fmu_context entries.
 
     The different entries will impact where data is exported:
-    REALIZATION = "To realization-N/iter_M/share"
-    CASE = "To casename/share, but will also work on project disk"
-    PREPROCESSED = "To share/preprocessed; from interactive runs but re-used later"
-    NON_FMU = "Not ran in a FMU setting, e.g. interactive RMS"
-
+    REALIZATION: To realization-N/iter_M/share
+    CASE: To casename/share, but will also work on project disk
+    ITERATION: To casename/itername/share, only applicable for aggregated data
+    NON_FMU: Not ran in a FMU setting, e.g. interactive RMS.
     """
 
     REALIZATION = "realization"
     CASE = "case"
-    PREPROCESSED = "preprocessed"
+    ITERATION = "iteration"
     NON_FMU = "non-fmu"
 
     @classmethod

--- a/src/fmu/dataio/_metadata.py
+++ b/src/fmu/dataio/_metadata.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Final, Literal
 from pydantic import AnyHttpUrl, TypeAdapter
 
 from . import types
-from ._definitions import SCHEMA, SOURCE, VERSION, FmuContext
+from ._definitions import SCHEMA, SOURCE, VERSION
 from ._logging import null_logger
 from .datastructure._internal import internal
 from .datastructure.meta import meta
@@ -151,5 +151,5 @@ def generate_export_metadata(
         file=_get_meta_filedata(dataio, obj, objdata, fmudata, compute_md5),
         tracklog=generate_meta_tracklog(),
         display=_get_meta_display(dataio, objdata),
-        preprocessed=dataio.fmu_context == FmuContext.PREPROCESSED,
+        preprocessed=dataio.preprocessed,
     )

--- a/src/fmu/dataio/aggregation.py
+++ b/src/fmu/dataio/aggregation.py
@@ -9,6 +9,7 @@ from typing import ClassVar, Final, Literal, Optional, Union
 from pydantic import ValidationError
 
 from . import _utils, dataio, types
+from ._definitions import FmuContext
 from ._logging import null_logger
 from ._metadata import generate_meta_tracklog
 from .providers.objectdata._provider import objectdata_provider_factory
@@ -229,7 +230,7 @@ class AggregatedData:
         template["fmu"]["aggregation"]["id"] = self.aggregation_id
 
         # fmu.context.stage should be 'iteration'
-        template["fmu"]["context"]["stage"] = "iteration"
+        template["fmu"]["context"]["stage"] = FmuContext.ITERATION.value
 
         # next, the new object will trigger update of: 'file', 'data' (some fields) and
         # 'tracklog'.

--- a/src/fmu/dataio/providers/_filedata.py
+++ b/src/fmu/dataio/providers/_filedata.py
@@ -94,7 +94,7 @@ class FileDataProvider(Provider):
 
     def _get_share_folders(self) -> Path:
         """Get the export share folders."""
-        if self.dataio.fmu_context == FmuContext.PREPROCESSED:
+        if self.dataio.preprocessed:
             sharefolder = Path(ShareFolder.PREPROCESSED.value)
         elif self.dataio.is_observation:
             sharefolder = Path(ShareFolder.OBSERVATIONS.value)

--- a/tests/test_units/test_enum_classes.py
+++ b/tests/test_units/test_enum_classes.py
@@ -12,9 +12,9 @@ def test_fmu_context_validation() -> None:
     with pytest.raises(ValueError, match="Invalid FmuContext value='invalid_context'"):
         FmuContext("invalid_context")
 
-    assert FmuContext.list_valid_values() == [
+    assert set(FmuContext.list_valid_values()) == {
         "realization",
+        "iteration",
         "case",
-        "preprocessed",
         "non-fmu",
-    ]
+    }

--- a/tests/test_units/test_objectdataprovider_class.py
+++ b/tests/test_units/test_objectdataprovider_class.py
@@ -113,7 +113,7 @@ def test_regsurf_preprocessed_observation(
         os.chdir(rmssetup)
         edata = dataio.ExportData(
             config=rmsglobalconfig,  # read from global config
-            fmu_context="preprocessed",
+            preprocessed=True,
             name="TopVolantis",
             content="depth",
             is_observation=True,

--- a/tests/test_units/test_prerealization_surfaces.py
+++ b/tests/test_units/test_prerealization_surfaces.py
@@ -4,7 +4,7 @@ These outputs may need an active 'fmu_context' key in order to come into the rig
 folder and classification, but there are various ways to to this:
 
 1) Have files in a folder without any metadata; cf fmu_context="case"
-2) Have files with pregenerated matadata in a folder; cf fmu_context="preprocessed"
+2) Have files with pregenerated matadata in a folder; cf preprocessed=True
 
 These objects are normally made as hook workflows before ERT has ran any forward jobs
 and are typically used to compare results.
@@ -67,7 +67,7 @@ def test_regsurf_preprocessed_observation(
         os.chdir(rmssetup)
         edata = dataio.ExportData(
             config=rmsglobalconfig,  # read from global config
-            fmu_context="preprocessed",
+            preprocessed=True,
             name="TopVolantis",
             content="depth",
             is_observation=True,
@@ -183,7 +183,7 @@ def test_regsurf_preprocessed_filename_retained(
         os.chdir(rmssetup)
         edata = dataio.ExportData(
             config=rmsglobalconfig,  # read from global config
-            fmu_context="preprocessed",
+            preprocessed=True,
             content="depth",
             parent=parent,
             timedata=[[20240802, "moni"], [20200909, "base"]],
@@ -245,7 +245,7 @@ def test_regsurf_preprocessed_observation_subfolder(
         os.chdir(rmssetup)
         edata = dataio.ExportData(
             config=rmsglobalconfig,  # read from global config
-            fmu_context="preprocessed",
+            preprocessed=True,
             name="preprocessedmap",
             content="depth",
             is_observation=True,
@@ -298,7 +298,7 @@ def test_preprocessed_with_abs_forcefolder_shall_fail(
     os.chdir(rmssetup)
     edata = dataio.ExportData(
         config=rmsglobalconfig,  # read from global config
-        fmu_context="preprocessed",
+        preprocessed=True,
         name="some",
         content="depth",
         is_observation=True,
@@ -318,7 +318,7 @@ def test_preprocessed_with_rel_forcefolder_ok(rmssetup, rmsglobalconfig, regsurf
     os.chdir(rmssetup)
     edata = dataio.ExportData(
         config=rmsglobalconfig,  # read from global config
-        fmu_context="preprocessed",
+        preprocessed=True,
         name="some",
         content="depth",
         is_observation=True,
@@ -351,7 +351,7 @@ def test_access_settings_retained(
         os.chdir(rmssetup)
         edata = dataio.ExportData(
             config=rmsglobalconfig,
-            fmu_context="preprocessed",
+            preprocessed=True,
             name="preprocessedmap",
             content="depth",
             access_ssdl={"access_level": "restricted"},  # access != config


### PR DESCRIPTION
PR to deprecate `fmu_context="preprocessed"` and add a `preprocessed` argument instead

- getting very close to fixing this #544
- enables removing `fmu_context` arguments from all `ExportData` initializations, as it now is possible to use only ERT environment variables to infer the value of the context.

Closes #593 