### PR TITLE
FIX: Support giving in arguments on export for preprocessed data

### DIFF
--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -755,7 +755,8 @@ class ExportData:
         self._update_check_settings(kwargs)
 
         if isinstance(obj, (str, Path)):
-            assert self.casepath is not None
+            if self.casepath is None:
+                raise TypeError("No 'casepath' argument provided")
             _future_warning_preprocessed()
             return ExportPreprocessedData(
                 config=self.config,
@@ -804,7 +805,9 @@ class ExportData:
                 "The return_symlink option is deprecated and can safely be removed."
             )
         if isinstance(obj, (str, Path)):
-            assert self.casepath is not None
+            self._update_check_settings(kwargs)
+            if self.casepath is None:
+                raise TypeError("No 'casepath' argument provided")
             _future_warning_preprocessed()
             return ExportPreprocessedData(
                 config=self.config,


### PR DESCRIPTION
Fix bug to handle `casepath` given in as argument to `ExportData.export()`. 

As is the case in Drogon
https://github.com/equinor/fmu-drogon/blob/57007d8ac3faca2c743c5013a0756ea9ac52a7ec/ert/bin/scripts/wf_copy_preprocessed_dataio.py#L47-L53

Closes #675