### PR TITLE
BUG: Fix data.spec not resolved properly by pydantic

### DIFF
--- a/schema/definitions/0.8.0/examples/table_inplace.yml
+++ b/schema/definitions/0.8.0/examples/table_inplace.yml
@@ -112,9 +112,7 @@ data: # The data block describes the actual data (e.g. surface). Only present in
   grid_model: # Making this an object to allow for expanding in the future
     name: MyGrid # important for data identification, also important for other data types
   spec: # class/layout dependent, optional? Can spec be expanded to work for all data types?
-    ncol: 281
-    nrow: 441
-    undef: -999.25  # Allow both number and string
+    size: 123921
     columns:
       - BULK_OIL
       - NET_OIL

--- a/schema/definitions/0.8.0/examples/table_wellpicks.yml
+++ b/schema/definitions/0.8.0/examples/table_wellpicks.yml
@@ -77,9 +77,7 @@ data: # The data block describes the actual data (e.g. surface). Only present in
   vertical_domain: depth # / time / null
   depth_reference: msl # / seabed / etc
   spec: # class/layout dependent, optional? Can spec be expanded to work for all data types?
-    ncol: 281
-    nrow: 441
-    undef: -999.25  # Allow both number and string
+    size: 123921
     columns:
       - X_UTME
       - Y_UTMN

--- a/schema/definitions/0.8.0/schema/fmu_meta.json
+++ b/schema/definitions/0.8.0/schema/fmu_meta.json
@@ -714,9 +714,6 @@
               "$ref": "#/$defs/TableSpecification"
             },
             {
-              "$ref": "#/$defs/WellPointsDictionaryCaseSpecification"
-            },
-            {
               "type": "null"
             }
           ],
@@ -1394,9 +1391,6 @@
               "$ref": "#/$defs/TableSpecification"
             },
             {
-              "$ref": "#/$defs/WellPointsDictionaryCaseSpecification"
-            },
-            {
               "type": "null"
             }
           ],
@@ -1679,9 +1673,6 @@
               "$ref": "#/$defs/TableSpecification"
             },
             {
-              "$ref": "#/$defs/WellPointsDictionaryCaseSpecification"
-            },
-            {
               "type": "null"
             }
           ],
@@ -1962,9 +1953,6 @@
             },
             {
               "$ref": "#/$defs/TableSpecification"
-            },
-            {
-              "$ref": "#/$defs/WellPointsDictionaryCaseSpecification"
             },
             {
               "type": "null"
@@ -2350,9 +2338,6 @@
               "$ref": "#/$defs/TableSpecification"
             },
             {
-              "$ref": "#/$defs/WellPointsDictionaryCaseSpecification"
-            },
-            {
               "type": "null"
             }
           ],
@@ -2652,9 +2637,6 @@
             },
             {
               "$ref": "#/$defs/TableSpecification"
-            },
-            {
-              "$ref": "#/$defs/WellPointsDictionaryCaseSpecification"
             },
             {
               "type": "null"
@@ -3059,9 +3041,6 @@
               "$ref": "#/$defs/TableSpecification"
             },
             {
-              "$ref": "#/$defs/WellPointsDictionaryCaseSpecification"
-            },
-            {
               "type": "null"
             }
           ],
@@ -3417,9 +3396,6 @@
               "$ref": "#/$defs/TableSpecification"
             },
             {
-              "$ref": "#/$defs/WellPointsDictionaryCaseSpecification"
-            },
-            {
               "type": "null"
             }
           ],
@@ -3730,9 +3706,6 @@
               "$ref": "#/$defs/TableSpecification"
             },
             {
-              "$ref": "#/$defs/WellPointsDictionaryCaseSpecification"
-            },
-            {
               "type": "null"
             }
           ],
@@ -4027,9 +4000,6 @@
               "$ref": "#/$defs/TableSpecification"
             },
             {
-              "$ref": "#/$defs/WellPointsDictionaryCaseSpecification"
-            },
-            {
               "type": "null"
             }
           ],
@@ -4310,9 +4280,6 @@
             },
             {
               "$ref": "#/$defs/TableSpecification"
-            },
-            {
-              "$ref": "#/$defs/WellPointsDictionaryCaseSpecification"
             },
             {
               "type": "null"
@@ -4617,9 +4584,6 @@
               "$ref": "#/$defs/TableSpecification"
             },
             {
-              "$ref": "#/$defs/WellPointsDictionaryCaseSpecification"
-            },
-            {
               "type": "null"
             }
           ],
@@ -4900,9 +4864,6 @@
             },
             {
               "$ref": "#/$defs/TableSpecification"
-            },
-            {
-              "$ref": "#/$defs/WellPointsDictionaryCaseSpecification"
             },
             {
               "type": "null"
@@ -5235,9 +5196,6 @@
               "$ref": "#/$defs/TableSpecification"
             },
             {
-              "$ref": "#/$defs/WellPointsDictionaryCaseSpecification"
-            },
-            {
               "type": "null"
             }
           ],
