### PR TITLE
ENH: Implement ObjectDataProvider as a Provider

### DIFF
--- a/tests/test_units/test_metadata_class.py
+++ b/tests/test_units/test_metadata_class.py
@@ -9,7 +9,6 @@ from fmu.dataio._metadata import (
     SCHEMA,
     SOURCE,
     VERSION,
-    _get_objectdata_provider,
     generate_export_metadata,
 )
 from fmu.dataio._utils import prettyprint_dict
@@ -17,6 +16,7 @@ from fmu.dataio.datastructure.meta.meta import (
     SystemInformationOperatingSystem,
     TracklogEvent,
 )
+from fmu.dataio.providers.objectdata._provider import objectdata_provider_factory
 
 # pylint: disable=no-member
 
@@ -106,7 +106,7 @@ def test_generate_meta_tracklog_operating_system(edataobj1, regsurf):
 
 def test_populate_meta_objectdata(regsurf, edataobj2):
     mymeta = generate_export_metadata(regsurf, edataobj2)
-    objdata = _get_objectdata_provider(regsurf, edataobj2)
+    objdata = objectdata_provider_factory(regsurf, edataobj2)
 
     assert objdata.name == "VOLANTIS GP. Top"
     assert mymeta["display"]["name"] == objdata.name
@@ -399,7 +399,7 @@ def test_metadata_display_name_not_given(regsurf, edataobj2):
     """Test that display.name == data.name when not explicitly provided."""
 
     mymeta = generate_export_metadata(regsurf, edataobj2)
-    objdata = _get_objectdata_provider(regsurf, edataobj2)
+    objdata = objectdata_provider_factory(regsurf, edataobj2)
 
     assert "name" in mymeta["display"]
     assert mymeta["display"]["name"] == objdata.name
@@ -411,7 +411,7 @@ def test_metadata_display_name_given(regsurf, edataobj2):
     edataobj2.display_name = "My Display Name"
 
     mymeta = generate_export_metadata(regsurf, edataobj2)
-    objdata = _get_objectdata_provider(regsurf, edataobj2)
+    objdata = objectdata_provider_factory(regsurf, edataobj2)
 
     assert mymeta["display"]["name"] == "My Display Name"
     assert objdata.name == "VOLANTIS GP. Top"

--- a/tests/test_units/test_objectdataprovider_class.py
+++ b/tests/test_units/test_objectdataprovider_class.py
@@ -46,24 +46,24 @@ def test_get_timedata_from_existing(given: dict, expected: tuple):
 # --------------------------------------------------------------------------------------
 
 
-def test_objectdata_regularsurface_derive_name_stratigraphy(regsurf, edataobj1):
+def test_objectdata_regularsurface_derive_named_stratigraphy(regsurf, edataobj1):
     """Get name and some stratigaphic keys for a valid RegularSurface object ."""
     # mimic the stripped parts of configuations for testing here
     objdata = objectdata_provider_factory(regsurf, edataobj1)
 
-    res = objdata._derive_name_stratigraphy()
+    res = objdata._derive_named_stratigraphy()
 
     assert res.name == "Whatever Top"
     assert "TopWhatever" in res.alias
     assert res.stratigraphic is True
 
 
-def test_objectdata_regularsurface_derive_name_stratigraphy_differ(regsurf, edataobj2):
+def test_objectdata_regularsurface_derive_named_stratigraphy_differ(regsurf, edataobj2):
     """Get name and some stratigaphic keys for a valid RegularSurface object ."""
     # mimic the stripped parts of configuations for testing here
     objdata = objectdata_provider_factory(regsurf, edataobj2)
 
-    res = objdata._derive_name_stratigraphy()
+    res = objdata._derive_named_stratigraphy()
 
     assert res.name == "VOLANTIS GP. Top"
     assert "TopVolantis" in res.alias

--- a/tests/test_units/test_objectdataprovider_class.py
+++ b/tests/test_units/test_objectdataprovider_class.py
@@ -117,10 +117,8 @@ def test_objectdata_regularsurface_derive_metadata(regsurf, edataobj1):
     """Derive all metadata for the 'data' block in fmu-dataio."""
 
     myobj = objectdata_provider_factory(regsurf, edataobj1)
-    myobj.derive_metadata()
-    res = myobj.metadata
-    assert res["content"] == "depth"
-    assert res["alias"]
+    assert myobj.metadata["content"] == "depth"
+    assert myobj.metadata["alias"]
 
 
 def test_objectdata_provider_factory_raises_on_unknown(edataobj1):


### PR DESCRIPTION
Resolves #564 

It now sets its state on initialization and returns a Pydantic model via the prescribed method. Does not do much of the possible clean-ups within the base class.

There is still more work to be within the object data provider base class but this should have the inputs (spec, bbox, etc) and outputs (content) where they need to be.