### PR TITLE
MAINT: Move workflow conversion to silence warning

### DIFF
--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -31,7 +31,7 @@ from ._utils import (
 from .aggregation import AggregatedData
 from .case import InitializeCase
 from .datastructure.configuration import global_configuration
-from .datastructure.meta import enums, meta
+from .datastructure.meta import enums
 from .providers._fmu import FmuProvider, get_fmu_context_from_environment
 
 # DATAIO_EXAMPLES: Final = dataio_examples()
@@ -406,7 +406,6 @@ class ExportData:
             self.config = some_config_from_env(GLOBAL_ENVNAME) or {}
 
         self._validate_and_establish_fmucontext()
-        self._validate_workflow_key()
 
         # check state of global config
         self._config_is_valid = global_configuration.is_valid(self.config)
@@ -583,17 +582,6 @@ class ExportData:
                 UserWarning,
             )
 
-    def _validate_workflow_key(self) -> None:
-        if self.workflow:
-            if isinstance(self.workflow, str):
-                workflow = meta.Workflow(reference=self.workflow)
-            elif isinstance(self.workflow, dict):
-                workflow = meta.Workflow.model_validate(self.workflow)
-            else:
-                raise TypeError("'workflow' should be string.")
-
-            self.workflow = workflow.model_dump(mode="json", exclude_none=True)
-
     def _validate_and_establish_fmucontext(self) -> None:
         """
         Validate the given 'fmu_context' input. if not explicitly given it
@@ -668,7 +656,6 @@ class ExportData:
                 logger.info("New setting OK for %s", setting)
 
         self._show_deprecations_or_notimplemented()
-        self._validate_workflow_key()
         self._validate_and_establish_fmucontext()
         self._rootpath = self._establish_rootpath()
 
@@ -740,7 +727,6 @@ class ExportData:
 
     def _get_fmu_provider(self) -> FmuProvider:
         assert isinstance(self.fmu_context, FmuContext)
-        assert isinstance(self.workflow, dict) or self.workflow is None
         return FmuProvider(
             model=self.config.get("model"),
             fmu_context=self.fmu_context,

--- a/src/fmu/dataio/providers/_fmu.py
+++ b/src/fmu/dataio/providers/_fmu.py
@@ -33,7 +33,7 @@ import os
 from dataclasses import dataclass, field
 from enum import Enum, auto
 from pathlib import Path
-from typing import TYPE_CHECKING, Final, Optional
+from typing import TYPE_CHECKING, Final, Optional, Union
 from warnings import warn
 
 from fmu.config import utilities as ut
@@ -106,7 +106,7 @@ class FmuProvider:
     fmu_context: FmuContext = FmuContext.REALIZATION
     include_ertjobs: bool = True
     casepath_proposed: Optional[Path] = None
-    workflow: Optional[dict[str, str]] = None
+    workflow: Optional[Union[str, dict[str, str]]] = None
 
     # private properties for this class
     _runpath: Optional[Path] = field(default_factory=Path, init=False)
@@ -319,4 +319,7 @@ class FmuProvider:
         return meta.FMUModel.model_validate(self.model)
 
     def _get_workflow_meta(self) -> meta.Workflow:
-        return meta.Workflow.model_validate(self.workflow)
+        assert self.workflow is not None
+        if isinstance(self.workflow, dict):
+            return meta.Workflow.model_validate(self.workflow)
+        return meta.Workflow(reference=self.workflow)

--- a/tests/test_units/test_fmuprovider_class.py
+++ b/tests/test_units/test_fmuprovider_class.py
@@ -319,33 +319,35 @@ def test_fmuprovider_workflow_reference(fmurun_w_casemetadata):
     os.chdir(fmurun_w_casemetadata)
 
     # workflow input is a string
-    edata = dataio.ExportData(workflow="workflow as string")
-    # check that the conversion to dict works
-    assert edata.workflow == {"reference": "workflow as string"}
     myfmu_meta = FmuProvider(
-        model=GLOBAL_CONFIG_MODEL, workflow=edata.workflow
+        model=GLOBAL_CONFIG_MODEL, workflow="workflow as string"
     ).get_metadata()
     assert myfmu_meta.workflow is not None
-    assert (
-        myfmu_meta.workflow.model_dump(mode="json", exclude_none=True) == edata.workflow
-    )
+    assert myfmu_meta.workflow.model_dump(mode="json") == {
+        "reference": "workflow as string"
+    }
 
-    # workflow input is a correct dict
+    # workflow as a dict should give future warning
     with pytest.warns(FutureWarning, match="The 'workflow' argument"):
-        edata = dataio.ExportData(workflow={"reference": "workflow as dict"})
-    assert edata.workflow == {"reference": "workflow as dict"}
+        dataio.ExportData(workflow={"reference": "workflow as dict"})
+
+    # test that workflow as a dict still gives valid results
     myfmu_meta = FmuProvider(
-        model=GLOBAL_CONFIG_MODEL, workflow=edata.workflow
+        model=GLOBAL_CONFIG_MODEL, workflow={"reference": "workflow as dict"}
     ).get_metadata()
     assert myfmu_meta.workflow is not None
-    assert (
-        myfmu_meta.workflow.model_dump(mode="json", exclude_none=True) == edata.workflow
-    )
+    assert myfmu_meta.workflow.model_dump(mode="json") == {
+        "reference": "workflow as dict"
+    }
 
     # workflow input is non-correct dict
     with pytest.raises(pydantic.ValidationError):
-        dataio.ExportData(workflow={"wrong": "workflow as dict"})
+        FmuProvider(
+            model=GLOBAL_CONFIG_MODEL, workflow={"wrong": "workflow as dict"}
+        ).get_metadata()
 
     # workflow input is other types - shall fail
-    with pytest.raises(TypeError):
-        dataio.ExportData(workflow=123.4)
+    with pytest.raises(
+        pydantic.ValidationError, match="Input should be a valid string"
+    ):
+        FmuProvider(model=GLOBAL_CONFIG_MODEL, workflow=123.4).get_metadata()


### PR DESCRIPTION
PR to remove the conversion of the `workflow` argument of type `str` to a `dict` inside the ExportData post-init, and do it more directly inside the `FmuProvider.`

Since we run the `_show_deprecations_or_notimplemented` twice, initially in the init and subsequently when running the  `generate_metadata` function (since users may have updated class arguments), it causes a `FutureWarning` to be thrown the second time saying that `workflow` of type `dict` is deprecated.