### PR TITLE
ENH: Don't persist metadata in ExportData

### DIFF
--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import os
 import warnings
-from copy import deepcopy
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, ClassVar, Dict, Final, List, Literal, Optional, Union
@@ -22,7 +21,6 @@ from ._logging import null_logger
 from ._metadata import generate_export_metadata
 from ._utils import (
     detect_inside_rms,  # dataio_examples,
-    drop_nones,
     export_file,
     export_metadata_file,
     prettyprint_dict,
@@ -377,7 +375,6 @@ class ExportData:
     _usefmtflag: str = field(default="", init=False)
 
     # storing resulting state variables for instance, non-public:
-    _metadata: dict = field(default_factory=dict, init=False)
     _pwd: Path = field(default_factory=Path, init=False)
     _config_is_valid: bool = field(default=True, init=False)
     _fmurun: bool = field(default=False, init=False)
@@ -769,15 +766,10 @@ class ExportData:
 
         self._update_fmt_flag()
         fmudata = self._get_fmu_provider() if self._fmurun else None
-        self._metadata = drop_nones(
-            generate_export_metadata(
-                obj, self, fmudata, compute_md5=compute_md5
-            ).model_dump(mode="json", exclude_none=True, by_alias=True)
-        )
 
-        logger.info("The metadata are now ready!")
-
-        return deepcopy(self._metadata)
+        return generate_export_metadata(
+            obj, self, fmudata, compute_md5=compute_md5
+        ).model_dump(mode="json", exclude_none=True, by_alias=True)
 
     def export(
         self,

--- a/tests/test_units/test_dataio.py
+++ b/tests/test_units/test_dataio.py
@@ -535,12 +535,13 @@ def test_exportdata_no_iter_folder(
     edata = ExportData(config=rmsglobalconfig, content="depth")
     assert edata._fmurun is True
 
-    edata.export(regsurf)
-
-    assert edata._metadata["fmu"]["realization"]["name"] == "realization-1"
-    assert edata._metadata["fmu"]["realization"]["id"] == 1
-    assert edata._metadata["fmu"]["iteration"]["name"] == "iter-0"
-    assert edata._metadata["fmu"]["iteration"]["id"] == 0
+    out = Path(edata.export(regsurf))
+    with open(out.parent / f".{out.name}.yml", encoding="utf-8") as f:
+        metadata = yaml.safe_load(f)
+    assert metadata["fmu"]["realization"]["name"] == "realization-1"
+    assert metadata["fmu"]["realization"]["id"] == 1
+    assert metadata["fmu"]["iteration"]["name"] == "iter-0"
+    assert metadata["fmu"]["iteration"]["id"] == 0
 
 
 def test_fmucontext_case_casepath(fmurun_prehook, rmsglobalconfig, regsurf):

--- a/tests/test_units/test_ert_context.py
+++ b/tests/test_units/test_ert_context.py
@@ -8,10 +8,12 @@ from __future__ import annotations
 import logging
 import os
 import sys
+from pathlib import Path
 
 import fmu.dataio.dataio as dataio
 import pandas as pd
 import pytest
+import yaml
 from fmu.dataio._utils import prettyprint_dict
 
 logger = logging.getLogger(__name__)
@@ -115,8 +117,11 @@ def test_regsurf_export_file_fmurun(fmurun_w_casemetadata, rmsglobalconfig, regs
     )
     logger.info("Output is %s", output)
 
-    assert edata._metadata["access"]["ssdl"]["access_level"] == "restricted"
-    assert edata._metadata["data"]["unit"] == "forthnite"
+    out = Path(edata.export(regsurf))
+    with open(out.parent / f".{out.name}.yml", encoding="utf-8") as f:
+        metadata = yaml.safe_load(f)
+    assert metadata["access"]["ssdl"]["access_level"] == "restricted"
+    assert metadata["data"]["unit"] == "forthnite"
 
 
 # ======================================================================================

--- a/tests/test_units/test_objectdataprovider_class.py
+++ b/tests/test_units/test_objectdataprovider_class.py
@@ -1,9 +1,11 @@
 """Test the _ObjectData class from the _objectdata.py module"""
 
 import os
+from pathlib import Path
 
 import fmu.dataio as dataio
 import pytest
+import yaml
 from fmu.dataio._definitions import ConfigurationError, ValidFormats
 from fmu.dataio.providers.objectdata._provider import (
     objectdata_provider_factory,
@@ -141,4 +143,8 @@ def test_regsurf_preprocessed_observation(
     edata, mysurf = _export_data_from_rms(rmssetup, rmsglobalconfig, regsurf)
     set_ert_env_prehook(monkeypatch)
     case_meta = _run_case_fmu(fmurun_prehook, mysurf)
-    assert edata._metadata["data"] == case_meta["data"]
+
+    out = Path(mysurf)
+    with open(out.parent / f".{out.name}.yml", encoding="utf-8") as f:
+        metadata = yaml.safe_load(f)
+    assert metadata["data"] == case_meta["data"]

--- a/tests/test_units/test_rms_context.py
+++ b/tests/test_units/test_rms_context.py
@@ -13,6 +13,7 @@ import fmu.dataio.dataio as dataio
 import fmu.dataio.readers as readers
 import pandas as pd
 import pytest
+import yaml
 from fmu.dataio._definitions import FmuContext
 from fmu.dataio._utils import prettyprint_dict
 from fmu.dataio.dataio import ValidationError
@@ -224,8 +225,11 @@ def test_regsurf_export_file_fmurun(
     )
     logger.info("Output is %s", output)
 
-    assert edata._metadata["access"]["ssdl"]["access_level"] == "restricted"
-    assert edata._metadata["data"]["unit"] == "forthnite"
+    out = Path(edata.export(regsurf))
+    with open(out.parent / f".{out.name}.yml", encoding="utf-8") as f:
+        metadata = yaml.safe_load(f)
+    assert metadata["access"]["ssdl"]["access_level"] == "restricted"
+    assert metadata["data"]["unit"] == "forthnite"
 
 
 # ======================================================================================


### PR DESCRIPTION
`generate_metadata` stored the most recently generated metadata internally in the `ExportData` class. We don't need to do this, and probably don't want to do this, because an ExportData instance can be used to generate metadata across many objects.