### PR TITLE
FIX: Require fmu.model info in schema

### DIFF
--- a/schema/definitions/0.8.0/schema/fmu_meta.json
+++ b/schema/definitions/0.8.0/schema/fmu_meta.json
@@ -1179,36 +1179,24 @@
           "title": "Description"
         },
         "name": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
           "examples": [
             "Drogon"
           ],
-          "title": "Name"
+          "title": "Name",
+          "type": "string"
         },
         "revision": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
           "examples": [
             "21.0.0.dev"
           ],
-          "title": "Revision"
+          "title": "Revision",
+          "type": "string"
         }
       },
+      "required": [
+        "name",
+        "revision"
+      ],
       "title": "FMUModel",
       "type": "object"
     },

--- a/src/fmu/dataio/case.py
+++ b/src/fmu/dataio/case.py
@@ -120,8 +120,8 @@ class InitializeCase:  # pylint: disable=too-few-public-methods
         case_meta = internal.CaseSchema(
             masterdata=meta.Masterdata.model_validate(self.config["masterdata"]),
             access=meta.Access.model_validate(self.config["access"]),
-            fmu=internal.FMUModel(
-                model=global_configuration.Model.model_validate(
+            fmu=internal.FMUModelCase(
+                model=meta.FMUModel.model_validate(
                     self.config["model"],
                 ),
                 case=meta.FMUCase(

--- a/src/fmu/dataio/datastructure/_internal/internal.py
+++ b/src/fmu/dataio/datastructure/_internal/internal.py
@@ -13,9 +13,6 @@ from textwrap import dedent
 from typing import List, Literal, Optional, Union
 
 from fmu.dataio._definitions import SCHEMA, SOURCE, VERSION, FmuContext
-from fmu.dataio.datastructure.configuration.global_configuration import (
-    Model as GlobalConfigurationModel,
-)
 from fmu.dataio.datastructure.meta import meta
 from pydantic import (
     AnyHttpUrl,
@@ -109,8 +106,8 @@ class JsonSchemaMetadata(BaseModel, populate_by_name=True):
     source: str = Field(default=SOURCE)
 
 
-class FMUModel(BaseModel):
-    model: GlobalConfigurationModel
+class FMUModelCase(BaseModel):
+    model: meta.FMUModel
     case: meta.FMUCase
 
 
@@ -173,6 +170,6 @@ class CaseSchema(JsonSchemaMetadata):
     class_: Literal["case"] = Field(alias="class", default="case")
     masterdata: meta.Masterdata
     access: meta.Access
-    fmu: FMUModel
+    fmu: FMUModelCase
     description: Optional[List[str]] = Field(default=None)
     tracklog: List[meta.TracklogEvent]

--- a/src/fmu/dataio/datastructure/configuration/global_configuration.py
+++ b/src/fmu/dataio/datastructure/configuration/global_configuration.py
@@ -38,16 +38,6 @@ Detailed information:
     )
 
 
-class Model(BaseModel):
-    """
-    Represents a basic model configuration with a name and revision.
-    """
-
-    name: str
-    revision: str
-    description: Optional[List[str]] = Field(default=None)
-
-
 class Ssdl(BaseModel):
     """
     Defines the configuration for the SSDL.
@@ -131,7 +121,7 @@ class GlobalConfiguration(BaseModel):
 
     access: Access
     masterdata: meta.Masterdata
-    model: Model
+    model: meta.FMUModel
     stratigraphy: Optional[Stratigraphy] = Field(
         default=None,
     )

--- a/src/fmu/dataio/datastructure/meta/meta.py
+++ b/src/fmu/dataio/datastructure/meta/meta.py
@@ -159,12 +159,10 @@ class FMUModel(BaseModel):
         default=None,
         description="This is a free text description of the model setup",
     )
-    name: Optional[str] = Field(
-        default=None,
+    name: str = Field(
         examples=["Drogon"],
     )
-    revision: Optional[str] = Field(
-        default=None,
+    revision: str = Field(
         examples=["21.0.0.dev"],
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -300,7 +300,7 @@ def fixture_globalconfig1():
             ssdl=global_configuration.Ssdl(rep_include=False),
             classification=global_configuration.enums.AccessLevel.internal,
         ),
-        model=global_configuration.Model(
+        model=global_configuration.meta.FMUModel(
             name="Test",
             revision="AUTO",
         ),


### PR DESCRIPTION
The `fmu.model.name` and `fmu.model.revision` should not be optional in the schema. Closes #684 