@@ -5518,9 +5476,6 @@
             },
             {
               "$ref": "#/$defs/TableSpecification"
-            },
-            {
-              "$ref": "#/$defs/WellPointsDictionaryCaseSpecification"
             },
             {
               "type": "null"
@@ -5860,9 +5815,6 @@
               "$ref": "#/$defs/TableSpecification"
             },
             {
-              "$ref": "#/$defs/WellPointsDictionaryCaseSpecification"
-            },
-            {
               "type": "null"
             }
           ],
@@ -6143,9 +6095,6 @@
             },
             {
               "$ref": "#/$defs/TableSpecification"
-            },
-            {
-              "$ref": "#/$defs/WellPointsDictionaryCaseSpecification"
             },
             {
               "type": "null"
@@ -6519,9 +6468,6 @@
             },
             {
               "$ref": "#/$defs/TableSpecification"
-            },
-            {
-              "$ref": "#/$defs/WellPointsDictionaryCaseSpecification"
             },
             {
               "type": "null"
@@ -6915,9 +6861,6 @@
             },
             {
               "$ref": "#/$defs/TableSpecification"
-            },
-            {
-              "$ref": "#/$defs/WellPointsDictionaryCaseSpecification"
             },
             {
               "type": "null"
@@ -7393,9 +7336,6 @@
               "$ref": "#/$defs/TableSpecification"
             },
             {
-              "$ref": "#/$defs/WellPointsDictionaryCaseSpecification"
-            },
-            {
               "type": "null"
             }
           ],
@@ -7706,9 +7646,6 @@
               "$ref": "#/$defs/TableSpecification"
             },
             {
-              "$ref": "#/$defs/WellPointsDictionaryCaseSpecification"
-            },
-            {
               "type": "null"
             }
           ],
@@ -7989,9 +7926,6 @@
             },
             {
               "$ref": "#/$defs/TableSpecification"
-            },
-            {
-              "$ref": "#/$defs/WellPointsDictionaryCaseSpecification"
             },
             {
               "type": "null"
@@ -8334,9 +8268,6 @@
               "$ref": "#/$defs/TableSpecification"
             },
             {
-              "$ref": "#/$defs/WellPointsDictionaryCaseSpecification"
-            },
-            {
               "type": "null"
             }
           ],
@@ -8632,9 +8563,6 @@
               "$ref": "#/$defs/TableSpecification"
             },
             {
-              "$ref": "#/$defs/WellPointsDictionaryCaseSpecification"
-            },
-            {
               "type": "null"
             }
           ],
@@ -8917,9 +8845,6 @@
               "$ref": "#/$defs/TableSpecification"
             },
             {
-              "$ref": "#/$defs/WellPointsDictionaryCaseSpecification"
-            },
-            {
               "type": "null"
             }
           ],
@@ -9057,11 +8982,6 @@
         "stratigraphic"
       ],
       "title": "WellPicksContent",
-      "type": "object"
-    },
-    "WellPointsDictionaryCaseSpecification": {
-      "properties": {},
-      "title": "WellPointsDictionaryCaseSpecification",
       "type": "object"
     },
     "Workflow": {

--- a/src/fmu/dataio/datastructure/meta/specification.py
+++ b/src/fmu/dataio/datastructure/meta/specification.py
@@ -182,9 +182,6 @@ class CubeSpecification(SurfaceSpecification):
     )
 
 
-class WellPointsDictionaryCaseSpecification(BaseModel): ...
-
-
 AnySpecification = Union[
     CPGridPropertySpecification,
     CPGridSpecification,
@@ -194,5 +191,4 @@ AnySpecification = Union[
     PolygonsSpecification,
     SurfaceSpecification,
     TableSpecification,
-    WellPointsDictionaryCaseSpecification,
 ]

--- a/tests/test_units/test_metadata_class.py
+++ b/tests/test_units/test_metadata_class.py
@@ -112,6 +112,11 @@ def test_populate_meta_objectdata(regsurf, edataobj2):
     assert mymeta["display"]["name"] == objdata.name
     assert edataobj2.name == "TopVolantis"
 
+    # surfaces shall have data.spec
+    assert mymeta["data"]
+    assert mymeta["data"]["spec"]
+    assert mymeta["data"]["spec"] == objdata.get_spec()
+
 
 def test_populate_meta_undef_is_zero(regsurf, globalconfig2):
     eobj1 = dio.ExportData(


### PR DESCRIPTION
Closes #650 by removing the `WellPointsDictionaryCaseSpecification`  pydantic model. 

Also, two issues were identified and fixed in the examples; tables requires fields `columns` and `size` .