### PR TITLE
ENH: Return BaseModel from bbox getters

### DIFF
--- a/schema/definitions/0.8.0/schema/fmu_meta.json
+++ b/schema/definitions/0.8.0/schema/fmu_meta.json
@@ -237,6 +237,7 @@
       "type": "integer"
     },
     "BoundingBox2D": {
+      "description": "Contains the 2D coordinates within which a data object is contained.",
       "properties": {
         "xmax": {
           "description": "Maximum x-coordinate",
@@ -269,6 +270,7 @@
       "type": "object"
     },
     "BoundingBox3D": {
+      "description": "Contains the 3D coordinates within which a data object is contained.",
       "properties": {
         "xmax": {
           "description": "Maximum x-coordinate",

--- a/src/fmu/dataio/datastructure/meta/content.py
+++ b/src/fmu/dataio/datastructure/meta/content.py
@@ -122,6 +122,8 @@ class Layer(BaseModel):
 
 
 class BoundingBox2D(BaseModel):
+    """Contains the 2D coordinates within which a data object is contained."""
+
     xmin: float = Field(
         description="Minimum x-coordinate",
         allow_inf_nan=False,
@@ -141,6 +143,8 @@ class BoundingBox2D(BaseModel):
 
 
 class BoundingBox3D(BoundingBox2D):
+    """Contains the 3D coordinates within which a data object is contained."""
+
     zmin: float = Field(
         description=(
             "Minimum z-coordinate. For regular surfaces this field represents the "

--- a/src/fmu/dataio/providers/objectdata/_base.py
+++ b/src/fmu/dataio/providers/objectdata/_base.py
@@ -16,6 +16,7 @@ from fmu.dataio.datastructure.meta import content, enums
 
 if TYPE_CHECKING:
     from fmu.dataio.dataio import ExportData
+    from fmu.dataio.datastructure.meta.content import BoundingBox2D, BoundingBox3D
     from fmu.dataio.types import Classname, Efolder, Inferrable, Layout, Subtype
 
 logger: Final = null_logger(__name__)
@@ -261,7 +262,7 @@ class ObjectDataProvider(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def get_bbox(self) -> dict:
+    def get_bbox(self) -> BoundingBox2D | BoundingBox3D | None:
         raise NotImplementedError
 
     @abstractmethod

--- a/src/fmu/dataio/providers/objectdata/_faultroom.py
+++ b/src/fmu/dataio/providers/objectdata/_faultroom.py
@@ -5,7 +5,8 @@ from typing import Any, Final
 
 from fmu.dataio._definitions import ValidFormats
 from fmu.dataio._logging import null_logger
-from fmu.dataio.datastructure.meta import meta, specification
+from fmu.dataio.datastructure.meta import specification
+from fmu.dataio.datastructure.meta.content import BoundingBox3D
 from fmu.dataio.readers import FaultRoomSurface
 
 from ._base import (
@@ -20,20 +21,16 @@ logger: Final = null_logger(__name__)
 class FaultRoomSurfaceProvider(ObjectDataProvider):
     obj: FaultRoomSurface
 
-    def get_bbox(self) -> dict[str, Any]:
+    def get_bbox(self) -> BoundingBox3D:
         """Derive data.bbox for FaultRoomSurface."""
         logger.info("Get bbox for FaultRoomSurface")
-        faultsurf = self.obj
-        return meta.content.BoundingBox3D(
-            xmin=float(faultsurf.bbox["xmin"]),
-            xmax=float(faultsurf.bbox["xmin"]),
-            ymin=float(faultsurf.bbox["ymin"]),
-            ymax=float(faultsurf.bbox["ymax"]),
-            zmin=float(faultsurf.bbox["zmin"]),
-            zmax=float(faultsurf.bbox["zmax"]),
-        ).model_dump(
-            mode="json",
-            exclude_none=True,
+        return BoundingBox3D(
+            xmin=float(self.obj.bbox["xmin"]),
+            xmax=float(self.obj.bbox["xmin"]),
+            ymin=float(self.obj.bbox["ymin"]),
+            ymax=float(self.obj.bbox["ymax"]),
+            zmin=float(self.obj.bbox["zmin"]),
+            zmax=float(self.obj.bbox["zmax"]),
         )
 
     def get_spec(self) -> dict[str, Any]:
@@ -61,7 +58,7 @@ class FaultRoomSurfaceProvider(ObjectDataProvider):
             efolder="maps",
             fmt=(fmt := self.dataio.dict_fformat),
             spec=self.get_spec(),
-            bbox=self.get_bbox(),
+            bbox=self.get_bbox().model_dump(mode="json", exclude_none=True),
             extension=self._validate_get_ext(fmt, "JSON", ValidFormats().dictionary),
             table_index=None,
         )

--- a/src/fmu/dataio/providers/objectdata/_provider.py
+++ b/src/fmu/dataio/providers/objectdata/_provider.py
@@ -171,9 +171,8 @@ class ExistingDataProvider(ObjectDataProvider):
         """Derive data.spec from existing metadata."""
         return self.metadata["spec"]
 
-    def get_bbox(self) -> dict:
+    def get_bbox(self) -> None:
         """Derive data.bbox from existing metadata."""
-        return self.metadata["bbox"]
 
     def get_objectdata(self) -> DerivedObjectDescriptor:
         """Derive object data for existing metadata."""
@@ -185,14 +184,13 @@ class ExistingDataProvider(ObjectDataProvider):
             fmt=self.fmt,
             extension=self.extension,
             spec=self.get_spec(),
-            bbox=self.get_bbox(),
+            bbox=self.metadata["bbox"],
             table_index=None,
         )
 
     def derive_metadata(self) -> None:
         """Metadata has already been derived for this provider, and is already set from
         instantiation, so override this method and do nothing."""
-        return
 
 
 @dataclass
@@ -204,10 +202,8 @@ class DictionaryDataProvider(ObjectDataProvider):
         logger.info("Get spec for dictionary")
         return {}
 
-    def get_bbox(self) -> dict[str, Any]:
+    def get_bbox(self) -> None:
         """Derive data.bbox for dict."""
-        logger.info("Get bbox for dictionary")
-        return {}
 
     def get_objectdata(self) -> DerivedObjectDescriptor:
         """Derive object data for dict."""
@@ -219,6 +215,6 @@ class DictionaryDataProvider(ObjectDataProvider):
             fmt=(fmt := self.dataio.dict_fformat),
             extension=self._validate_get_ext(fmt, "JSON", ValidFormats().dictionary),
             spec=self.get_spec() or None,
-            bbox=self.get_bbox() or None,
+            bbox=None,
             table_index=None,
         )

--- a/src/fmu/dataio/providers/objectdata/_tables.py
+++ b/src/fmu/dataio/providers/objectdata/_tables.py
@@ -71,10 +71,8 @@ class DataFrameDataProvider(ObjectDataProvider):
             exclude_none=True,
         )
 
-    def get_bbox(self) -> dict:
+    def get_bbox(self) -> None:
         """Derive data.bbox for pd.DataFrame."""
-        logger.info("Get bbox for pd.DataFrame (tables)")
-        return {}
 
     def get_objectdata(self) -> DerivedObjectDescriptor:
         """Derive object data for pd.DataFrame."""
@@ -87,7 +85,7 @@ class DataFrameDataProvider(ObjectDataProvider):
             fmt=(fmt := self.dataio.table_fformat),
             extension=self._validate_get_ext(fmt, "DataFrame", ValidFormats().table),
             spec=self.get_spec(),
-            bbox=self.get_bbox() or None,
+            bbox=None,
             table_index=table_index,
         )
 
@@ -108,10 +106,8 @@ class ArrowTableDataProvider(ObjectDataProvider):
             exclude_none=True,
         )
 
-    def get_bbox(self) -> dict:
+    def get_bbox(self) -> None:
         """Derive data.bbox for pyarrow.Table."""
-        logger.info("Get bbox for pyarrow (tables)")
-        return {}
 
     def get_objectdata(self) -> DerivedObjectDescriptor:
         """Derive object data from pyarrow.Table."""
@@ -124,6 +120,6 @@ class ArrowTableDataProvider(ObjectDataProvider):
             fmt=(fmt := self.dataio.arrow_fformat),
             extension=self._validate_get_ext(fmt, "ArrowTable", ValidFormats().table),
             spec=self.get_spec(),
-            bbox=self.get_bbox() or None,
+            bbox=None,
             table_index=table_index,
         )

--- a/tests/test_units/test_objectdataprovider_class.py
+++ b/tests/test_units/test_objectdataprovider_class.py
@@ -97,8 +97,8 @@ def test_objectdata_regularsurface_spec_bbox(regsurf, edataobj1):
     bbox = objdata.get_bbox()
 
     assert specs["ncol"] == regsurf.ncol
-    assert bbox["xmin"] == 0.0
-    assert bbox["zmin"] == 1234.0
+    assert bbox.xmin == 0.0
+    assert bbox.zmin == 1234.0
 
 
 def test_objectdata_regularsurface_derive_objectdata(regsurf, edataobj1):


### PR DESCRIPTION
Contributes to #564 

This also allows the getter to be optional in the cases in which the method will never be called because a bounding box is not relevant to the data type.

Schema was updated to reflect the added docstrings.