### PR TITLE
ENH: Add optional geometry for Grid property

### DIFF
--- a/examples/s/d/nn/xcase/realization-0/iter-0/any/bin/export_grid3d.py
+++ b/examples/s/d/nn/xcase/realization-0/iter-0/any/bin/export_grid3d.py
@@ -38,9 +38,10 @@ def export_geogrid_geometry():
 
     out = ed.export(grd)
     print(f"Stored grid as {out}")
+    return out
 
 
-def export_geogrid_parameters():
+def export_geogrid_parameters(outgrid):
     """Export geogrid assosiated parameters based on user defined lists"""
 
     props = PROPS_SEISMIC + PROPS_OTHER
@@ -51,10 +52,9 @@ def export_geogrid_parameters():
         prop = xtgeo.gridproperty_from_file(filename)
         ed = dataio.ExportData(
             name=propname,
-            # parent={"name": GNAME},
+            geometry=outgrid,
             config=CFG,
-            content="depth",
-            unit="m",
+            content={"property": {"is_discrete": False}},
             vertical_domain={"depth": "msl"},
             timedata=None,
             is_prediction=True,
@@ -67,6 +67,6 @@ def export_geogrid_parameters():
 
 
 if __name__ == "__main__":
-    export_geogrid_geometry()
-    export_geogrid_parameters()
+    outgrid = export_geogrid_geometry()
+    export_geogrid_parameters(outgrid)
     print("Done.")

--- a/schema/definitions/0.8.0/schema/fmu_meta.json
+++ b/schema/definitions/0.8.0/schema/fmu_meta.json
@@ -644,6 +644,17 @@
           "title": "Format",
           "type": "string"
         },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "grid_model": {
           "anyOf": [
             {
@@ -1309,6 +1320,17 @@
           "title": "Format",
           "type": "string"
         },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "grid_model": {
           "anyOf": [
             {
@@ -1591,6 +1613,17 @@
           "title": "Format",
           "type": "string"
         },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "grid_model": {
           "anyOf": [
             {
@@ -1872,6 +1905,17 @@
           ],
           "title": "Format",
           "type": "string"
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "grid_model": {
           "anyOf": [
@@ -2257,6 +2301,17 @@
           "title": "Format",
           "type": "string"
         },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "grid_model": {
           "anyOf": [
             {
@@ -2557,6 +2612,17 @@
           ],
           "title": "Format",
           "type": "string"
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "grid_model": {
           "anyOf": [
@@ -2960,6 +3026,17 @@
           "title": "Format",
           "type": "string"
         },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "grid_model": {
           "anyOf": [
             {
@@ -3174,6 +3251,30 @@
       "title": "FluidContactContent",
       "type": "object"
     },
+    "Geometry": {
+      "properties": {
+        "name": {
+          "examples": [
+            "MyGrid"
+          ],
+          "title": "Name",
+          "type": "string"
+        },
+        "relative_path": {
+          "examples": [
+            "some/relative/path/mygrid.roff"
+          ],
+          "title": "Relative Path",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "relative_path"
+      ],
+      "title": "Geometry",
+      "type": "object"
+    },
     "GridModel": {
       "properties": {
         "name": {
@@ -3314,6 +3415,17 @@
           ],
           "title": "Format",
           "type": "string"
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "grid_model": {
           "anyOf": [
@@ -3637,6 +3749,17 @@
           "title": "Format",
           "type": "string"
         },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "grid_model": {
           "anyOf": [
             {
@@ -3931,6 +4054,17 @@
           "title": "Format",
           "type": "string"
         },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "grid_model": {
           "anyOf": [
             {
@@ -4212,6 +4346,17 @@
           ],
           "title": "Format",
           "type": "string"
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "grid_model": {
           "anyOf": [
@@ -4515,6 +4660,17 @@
           "title": "Format",
           "type": "string"
         },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "grid_model": {
           "anyOf": [
             {
@@ -4796,6 +4952,17 @@
           ],
           "title": "Format",
           "type": "string"
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "grid_model": {
           "anyOf": [
@@ -5129,6 +5296,17 @@
           "title": "Format",
           "type": "string"
         },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "grid_model": {
           "anyOf": [
             {
@@ -5410,6 +5588,17 @@
           ],
           "title": "Format",
           "type": "string"
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "grid_model": {
           "anyOf": [
@@ -5748,6 +5937,17 @@
           "title": "Format",
           "type": "string"
         },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "grid_model": {
           "anyOf": [
             {
@@ -6029,6 +6229,17 @@
           ],
           "title": "Format",
           "type": "string"
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "grid_model": {
           "anyOf": [
@@ -6399,6 +6610,17 @@
           ],
           "title": "Format",
           "type": "string"
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "grid_model": {
           "anyOf": [
@@ -6795,6 +7017,17 @@
           ],
           "title": "Format",
           "type": "string"
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "grid_model": {
           "anyOf": [
@@ -7271,6 +7504,17 @@
           "title": "Format",
           "type": "string"
         },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "grid_model": {
           "anyOf": [
             {
@@ -7581,6 +7825,17 @@
           "title": "Format",
           "type": "string"
         },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "grid_model": {
           "anyOf": [
             {
@@ -7862,6 +8117,17 @@
           ],
           "title": "Format",
           "type": "string"
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "grid_model": {
           "anyOf": [
@@ -8203,6 +8469,17 @@
           "title": "Format",
           "type": "string"
         },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "grid_model": {
           "anyOf": [
             {
@@ -8498,6 +8775,17 @@
           "title": "Format",
           "type": "string"
         },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "grid_model": {
           "anyOf": [
             {
@@ -8779,6 +9067,17 @@
           ],
           "title": "Format",
           "type": "string"
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "grid_model": {
           "anyOf": [

--- a/src/fmu/dataio/_utils.py
+++ b/src/fmu/dataio/_utils.py
@@ -432,3 +432,37 @@ def read_metadata_from_file(filename: str | Path) -> dict:
         raise OSError(f"Cannot find requested metafile: {metafile}")
     with open(metafilepath) as stream:
         return yaml.safe_load(stream)
+
+
+def get_geometry_ref(
+    geometrypath: str | None, obj: Any
+) -> tuple[str | None, str | None]:
+    """Get a reference to a geometry.
+
+    Read the metadata file for an already exported file, and returns info like this
+    for the data block:
+
+    data:
+      geometry:
+        name: somename
+        relative_path: some_relative/path/geometry.roff
+
+    This means that the geometry may be 'located' both on disk (relative path) and in
+    Sumo
+    """
+    if not geometrypath:
+        return None, None
+
+    gmeta = read_metadata_from_file(geometrypath)
+
+    # some basic checks (may be exteneded to e.g. match on NCOL, NROW, ...?)
+    if isinstance(obj, xtgeo.GridProperty) and gmeta["class"] != "cpgrid":
+        raise ValueError("The geometry for a grid property must be a grid")
+
+    if isinstance(obj, xtgeo.RegularSurface) and gmeta["class"] != "surface":
+        raise ValueError("The geometry for a surface must be another surface")
+
+    geom_name = gmeta["data"].get("name")
+    relpath = gmeta["file"]["relative_path"]
+
+    return geom_name, relpath

--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -238,7 +238,16 @@ class ExportData:
             standard folder for Cube output with "seismics". Use with care and avoid if
             possible!
 
-        grid_model: Currently allowed but planned for deprecation
+        geometry: Optional, and for grid properties only, which may need a
+            reference to the 3D grid geometry object. The value shall
+            point to an existing file which is already exported with dataio,
+            and hence has an assosiated metadata file. The grid name will be derived
+            from the grid metadata, if present, and applied as part of the gridproperty
+            file name (same behaviour as the `parent` key; replacing this).
+            Note that this key may replace the usage of both the `parent` key and the
+            `grid_model` key in the near future.
+
+        grid_model: Currently allowed but planned for deprecation. See `geometry`.
 
         table_index: This applies to Pandas (table) data only, and is a list of the
             column names to use as index columns e.g. ["ZONE", "REGION"].
@@ -257,8 +266,12 @@ class ExportData:
             if "TopValysar" is the model name and the actual name is "Valysar Top Fm."
             that latter name will be used.
 
-        parent: Optional. This key is required for datatype GridProperty, and
-            refers to the name of the grid geometry.
+        parent: Optional. This key is required for datatype GridProperty, unless the
+            `geometry` is given, and refers to the name of the grid geometry. It will
+            only be added in the filename, and not as genuine metadata entry.
+            This key is a candidate for deprecation, and users shall use the
+            `geometry` key instead. If both `parent` and `geometry` is given, the grid
+            name derived from the `geometry` object will have predence.
 
         rep_include: Optional. If True then the data object will be available in REP.
             Default is False.
@@ -354,6 +367,7 @@ class ExportData:
     display_name: Optional[str] = None
     fmu_context: Optional[str] = None
     forcefolder: str = ""
+    geometry: Optional[str] = None
     grid_model: Optional[str] = None
     is_observation: bool = False
     is_prediction: bool = True

--- a/src/fmu/dataio/datastructure/meta/content.py
+++ b/src/fmu/dataio/datastructure/meta/content.py
@@ -111,6 +111,11 @@ class FieldRegion(BaseModel):
     )
 
 
+class Geometry(BaseModel):
+    name: str = Field(examples=["MyGrid"])
+    relative_path: str = Field(examples=["some/relative/path/mygrid.roff"])
+
+
 class GridModel(BaseModel):
     name: str = Field(examples=["MyGrid"])
 
@@ -180,7 +185,10 @@ class Content(BaseModel):
 
     alias: Optional[List[str]] = Field(default=None)
 
-    # Only valid for cooridate based meta.
+    # only relevant for grid properties
+    geometry: Optional[Geometry] = Field(default=None)
+
+    # Only valid for coordinate based meta.
     bbox: Optional[Union[BoundingBox3D, BoundingBox2D]] = Field(default=None)
 
     description: Optional[List[str]] = Field(
@@ -189,7 +197,6 @@ class Content(BaseModel):
     format: str = Field(
         examples=["irap_binary"],
     )
-
     grid_model: Optional[GridModel] = Field(default=None)
     is_observation: bool = Field(
         title="Is observation flag",

--- a/src/fmu/dataio/providers/objectdata/_base.py
+++ b/src/fmu/dataio/providers/objectdata/_base.py
@@ -21,7 +21,11 @@ from fmu.dataio.providers._base import Provider
 
 if TYPE_CHECKING:
     from fmu.dataio.dataio import ExportData
-    from fmu.dataio.datastructure.meta.content import BoundingBox2D, BoundingBox3D
+    from fmu.dataio.datastructure.meta.content import (
+        BoundingBox2D,
+        BoundingBox3D,
+        Geometry,
+    )
     from fmu.dataio.datastructure.meta.enums import FMUClassEnum, Layout
     from fmu.dataio.datastructure.meta.specification import AnySpecification
     from fmu.dataio.types import Inferrable
@@ -103,6 +107,7 @@ class ObjectDataProvider(Provider):
         metadata["depth_reference"] = list(self.dataio.vertical_domain.values())[0]
 
         metadata["spec"] = self.get_spec()
+        metadata["geometry"] = self.get_geometry()
         metadata["bbox"] = self.get_bbox()
         metadata["time"] = self._get_timedata()
         metadata["table_index"] = self.table_index
@@ -147,6 +152,10 @@ class ObjectDataProvider(Provider):
     @property
     @abstractmethod
     def table_index(self) -> list[str] | None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_geometry(self) -> Geometry | None:
         raise NotImplementedError
 
     @abstractmethod

--- a/src/fmu/dataio/providers/objectdata/_faultroom.py
+++ b/src/fmu/dataio/providers/objectdata/_faultroom.py
@@ -45,6 +45,9 @@ class FaultRoomSurfaceProvider(ObjectDataProvider):
     def table_index(self) -> None:
         """Return the table index."""
 
+    def get_geometry(self) -> None:
+        """Derive data.geometry for FaultRoomSurface."""
+
     def get_bbox(self) -> BoundingBox3D:
         """Derive data.bbox for FaultRoomSurface."""
         logger.info("Get bbox for FaultRoomSurface")

--- a/src/fmu/dataio/providers/objectdata/_provider.py
+++ b/src/fmu/dataio/providers/objectdata/_provider.py
@@ -187,6 +187,9 @@ class DictionaryDataProvider(ObjectDataProvider):
     def table_index(self) -> None:
         """Return the table index."""
 
+    def get_geometry(self) -> None:
+        """Derive data.geometry for dictionary."""
+
     def get_bbox(self) -> None:
         """Derive data.bbox for dict."""
 

--- a/src/fmu/dataio/providers/objectdata/_tables.py
+++ b/src/fmu/dataio/providers/objectdata/_tables.py
@@ -88,6 +88,9 @@ class DataFrameDataProvider(ObjectDataProvider):
         """Return the table index."""
         return _derive_index(self.dataio.table_index, list(self.obj.columns))
 
+    def get_geometry(self) -> None:
+        """Derive data.geometry for data frame"""
+
     def get_bbox(self) -> None:
         """Derive data.bbox for pd.DataFrame."""
 
@@ -128,6 +131,9 @@ class ArrowTableDataProvider(ObjectDataProvider):
     def table_index(self) -> list[str]:
         """Return the table index."""
         return _derive_index(self.dataio.table_index, list(self.obj.column_names))
+
+    def get_geometry(self) -> None:
+        """Derive data.geometry for Arrow table."""
 
     def get_bbox(self) -> None:
         """Derive data.bbox for pyarrow.Table."""


### PR DESCRIPTION
Ref. former PR https://github.com/equinor/fmu-dataio/pull/635 ...

A new attempt for adding the geometry field for a grid property. In this round, it is only relevant for grid properties, as a geometry link for e.g. a surface is more ambiguous.

Also, there was a former discussion on a new type of `uuid` made upfront by `fmu-dataio` in order to connect the geometry to a grid property. This PR does not include that; rather propose this (in case is still relevant) as a separate PR, since it has potential side effects and needs coordination with Sumo. 