### PR TITLE
MAINT: Refactor ObjectDataProvider base class

### DIFF
--- a/src/fmu/dataio/aggregation.py
+++ b/src/fmu/dataio/aggregation.py
@@ -243,7 +243,9 @@ class AggregatedData:
             "model": template["fmu"]["model"],
         }
         etemp = dataio.ExportData(config=config, name=self.name)
-        objdata = objectdata_provider_factory(obj=obj, dataio=etemp).get_objectdata()
+
+        objectdata_provider = objectdata_provider_factory(obj=obj, dataio=etemp)
+        objdata = objectdata_provider.get_objectdata()
 
         template["tracklog"] = [generate_meta_tracklog()[0].model_dump(mode="json")]
         template["file"] = {
@@ -260,8 +262,8 @@ class AggregatedData:
             template["data"]["name"] = self.name
         if self.tagname:
             template["data"]["tagname"] = self.tagname
-        if objdata.bbox:
-            template["data"]["bbox"] = objdata.bbox
+        if bbox := objectdata_provider.get_bbox():
+            template["data"]["bbox"] = bbox.model_dump(mode="json", exclude_none=True)
 
         self._metadata = template
 

--- a/src/fmu/dataio/providers/objectdata/_faultroom.py
+++ b/src/fmu/dataio/providers/objectdata/_faultroom.py
@@ -6,6 +6,7 @@ from typing import Final
 from fmu.dataio._definitions import ValidFormats
 from fmu.dataio._logging import null_logger
 from fmu.dataio.datastructure.meta.content import BoundingBox3D
+from fmu.dataio.datastructure.meta.enums import FMUClassEnum
 from fmu.dataio.datastructure.meta.specification import FaultRoomSurfaceSpecification
 from fmu.dataio.readers import FaultRoomSurface
 
@@ -20,6 +21,10 @@ logger: Final = null_logger(__name__)
 @dataclass
 class FaultRoomSurfaceProvider(ObjectDataProvider):
     obj: FaultRoomSurface
+
+    @property
+    def classname(self) -> FMUClassEnum:
+        return FMUClassEnum.surface
 
     def get_bbox(self) -> BoundingBox3D:
         """Derive data.bbox for FaultRoomSurface."""
@@ -49,12 +54,9 @@ class FaultRoomSurfaceProvider(ObjectDataProvider):
         """Derive object data for FaultRoomSurface"""
         return DerivedObjectDescriptor(
             subtype="JSON",
-            classname="surface",
             layout="faultroom_triangulated",
             efolder="maps",
             fmt=(fmt := self.dataio.dict_fformat),
-            spec=self.get_spec().model_dump(mode="json", exclude_none=True),
-            bbox=self.get_bbox().model_dump(mode="json", exclude_none=True),
             extension=self._validate_get_ext(fmt, "JSON", ValidFormats().dictionary),
             table_index=None,
         )

--- a/src/fmu/dataio/providers/objectdata/_provider.py
+++ b/src/fmu/dataio/providers/objectdata/_provider.py
@@ -94,6 +94,7 @@ import xtgeo
 
 from fmu.dataio._definitions import ValidFormats
 from fmu.dataio._logging import null_logger
+from fmu.dataio.datastructure.meta.enums import FMUClassEnum
 from fmu.dataio.readers import FaultRoomSurface
 
 from ._base import (
@@ -163,6 +164,10 @@ def objectdata_provider_factory(
 class DictionaryDataProvider(ObjectDataProvider):
     obj: dict
 
+    @property
+    def classname(self) -> FMUClassEnum:
+        return FMUClassEnum.dictionary
+
     def get_spec(self) -> None:
         """Derive data.spec for dict."""
 
@@ -173,12 +178,9 @@ class DictionaryDataProvider(ObjectDataProvider):
         """Derive object data for dict."""
         return DerivedObjectDescriptor(
             subtype="JSON",
-            classname="dictionary",
             layout="dictionary",
             efolder="dictionaries",
             fmt=(fmt := self.dataio.dict_fformat),
             extension=self._validate_get_ext(fmt, "JSON", ValidFormats().dictionary),
-            spec=None,
-            bbox=None,
             table_index=None,
         )

--- a/src/fmu/dataio/providers/objectdata/_tables.py
+++ b/src/fmu/dataio/providers/objectdata/_tables.py
@@ -7,6 +7,7 @@ import pandas as pd
 
 from fmu.dataio._definitions import STANDARD_TABLE_INDEX_COLUMNS, ValidFormats
 from fmu.dataio._logging import null_logger
+from fmu.dataio.datastructure.meta.enums import FMUClassEnum
 from fmu.dataio.datastructure.meta.specification import TableSpecification
 
 from ._base import (
@@ -59,6 +60,10 @@ def _derive_index(table_index: list[str] | None, columns: list[str]) -> list[str
 class DataFrameDataProvider(ObjectDataProvider):
     obj: pd.DataFrame
 
+    @property
+    def classname(self) -> FMUClassEnum:
+        return FMUClassEnum.table
+
     def get_spec(self) -> TableSpecification:
         """Derive data.spec for pd.DataFrame."""
         logger.info("Get spec for pd.DataFrame (tables)")
@@ -75,13 +80,10 @@ class DataFrameDataProvider(ObjectDataProvider):
         table_index = _derive_index(self.dataio.table_index, list(self.obj.columns))
         return DerivedObjectDescriptor(
             subtype="DataFrame",
-            classname="table",
             layout="table",
             efolder="tables",
             fmt=(fmt := self.dataio.table_fformat),
             extension=self._validate_get_ext(fmt, "DataFrame", ValidFormats().table),
-            spec=self.get_spec().model_dump(mode="json", exclude_none=True),
-            bbox=None,
             table_index=table_index,
         )
 
@@ -89,6 +91,10 @@ class DataFrameDataProvider(ObjectDataProvider):
 @dataclass
 class ArrowTableDataProvider(ObjectDataProvider):
     obj: pyarrow.Table
+
+    @property
+    def classname(self) -> FMUClassEnum:
+        return FMUClassEnum.table
 
     def get_spec(self) -> TableSpecification:
         """Derive data.spec for pyarrow.Table."""
@@ -106,12 +112,9 @@ class ArrowTableDataProvider(ObjectDataProvider):
         table_index = _derive_index(self.dataio.table_index, self.obj.column_names)
         return DerivedObjectDescriptor(
             subtype="ArrowTable",
-            classname="table",
             layout="table",
             efolder="tables",
             fmt=(fmt := self.dataio.arrow_fformat),
             extension=self._validate_get_ext(fmt, "ArrowTable", ValidFormats().table),
-            spec=self.get_spec().model_dump(mode="json", exclude_none=True),
-            bbox=None,
             table_index=table_index,
         )

--- a/src/fmu/dataio/providers/objectdata/_xtgeo.py
+++ b/src/fmu/dataio/providers/objectdata/_xtgeo.py
@@ -11,6 +11,7 @@ from fmu.dataio._definitions import ValidFormats
 from fmu.dataio._logging import null_logger
 from fmu.dataio._utils import npfloat_to_float
 from fmu.dataio.datastructure.meta.content import BoundingBox2D, BoundingBox3D
+from fmu.dataio.datastructure.meta.enums import FMUClassEnum
 from fmu.dataio.datastructure.meta.specification import (
     CPGridPropertySpecification,
     CPGridSpecification,
@@ -34,6 +35,10 @@ logger: Final = null_logger(__name__)
 @dataclass
 class RegularSurfaceDataProvider(ObjectDataProvider):
     obj: xtgeo.RegularSurface
+
+    @property
+    def classname(self) -> FMUClassEnum:
+        return FMUClassEnum.surface
 
     def get_spec(self) -> SurfaceSpecification:
         """Derive data.spec for xtgeo.RegularSurface."""
@@ -81,12 +86,9 @@ class RegularSurfaceDataProvider(ObjectDataProvider):
         """Derive object data for xtgeo.RegularSurface."""
         return DerivedObjectDescriptor(
             subtype="RegularSurface",
-            classname="surface",
             layout="regular",
             efolder="maps",
             fmt=(fmt := self.dataio.surface_fformat),
-            spec=self.get_spec().model_dump(mode="json", exclude_none=True),
-            bbox=self.get_bbox().model_dump(mode="json", exclude_none=True),
             extension=self._validate_get_ext(
                 fmt, "RegularSurface", ValidFormats().surface
             ),
@@ -97,6 +99,10 @@ class RegularSurfaceDataProvider(ObjectDataProvider):
 @dataclass
 class PolygonsDataProvider(ObjectDataProvider):
     obj: xtgeo.Polygons
+
+    @property
+    def classname(self) -> FMUClassEnum:
+        return FMUClassEnum.polygons
 
     def get_spec(self) -> PolygonsSpecification:
         """Derive data.spec for xtgeo.Polygons."""
@@ -126,13 +132,10 @@ class PolygonsDataProvider(ObjectDataProvider):
         """Derive object data for xtgeo.Polygons."""
         return DerivedObjectDescriptor(
             subtype="Polygons",
-            classname="polygons",
             layout="unset",
             efolder="polygons",
             fmt=(fmt := self.dataio.polygons_fformat),
             extension=self._validate_get_ext(fmt, "Polygons", ValidFormats().polygons),
-            spec=self.get_spec().model_dump(mode="json", exclude_none=True),
-            bbox=self.get_bbox().model_dump(mode="json", exclude_none=True),
             table_index=None,
         )
 
@@ -145,6 +148,10 @@ class PointsDataProvider(ObjectDataProvider):
     def obj_dataframe(self) -> pd.DataFrame:
         """Returns a dataframe of the referenced xtgeo.Points object."""
         return self.obj.get_dataframe(copy=False)
+
+    @property
+    def classname(self) -> FMUClassEnum:
+        return FMUClassEnum.points
 
     def get_spec(self) -> PointSpecification:
         """Derive data.spec for xtgeo.Points."""
@@ -174,13 +181,10 @@ class PointsDataProvider(ObjectDataProvider):
         """Derive object data for xtgeo.Points."""
         return DerivedObjectDescriptor(
             subtype="Points",
-            classname="points",
             layout="unset",
             efolder="points",
             fmt=(fmt := self.dataio.points_fformat),
             extension=self._validate_get_ext(fmt, "Points", ValidFormats().points),
-            spec=self.get_spec().model_dump(mode="json", exclude_none=True),
-            bbox=self.get_bbox().model_dump(mode="json", exclude_none=True),
             table_index=None,
         )
 
@@ -188,6 +192,10 @@ class PointsDataProvider(ObjectDataProvider):
 @dataclass
 class CubeDataProvider(ObjectDataProvider):
     obj: xtgeo.Cube
+
+    @property
+    def classname(self) -> FMUClassEnum:
+        return FMUClassEnum.cube
 
     def get_spec(self) -> CubeSpecification:
         """Derive data.spec for xtgeo.Cube."""
@@ -244,13 +252,10 @@ class CubeDataProvider(ObjectDataProvider):
         """Derive object data for xtgeo.Cube."""
         return DerivedObjectDescriptor(
             subtype="RegularCube",
-            classname="cube",
             layout="regular",
             efolder="cubes",
             fmt=(fmt := self.dataio.cube_fformat),
             extension=self._validate_get_ext(fmt, "RegularCube", ValidFormats().cube),
-            spec=self.get_spec().model_dump(mode="json", exclude_none=True),
-            bbox=self.get_bbox().model_dump(mode="json", exclude_none=True),
             table_index=None,
         )
 
@@ -258,6 +263,10 @@ class CubeDataProvider(ObjectDataProvider):
 @dataclass
 class CPGridDataProvider(ObjectDataProvider):
     obj: xtgeo.Grid
+
+    @property
+    def classname(self) -> FMUClassEnum:
+        return FMUClassEnum.cpgrid
 
     def get_spec(self) -> CPGridSpecification:
         """Derive data.spec for xtgeo.Grid."""
@@ -298,13 +307,10 @@ class CPGridDataProvider(ObjectDataProvider):
         """Derive object data for xtgeo.Grid."""
         return DerivedObjectDescriptor(
             subtype="CPGrid",
-            classname="cpgrid",
             layout="cornerpoint",
             efolder="grids",
             fmt=(fmt := self.dataio.grid_fformat),
             extension=self._validate_get_ext(fmt, "CPGrid", ValidFormats().grid),
-            spec=self.get_spec().model_dump(mode="json", exclude_none=True),
-            bbox=self.get_bbox().model_dump(mode="json", exclude_none=True),
             table_index=None,
         )
 
@@ -312,6 +318,10 @@ class CPGridDataProvider(ObjectDataProvider):
 @dataclass
 class CPGridPropertyDataProvider(ObjectDataProvider):
     obj: xtgeo.GridProperty
+
+    @property
+    def classname(self) -> FMUClassEnum:
+        return FMUClassEnum.cpgrid_property
 
     def get_spec(self) -> CPGridPropertySpecification:
         """Derive data.spec for xtgeo.GridProperty."""
@@ -330,14 +340,11 @@ class CPGridPropertyDataProvider(ObjectDataProvider):
         """Derive object data for xtgeo.GridProperty."""
         return DerivedObjectDescriptor(
             subtype="CPGridProperty",
-            classname="cpgrid_property",
             layout="cornerpoint",
             efolder="grids",
             fmt=(fmt := self.dataio.grid_fformat),
             extension=self._validate_get_ext(
                 fmt, "CPGridProperty", ValidFormats().grid
             ),
-            spec=self.get_spec().model_dump(mode="json", exclude_none=True),
-            bbox=None,
             table_index=None,
         )

--- a/src/fmu/dataio/types.py
+++ b/src/fmu/dataio/types.py
@@ -78,17 +78,6 @@ Subtype: TypeAlias = Literal[
     "ArrowTable",
 ]
 
-Classname: TypeAlias = Literal[
-    "surface",
-    "polygons",
-    "points",
-    "cube",
-    "cpgrid",
-    "cpgrid_property",
-    "table",
-    "dictionary",
-]
-
 Layout: TypeAlias = Literal[
     "regular",
     "unset",

--- a/tests/test_units/test_filedataprovider_class.py
+++ b/tests/test_units/test_filedataprovider_class.py
@@ -9,10 +9,7 @@ import pytest
 from fmu.dataio import ExportData
 from fmu.dataio.datastructure.meta import meta
 from fmu.dataio.providers._filedata import FileDataProvider
-from fmu.dataio.providers.objectdata._base import derive_name
 from fmu.dataio.providers.objectdata._provider import objectdata_provider_factory
-from xtgeo.cube import Cube
-from xtgeo.surface import RegularSurface
 
 
 @pytest.mark.parametrize(
@@ -248,58 +245,3 @@ def test_filedata_has_nonascii_letters(regsurf, tmp_path):
     fdata = FileDataProvider(edataobj1, objdata)
     with pytest.raises(ValueError, match="Path has non-ascii elements"):
         fdata.get_metadata()
-
-
-@pytest.mark.parametrize(
-    "exportdata, obj, expected_name",
-    (
-        (
-            ExportData(),
-            Cube(
-                ncol=1,
-                nrow=1,
-                nlay=1,
-                xinc=25.0,
-                yinc=25.0,
-                zinc=2.0,
-            ),
-            "",
-        ),
-        (
-            ExportData(name="NamedExportData"),
-            Cube(
-                ncol=1,
-                nrow=1,
-                nlay=1,
-                xinc=25.0,
-                yinc=25.0,
-                zinc=2.0,
-            ),
-            "NamedExportData",
-        ),
-        (
-            ExportData(),
-            RegularSurface(
-                name="NamedRegularSurface",
-                ncol=25,
-                nrow=25,
-                xinc=1,
-                yinc=1,
-            ),
-            "NamedRegularSurface",
-        ),
-        (
-            ExportData(name="NamedExportData"),
-            RegularSurface(
-                name="NamedRegularSurface",
-                ncol=25,
-                nrow=25,
-                xinc=1,
-                yinc=1,
-            ),
-            "NamedExportData",
-        ),
-    ),
-)
-def test_derive_name(exportdata, obj, expected_name) -> None:
-    assert derive_name(exportdata, obj) == expected_name


### PR DESCRIPTION
Starts on #666 😈

This PR tries to add some firmer standardization to how metadata is defined within objects we generate metadata for. Presently there are string literals defined and grouped into an unvalidated object returned from the child providers. This change makes progress toward having stronger guarantees that are also type checked.

This PR cleans up the base class and moves toward having these defined as properties of providers classes. To keep the PR from being too large it makes this change to the classname only.

This work precedes initialization internal metadata into a Pydantic object directly.

This PR should follow #660 