### PR TITLE
ENH: Use fmu.model info from casemeta if not provided

### DIFF
--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -759,7 +759,6 @@ class ExportData:
                 raise TypeError("No 'casepath' argument provided")
             _future_warning_preprocessed()
             return ExportPreprocessedData(
-                config=self.config,
                 casepath=self.casepath,
                 is_observation=self.is_observation,
             ).generate_metadata(obj)
@@ -810,7 +809,6 @@ class ExportData:
                 raise TypeError("No 'casepath' argument provided")
             _future_warning_preprocessed()
             return ExportPreprocessedData(
-                config=self.config,
                 casepath=self.casepath,
                 is_observation=self.is_observation,
             ).export(obj)

--- a/src/fmu/dataio/preprocessed.py
+++ b/src/fmu/dataio/preprocessed.py
@@ -59,7 +59,6 @@ class ExportPreprocessedData:
             "casepath/share/observations" folder, otherwise on casepath/share/result.
     """
 
-    config: dict
     casepath: str | Path
     is_observation: bool = True
 
@@ -73,7 +72,6 @@ class ExportPreprocessedData:
             )
 
         self._fmudata = FmuProvider(
-            model=self.config.get("model"),
             fmu_context=FmuContext.CASE,
             casepath_proposed=Path(self.casepath),
             workflow=None,

--- a/tests/test_units/test_fmuprovider_class.py
+++ b/tests/test_units/test_fmuprovider_class.py
@@ -27,9 +27,7 @@ def test_fmuprovider_no_provider():
         casepath_proposed="",
         workflow=WORKFLOW,
     )
-    with pytest.raises(
-        InvalidMetadataError, match="Missing casepath or model description"
-    ):
+    with pytest.raises(InvalidMetadataError, match="Missing casepath"):
         myfmu.get_metadata()
 
 
@@ -45,16 +43,20 @@ def test_fmuprovider_model_info_in_metadata(fmurun_w_casemetadata):
     assert "model" in meta.model_fields_set
     assert meta.model.model_dump(mode="json", exclude_none=True) == GLOBAL_CONFIG_MODEL
 
+
+def test_fmuprovider_no_model_info_use_case(fmurun_w_casemetadata):
+    """Test that if no model info it is picking up from the case metadata."""
+
     myfmu = FmuProvider(
         model=None,
         fmu_context=FmuContext.REALIZATION,
         workflow=WORKFLOW,
     )
 
-    with pytest.raises(
-        InvalidMetadataError, match="Missing casepath or model description"
-    ):
-        meta = myfmu.get_metadata()
+    meta = myfmu.get_metadata()
+    casemeta = myfmu._get_case_meta()
+    assert meta.model.name == casemeta.fmu.model.name
+    assert meta.model.revision == casemeta.fmu.model.revision
 
 
 def test_fmuprovider_ert_provider_guess_casemeta_path(fmurun):
@@ -72,9 +74,7 @@ def test_fmuprovider_ert_provider_guess_casemeta_path(fmurun):
         )
 
     assert myfmu.get_casepath() is None
-    with pytest.raises(
-        InvalidMetadataError, match="Missing casepath or model description"
-    ):
+    with pytest.raises(InvalidMetadataError, match="Missing casepath"):
         myfmu.get_metadata()
 
 
@@ -211,9 +211,7 @@ def test_fmuprovider_detect_no_case_metadata(fmurun):
             model=GLOBAL_CONFIG_MODEL,
             fmu_context=FmuContext.REALIZATION,
         )
-    with pytest.raises(
-        InvalidMetadataError, match="Missing casepath or model description"
-    ):
+    with pytest.raises(InvalidMetadataError, match="Missing casepath"):
         myfmu.get_metadata()
 
 

--- a/tests/test_units/test_objectdataprovider_class.py
+++ b/tests/test_units/test_objectdataprovider_class.py
@@ -118,7 +118,7 @@ def test_regsurf_preprocessed_observation(
         )
         return edata, edata.export(regsurf)
 
-    def _run_case_fmu(fmurun_prehook, rmsglobalconfig, surfacepath):
+    def _run_case_fmu(fmurun_prehook, surfacepath):
         """Run FMU workflow, using the preprocessed data as case data.
 
         When re-using metadata, the input object to dataio shall not be a XTGeo or
