### PR TITLE
FIX: Support unit input as None

### DIFF
--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -354,7 +354,7 @@ class ExportData:
     subfolder: str = ""
     tagname: str = ""
     timedata: Optional[List[list]] = None
-    unit: str = ""
+    unit: Optional[str] = ""
     verbosity: str = "DEPRECATED"  # remove in version 2
     vertical_domain: dict = field(default_factory=dict)
     workflow: Optional[Union[str, Dict[str, str]]] = None

--- a/src/fmu/dataio/providers/objectdata/_base.py
+++ b/src/fmu/dataio/providers/objectdata/_base.py
@@ -222,7 +222,7 @@ class ObjectDataProvider(Provider):
         self.metadata["tagname"] = self.dataio.tagname
         self.metadata["format"] = objres.fmt
         self.metadata["layout"] = objres.layout
-        self.metadata["unit"] = self.dataio.unit
+        self.metadata["unit"] = self.dataio.unit or ""
         self.metadata["vertical_domain"] = list(self.dataio.vertical_domain.keys())[0]
         self.metadata["depth_reference"] = list(self.dataio.vertical_domain.values())[0]
         self.metadata["spec"] = objres.spec

--- a/tests/test_units/test_dataio.py
+++ b/tests/test_units/test_dataio.py
@@ -284,6 +284,13 @@ def test_rep_include(globalconfig1, regsurf):
     assert mymeta["access"]["ssdl"]["rep_include"] is False
 
 
+def test_unit_is_none(globalconfig1, regsurf):
+    """Test that unit=None works and is translated into an enpty string"""
+    eobj = ExportData(config=globalconfig1, unit=None)
+    meta = eobj.generate_metadata(regsurf)
+    assert meta["data"]["unit"] == ""
+
+
 def test_content_not_given(globalconfig1, regsurf):
     """When content is not explicitly given, warning shall be issued."""
     eobj = ExportData(config=globalconfig1)


### PR DESCRIPTION
In the SIM2SEIS workflow in Drogon `unit` is given in as `None,` to avoid breaking changes for people we should support this.