### PR TITLE
DEP: Give deprecation warning for arguments in kwargs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -549,7 +549,7 @@ def _create_aggregated_surface_dataset(rmsglobalconfig, regsurf, content):
     for i in range(10):  # TODO! 10
         use_regsurf = regsurf.copy()
         use_regsurf.values += float(i)
-        expfile = edata.export(use_regsurf, name="mymap_" + str(i), realization=i)
+        expfile = edata.export(use_regsurf, name=f"mymap_{i}")
         aggs.append(expfile)
 
     # next task is to do an aggradation, and now the metadata already exists

--- a/tests/test_units/test_aggregated_surfaces.py
+++ b/tests/test_units/test_aggregated_surfaces.py
@@ -337,7 +337,6 @@ def test_regsurf_aggregated_diffdata(fmurun_w_casemetadata, rmsglobalconfig, reg
         expfile = edata.export(
             use_regsurf,
             name="mymap_" + str(i),
-            realization=i,
             timedata=[[20300201], [19990204]],
         )
         aggs.append(expfile)

--- a/tests/test_units/test_dictionary.py
+++ b/tests/test_units/test_dictionary.py
@@ -117,8 +117,8 @@ def test_export_dict_w_meta(globalconfig2, dictionary, request, monkeypatch, tmp
     name = dictionary
     in_dict = request.getfixturevalue(dictionary)
     print(f"{name}: {in_dict}")
-    exd = ExportData(config=globalconfig2, content="parameters")
-    out_dict, out_meta = read_dict_and_meta(exd.export(in_dict, name=name))
+    exd = ExportData(config=globalconfig2, content="parameters", name=name)
+    out_dict, out_meta = read_dict_and_meta(exd.export(in_dict))
     assert in_dict == out_dict
     assert_dict_correct(out_dict, out_meta, name)
 
@@ -134,10 +134,10 @@ def test_invalid_dict(
     """
     monkeypatch.chdir(tmp_path)
     in_dict = {"volumes": drogon_volumes, "summary": drogon_summary}
-    exd = ExportData(config=globalconfig2, content="parameters")
+    exd = ExportData(config=globalconfig2, content="parameters", name="invalid")
     with pytest.raises(TypeError) as exc_info:
         print(exc_info)
-        exd.export(in_dict, name="invalid")
+        exd.export(in_dict)
         assert exc_info[1] == "Object of type Table is not JSON serializable"
 
 

--- a/tests/test_units/test_metadata_class.py
+++ b/tests/test_units/test_metadata_class.py
@@ -145,7 +145,9 @@ def test_populate_meta_undef_is_zero(regsurf, globalconfig2):
     assert mymeta1["data"]["undef_is_zero"] is False
 
     # assert that value is reflected when passed to generate_metadata
-    mymeta2 = eobj1.generate_metadata(regsurf, undef_is_zero=True)
+    # and warning is issued to move the argument to initialization
+    with pytest.warns(FutureWarning, match="move them up to initialization"):
+        mymeta2 = eobj1.generate_metadata(regsurf, undef_is_zero=True)
     assert mymeta2["data"]["undef_is_zero"] is True
 
     # assert that value is reflected when passed to ExportData
@@ -156,7 +158,7 @@ def test_populate_meta_undef_is_zero(regsurf, globalconfig2):
         unit="m",
         undef_is_zero=True,
     )
-    mymeta3 = eobj2.generate_metadata(regsurf, undef_is_zero=True)
+    mymeta3 = eobj2.generate_metadata(regsurf)
     assert mymeta3["data"]["undef_is_zero"] is True
 
 

--- a/tests/test_units/test_preprocessed.py
+++ b/tests/test_units/test_preprocessed.py
@@ -27,7 +27,7 @@ def read_metadata(objmetafile):
 def export_preprocessed_surface(config, regsurf):
     edata = dataio.ExportData(
         config=config,
-        fmu_context="preprocessed",
+        preprocessed=True,
         name="TopVolantis",
         content="depth",
         timedata=[[20240802, "moni"], [20200909, "base"]],
@@ -200,7 +200,7 @@ def test_preprocessed_surface_modified_post_export(
         ).export(surfacepath)
 
 
-def test_preprocessed_surface_fmucontext_not_case(rmsglobalconfig, monkeypatch):
+def test_preprocessed_surface_fmucontext_not_case(monkeypatch):
     """
     Test that an error is raised if ExportPreprocessedData is used
     in other fmu_context than 'case'
@@ -216,7 +216,7 @@ def test_preprocessed_surface_fmucontext_not_case(rmsglobalconfig, monkeypatch):
         dataio.ExportPreprocessedData(casepath="dummy")
 
 
-def test_preprocessed_surface_invalid_casepath(fmurun_prehook, rmsglobalconfig):
+def test_preprocessed_surface_invalid_casepath(fmurun_prehook):
     """Test that an error is raised if casepath is wrong or no case meta exist"""
 
     # error should be raised when running on a casepath without case metadata
@@ -307,33 +307,29 @@ def test_export_preprocessed_file_exportdata_casepath_on_export(
     set_ert_env_prehook(monkeypatch)
 
     # Use the ExportData class instead of the ExportPreprocessedData
-    edata = dataio.ExportData(config=rmsglobalconfig)
+    edata = dataio.ExportData(config=rmsglobalconfig, is_observation=True)
 
     # test that error is thrown when missing casepath
     with pytest.raises(TypeError, match="No 'casepath' argument provided"):
-        edata.export(surfacepath, is_observation=True)
+        edata.export(surfacepath)
 
     # test that export() works if casepath is provided
     with pytest.warns(FutureWarning, match="no longer supported"):
-        filepath = Path(
-            edata.export(surfacepath, is_observation=True, casepath=fmurun_prehook)
-        )
+        filepath = Path(edata.export(surfacepath, casepath=fmurun_prehook))
     assert filepath.exists()
     metafile = filepath.parent / f".{filepath.name}.yml"
     assert metafile.exists()
 
     # Use the ExportData class instead of the ExportPreprocessedData
-    edata = dataio.ExportData(config=rmsglobalconfig)
+    edata = dataio.ExportData(config=rmsglobalconfig, is_observation=True)
 
     # test that error is thrown when missing casepath
     with pytest.raises(TypeError, match="No 'casepath' argument provided"):
-        edata.generate_metadata(surfacepath, is_observation=True)
+        edata.generate_metadata(surfacepath)
 
     # test that generate_metadata() works if casepath is provided
     with pytest.warns(FutureWarning, match="no longer supported"):
-        meta = edata.generate_metadata(
-            surfacepath, is_observation=True, casepath=fmurun_prehook
-        )
+        meta = edata.generate_metadata(surfacepath, casepath=fmurun_prehook)
 
     assert "fmu" in meta
     assert "merged" in meta["tracklog"][-1]["event"]

--- a/tests/test_units/test_table.py
+++ b/tests/test_units/test_table.py
@@ -58,8 +58,8 @@ def test_inplace_volume_index(mock_volumes, globalconfig2, monkeypatch, tmp_path
     """
     monkeypatch.chdir(tmp_path)
     answer = ["ZONE", "LICENCE"]
-    exd = ExportData(config=globalconfig2, content="volumes")
-    path = exd.export(mock_volumes, name="baretull")
+    exd = ExportData(config=globalconfig2, content="volumes", name="baretull")
+    path = exd.export(mock_volumes)
     assert_correct_table_index(path, answer)
 
 
@@ -74,8 +74,8 @@ def test_derive_summary_index_pandas(
     """
     monkeypatch.chdir(tmp_path)
     answer = ["DATE"]
-    exd = ExportData(config=globalconfig2, content="timeseries")
-    path = exd.export(mock_summary, name="baretull")
+    exd = ExportData(config=globalconfig2, content="timeseries", name="baretull")
+    path = exd.export(mock_summary)
     assert_correct_table_index(path, answer)
 
 
@@ -92,8 +92,8 @@ def test_derive_summary_index_pyarrow(
 
     monkeypatch.chdir(tmp_path)
     answer = ["DATE"]
-    exd = ExportData(config=globalconfig2, content="timeseries")
-    path = exd.export(Table.from_pandas(mock_summary), name="baretull")
+    exd = ExportData(config=globalconfig2, content="timeseries", name="baretull")
+    path = exd.export(Table.from_pandas(mock_summary))
     assert_correct_table_index(path, answer)
 
 
@@ -106,8 +106,10 @@ def test_set_from_exportdata(mock_volumes, globalconfig2, monkeypatch, tmp_path)
     """
     monkeypatch.chdir(tmp_path)
     index = ["OTHER"]
-    exd = ExportData(config=globalconfig2, table_index=index, content="timeseries")
-    path = exd.export(mock_volumes, name="baretull")
+    exd = ExportData(
+        config=globalconfig2, table_index=index, content="timeseries", name="baretull"
+    )
+    path = exd.export(mock_volumes)
     assert_correct_table_index(path, index)
 
 
@@ -120,8 +122,10 @@ def test_set_from_export(mock_volumes, globalconfig2, monkeypatch, tmp_path):
     """
     monkeypatch.chdir(tmp_path)
     index = ["OTHER"]
-    exd = ExportData(config=globalconfig2, content="timeseries")
-    path = exd.export(mock_volumes, name="baretull", table_index=index)
+    exd = ExportData(
+        config=globalconfig2, content="timeseries", table_index=index, name="baretull"
+    )
+    path = exd.export(mock_volumes)
     assert_correct_table_index(path, index)
 
 
@@ -136,9 +140,11 @@ def test_set_table_index_not_in_table(
     """
     monkeypatch.chdir(tmp_path)
     index = ["banana"]
-    exd = ExportData(config=globalconfig2, content="timeseries")
+    exd = ExportData(
+        config=globalconfig2, content="timeseries", table_index=index, name="baretull"
+    )
     with pytest.raises(KeyError) as k_err:
-        exd.export(mock_volumes, name="baretull", table_index=index)
+        exd.export(mock_volumes)
     assert k_err.value.args[0] == "banana is not in table"
 
 


### PR DESCRIPTION
PR to start emitting a deprecation warning for arguments coming in through kwargs in the `ExportData.generate_metadata()` and `ExportData.export()` methods.

Addresses #525
