### PR TITLE
FIX: Handle surfaces with only undefined values

### DIFF
--- a/schema/definitions/0.8.0/schema/fmu_meta.json
+++ b/schema/definitions/0.8.0/schema/fmu_meta.json
@@ -291,12 +291,12 @@
           "type": "number"
         },
         "zmax": {
-          "description": "Maximum z-coordinate",
+          "description": "Maximum z-coordinate. For regular surfaces this field represents the maximum surface value and it will be absent if all values are undefined.",
           "title": "Zmax",
           "type": "number"
         },
         "zmin": {
-          "description": "Minimum z-coordinate",
+          "description": "Minimum z-coordinate. For regular surfaces this field represents the minimum surface value and it will be absent if all values are undefined.",
           "title": "Zmin",
           "type": "number"
         }

--- a/src/fmu/dataio/datastructure/meta/content.py
+++ b/src/fmu/dataio/datastructure/meta/content.py
@@ -142,11 +142,17 @@ class BoundingBox2D(BaseModel):
 
 class BoundingBox3D(BoundingBox2D):
     zmin: float = Field(
-        description="Minimum z-coordinate",
+        description=(
+            "Minimum z-coordinate. For regular surfaces this field represents the "
+            "minimum surface value and it will be absent if all values are undefined."
+        ),
         allow_inf_nan=False,
     )
     zmax: float = Field(
-        description="Maximum z-coordinate",
+        description=(
+            "Maximum z-coordinate. For regular surfaces this field represents the "
+            "maximum surface value and it will be absent if all values are undefined."
+        ),
         allow_inf_nan=False,
     )
 

--- a/src/fmu/dataio/providers/objectdata/_xtgeo.py
+++ b/src/fmu/dataio/providers/objectdata/_xtgeo.py
@@ -48,20 +48,29 @@ class RegularSurfaceDataProvider(ObjectDataProvider):
         )
 
     def get_bbox(self) -> dict[str, Any]:
-        """Derive data.bbox for xtgeo.RegularSurface."""
+        """
+        Derive data.bbox for xtgeo.RegularSurface. The zmin/zmax fields represents
+        the minimum/maximum surface values and should be absent in the metadata if the
+        surface only has undefined values.
+        """
         logger.info("Get bbox for RegularSurface")
 
-        return meta.content.BoundingBox3D(
+        if np.isfinite(self.obj.values).any():
+            return meta.content.BoundingBox3D(
+                xmin=float(self.obj.xmin),
+                xmax=float(self.obj.xmax),
+                ymin=float(self.obj.ymin),
+                ymax=float(self.obj.ymax),
+                zmin=float(self.obj.values.min()),
+                zmax=float(self.obj.values.max()),
+            ).model_dump(mode="json", exclude_none=True)
+
+        return meta.content.BoundingBox2D(
             xmin=float(self.obj.xmin),
             xmax=float(self.obj.xmax),
             ymin=float(self.obj.ymin),
             ymax=float(self.obj.ymax),
-            zmin=float(self.obj.values.min()),
-            zmax=float(self.obj.values.max()),
-        ).model_dump(
-            mode="json",
-            exclude_none=True,
-        )
+        ).model_dump(mode="json", exclude_none=True)
 
     def get_objectdata(self) -> DerivedObjectDescriptor:
         """Derive object data for xtgeo.RegularSurface."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ import shutil
 from pathlib import Path
 
 import fmu.dataio as dio
+import numpy as np
 import pandas as pd
 import pytest
 import xtgeo
@@ -399,6 +400,22 @@ def metadata_examples():
 
     """
     return _metadata_examples()
+
+
+@pytest.fixture(name="regsurf_nan_only", scope="module")
+def fixture_regsurf_nan_only():
+    """Create an xtgeo surface with only NaNs."""
+    logger.debug("Ran %s", _current_function_name())
+    return xtgeo.RegularSurface(ncol=12, nrow=10, xinc=20, yinc=20, values=np.nan)
+
+
+@pytest.fixture(name="regsurf_masked_only", scope="module")
+def fixture_regsurf_masked_only():
+    """Create an xtgeo surface with only masked values."""
+    logger.debug("Ran %s", _current_function_name())
+    regsurf = xtgeo.RegularSurface(ncol=12, nrow=10, xinc=20, yinc=20, values=1000)
+    regsurf.values = np.ma.masked_array(regsurf.values, mask=True)
+    return regsurf
 
 
 # ======================================================================================

--- a/tests/test_units/test_dataio.py
+++ b/tests/test_units/test_dataio.py
@@ -429,6 +429,32 @@ def test_content_deprecated_seismic_offset(regsurf, globalconfig2):
     }
 
 
+def test_surfaces_with_non_finite_values(
+    globalconfig1, regsurf_masked_only, regsurf_nan_only, regsurf
+):
+    """
+    When a surface has no finite values the zmin/zmax should not be present
+    in the metadata.
+    """
+
+    eobj = ExportData(config=globalconfig1, content="time")
+
+    # test surface with only masked values
+    mymeta = eobj.generate_metadata(regsurf_masked_only)
+    assert "zmin" not in mymeta["data"]["bbox"]
+    assert "zmax" not in mymeta["data"]["bbox"]
+
+    # test surface with only nan values
+    mymeta = eobj.generate_metadata(regsurf_nan_only)
+    assert "zmin" not in mymeta["data"]["bbox"]
+    assert "zmax" not in mymeta["data"]["bbox"]
+
+    # test surface with finite values has zmin/zmax
+    mymeta = eobj.generate_metadata(regsurf)
+    assert "zmin" in mymeta["data"]["bbox"]
+    assert "zmax" in mymeta["data"]["bbox"]
+
+
 def test_workflow_as_string(fmurun_w_casemetadata, monkeypatch, globalconfig1, regsurf):
     """
     Check that having workflow as string works both in ExportData and on export.


### PR DESCRIPTION
Closes #634 by not setting the `zmin/zmax` in the metadata for surfaces with only undefined values.