@@ -132,16 +132,12 @@ def test_regsurf_preprocessed_observation(
         os.chdir(fmurun_prehook)
 
         casepath = fmurun_prehook
-        edata = dataio.ExportPreprocessedData(
-            config=rmsglobalconfig,
-            is_observation=True,
-            casepath=casepath,
-        )
+        edata = dataio.ExportPreprocessedData(is_observation=True, casepath=casepath)
         return edata.generate_metadata(surfacepath)
 
     # run two stage process
     remove_ert_env(monkeypatch)
     edata, mysurf = _export_data_from_rms(rmssetup, rmsglobalconfig, regsurf)
     set_ert_env_prehook(monkeypatch)
-    case_meta = _run_case_fmu(fmurun_prehook, rmsglobalconfig, mysurf)
+    case_meta = _run_case_fmu(fmurun_prehook, mysurf)
     assert edata._metadata["data"] == case_meta["data"]

--- a/tests/test_units/test_preprocessed.py
+++ b/tests/test_units/test_preprocessed.py
@@ -56,9 +56,7 @@ def test_export_preprocessed_surfacefile(
 
     # run the re-export of the preprocessed data inside an mocked FMU run
     set_ert_env_prehook(monkeypatch)
-    edata = dataio.ExportPreprocessedData(
-        config=rmsglobalconfig, is_observation=True, casepath=fmurun_prehook
-    )
+    edata = dataio.ExportPreprocessedData(is_observation=True, casepath=fmurun_prehook)
     # generate the updated metadata
     metadata = edata.generate_metadata(surfacepath)
 
@@ -106,9 +104,7 @@ def test_export_to_results_folder(
 
     # run the re-export of the preprocessed data inside an mocked FMU run
     set_ert_env_prehook(monkeypatch)
-    edata = dataio.ExportPreprocessedData(
-        config=rmsglobalconfig, is_observation=False, casepath=fmurun_prehook
-    )
+    edata = dataio.ExportPreprocessedData(is_observation=False, casepath=fmurun_prehook)
 
     # check that the export has been to the case/share/results folder
     relative_path = PREPROCESSED_SURFACEPATH.replace("preprocessed", "results")
@@ -138,9 +134,7 @@ def test_outdated_metadata(fmurun_prehook, rmsglobalconfig, regsurf, monkeypatch
     # run the re-export of the preprocessed data inside an mocked FMU run
     set_ert_env_prehook(monkeypatch)
 
-    edata = dataio.ExportPreprocessedData(
-        config=rmsglobalconfig, is_observation=True, casepath=fmurun_prehook
-    )
+    edata = dataio.ExportPreprocessedData(is_observation=True, casepath=fmurun_prehook)
     # error should be raised when trying to use the generate_metadata function
     with pytest.raises(InvalidMetadataError, match="outdated"):
         edata.generate_metadata(surfacepath)
@@ -166,9 +160,7 @@ def test_export_without_existing_meta(
 
     # delete the metafile
     metafile.unlink()
-    edata = dataio.ExportPreprocessedData(
-        config=rmsglobalconfig, is_observation=True, casepath=fmurun_prehook
-    )
+    edata = dataio.ExportPreprocessedData(is_observation=True, casepath=fmurun_prehook)
     # test that error is raised when creating metadata
     with pytest.raises(RuntimeError, match="Could not detect existing metadata"):
         edata.generate_metadata(surfacepath)
@@ -204,7 +196,7 @@ def test_preprocessed_surface_modified_post_export(
     # should issue warning
     with pytest.warns(UserWarning, match="seem to have been modified"):
         dataio.ExportPreprocessedData(
-            config=rmsglobalconfig, is_observation=True, casepath=fmurun_prehook
+            is_observation=True, casepath=fmurun_prehook
         ).export(surfacepath)
 
 
@@ -216,12 +208,12 @@ def test_preprocessed_surface_fmucontext_not_case(rmsglobalconfig, monkeypatch):
 
     # error should be raised when outside of FMU
     with pytest.raises(RuntimeError, match="Only possible to run re-export"):
-        dataio.ExportPreprocessedData(config=rmsglobalconfig, casepath="dummy")
+        dataio.ExportPreprocessedData(casepath="dummy")
 
     # error should be raised when running on forward_model in FMU
     set_ert_env_forward(monkeypatch)
     with pytest.raises(RuntimeError, match="Only possible to run re-export"):
-        dataio.ExportPreprocessedData(config=rmsglobalconfig, casepath="dummy")
+        dataio.ExportPreprocessedData(casepath="dummy")
 
 
 def test_preprocessed_surface_invalid_casepath(fmurun_prehook, rmsglobalconfig):
@@ -229,16 +221,16 @@ def test_preprocessed_surface_invalid_casepath(fmurun_prehook, rmsglobalconfig):
 
     # error should be raised when running on a casepath without case metadata
     with pytest.raises(ValueError, match="Could not detect valid case metadata"):
-        dataio.ExportPreprocessedData(config=rmsglobalconfig, casepath="dummy")
+        dataio.ExportPreprocessedData(casepath="dummy")
 
     # shall work when casepath that contains case matadata is provided
-    dataio.ExportPreprocessedData(config=rmsglobalconfig, casepath=fmurun_prehook)
+    dataio.ExportPreprocessedData(casepath=fmurun_prehook)
 
     # delete the case matadata and see that it fails
     metacase_file = fmurun_prehook / ERT_RELATIVE_CASE_METADATA_FILE
     metacase_file.unlink()
     with pytest.raises(ValueError, match="Could not detect valid case metadata"):
-        dataio.ExportPreprocessedData(config=rmsglobalconfig, casepath=fmurun_prehook)
+        dataio.ExportPreprocessedData(casepath=fmurun_prehook)
 
 
 def test_export_non_preprocessed_data(
@@ -262,7 +254,7 @@ def test_export_non_preprocessed_data(
     # check that the error is given
     with pytest.raises(RuntimeError, match="is not supported"):
         dataio.ExportPreprocessedData(
-            config=rmsglobalconfig, is_observation=True, casepath=fmurun_prehook
+            is_observation=True, casepath=fmurun_prehook
         ).generate_metadata(surfacepath)
 
 

--- a/tests/test_units/test_prerealization_surfaces.py
+++ b/tests/test_units/test_prerealization_surfaces.py
@@ -86,7 +86,7 @@ def test_regsurf_preprocessed_observation(
 
         return edata.export(regsurf)
 
-    def _run_case_fmu(fmurun_prehook, rmsglobalconfig, surfacepath):
+    def _run_case_fmu(fmurun_prehook, surfacepath):
         """Run FMU workflow, using the preprocessed data as case data.
 
         When re-using metadata, the input object to dataio shall not be a XTGeo or
@@ -102,11 +102,7 @@ def test_regsurf_preprocessed_observation(
 
         casepath = fmurun_prehook
 
-        edata = dataio.ExportPreprocessedData(
-            config=rmsglobalconfig,  # read from global config
-            is_observation=True,
-            casepath=casepath,
-        )
+        edata = dataio.ExportPreprocessedData(is_observation=True, casepath=casepath)
         metadata = edata.generate_metadata(surfacepath)
         logger.info("Casepath folder is now %s", casepath)
         logger.debug("\n%s", utils.prettyprint_dict(metadata))
@@ -135,7 +131,7 @@ def test_regsurf_preprocessed_observation(
     remove_ert_env(monkeypatch)
     mysurf = _export_data_from_rms(rmssetup, rmsglobalconfig, regsurf)
     set_ert_env_prehook(monkeypatch)
-    _run_case_fmu(fmurun_prehook, rmsglobalconfig, mysurf)
+    _run_case_fmu(fmurun_prehook, mysurf)
 
     logger.info("Preprocessed surface is %s", mysurf)
 
@@ -206,19 +202,13 @@ def test_regsurf_preprocessed_filename_retained(
 
         return edata.export(regsurf)
 
-    def _run_case_fmu(
-        fmurun_prehook,
-        rmsglobalconfig,
-        surfacepath,
-        exproot,
-    ):
+    def _run_case_fmu(fmurun_prehook, surfacepath, exproot):
         """Run FMU workflow, using the preprocessed data on a subfolder."""
 
         os.chdir(fmurun_prehook)
         logger.info("Active folder is %s", fmurun_prehook)
 
         edata = dataio.ExportPreprocessedData(
-            config=rmsglobalconfig,  # read from global config
             is_observation=True,
             casepath=fmurun_prehook,
         )
@@ -233,12 +223,7 @@ def test_regsurf_preprocessed_filename_retained(
         rmssetup, rmsglobalconfig, regsurf, parent, name, tagname, exproot
     )
     set_ert_env_prehook(monkeypatch)
-    _run_case_fmu(
-        fmurun_prehook,
-        rmsglobalconfig,
-        mysurf,
-        exproot,
-    )
+    _run_case_fmu(fmurun_prehook, mysurf, exproot)
 
 
 def test_regsurf_preprocessed_observation_subfolder(
@@ -278,14 +263,14 @@ def test_regsurf_preprocessed_observation_subfolder(
 
         return edata.export(regsurf)
 
-    def _run_case_fmu(fmurun_prehook, rmsglobalconfig, surfacepath):
+    def _run_case_fmu(fmurun_prehook, surfacepath):
         """Run FMU workflow, using the preprocessed data on a subfolder."""
 
         os.chdir(fmurun_prehook)
         logger.info("Active folder is %s", fmurun_prehook)
 
         edata = dataio.ExportPreprocessedData(
-            config=rmsglobalconfig, casepath=fmurun_prehook, is_observation=True
+            casepath=fmurun_prehook, is_observation=True
         )
         metadata = edata.generate_metadata(surfacepath)
         # check that the relative path is identical to existing except the share folder
@@ -300,7 +285,7 @@ def test_regsurf_preprocessed_observation_subfolder(
     mysurf = _export_data_from_rms(rmssetup, rmsglobalconfig, regsurf)
 
     set_ert_env_prehook(monkeypatch)
-    _run_case_fmu(fmurun_prehook, rmsglobalconfig, mysurf)
+    _run_case_fmu(fmurun_prehook, mysurf)
 
 
 @inside_rms
@@ -379,16 +364,13 @@ def test_access_settings_retained(
 
         return edata.export(regsurf)
 
-    def _run_case_fmu(fmurun_prehook, rmsglobalconfig, surfacepath):
+    def _run_case_fmu(fmurun_prehook, surfacepath):
         """Run FMU workflow, test that access is retained from preprocessed."""
 
         os.chdir(fmurun_prehook)
         logger.info("Active folder is %s", fmurun_prehook)
 
-        edata = dataio.ExportPreprocessedData(
-            config=rmsglobalconfig,
-            casepath=fmurun_prehook,
-        )
+        edata = dataio.ExportPreprocessedData(casepath=fmurun_prehook)
         metadata = edata.generate_metadata(surfacepath)
 
         # access shall be inherited from preprocessed data
@@ -398,4 +380,4 @@ def test_access_settings_retained(
     remove_ert_env(monkeypatch)
     surfacepath = _export_data_from_rms(rmssetup, rmsglobalconfig, regsurf)
     set_ert_env_prehook(monkeypatch)
-    _run_case_fmu(fmurun_prehook, rmsglobalconfig, surfacepath)
+    _run_case_fmu(fmurun_prehook, surfacepath)


### PR DESCRIPTION
If model information is not provided to the `FMUProvider` it will use the model info found in the case metadata.
This change enables the removal of the `config` argument in the newly released `ExportPreprocessedData` class. 
