### PR TITLE
DOC: Remove unused config argument in ExportPreprocessedData

### DIFF
--- a/src/fmu/dataio/preprocessed.py
+++ b/src/fmu/dataio/preprocessed.py
@@ -47,10 +47,6 @@ class ExportPreprocessedData:
     that the file and metadata are stored in the 'share/preprocessed/' folder.
 
     Args:
-        config: Required dictionary with 'model' information; 'name' and 'revision'.
-            Example is {'model': {'name': 'mymodelname', 'revision': '1.0.0'}}
-            Normally read from FMU global variables (via fmuconfig).
-
         casepath: Required casepath for the active ERT experiment. The case needs to
             contain valid case metadata i.e. the ERT workflow 'WF_CREATE_CASE_METADATA'
             has been run prior to using this class.


### PR DESCRIPTION
Remove doc for unused `config` argument in  `ExportPreprocessedData`