### PR TITLE
DOC: Complete adding docstrings to Pydantic models

### DIFF
--- a/schema/definitions/0.8.0/schema/fmu_meta.json
+++ b/schema/definitions/0.8.0/schema/fmu_meta.json
@@ -220,6 +220,7 @@
       "type": "object"
     },
     "AxisOrientation": {
+      "description": "The axis orientation for a given data object.",
       "enum": [
         1,
         -1
@@ -231,22 +232,18 @@
       "description": "Contains the 2D coordinates within which a data object is contained.",
       "properties": {
         "xmax": {
-          "description": "Maximum x-coordinate",
           "title": "Xmax",
           "type": "number"
         },
         "xmin": {
-          "description": "Minimum x-coordinate",
           "title": "Xmin",
           "type": "number"
         },
         "ymax": {
-          "description": "Maximum y-coordinate",
           "title": "Ymax",
           "type": "number"
         },
         "ymin": {
-          "description": "Minimum y-coordinate",
           "title": "Ymin",
           "type": "number"
         }
@@ -264,32 +261,26 @@
       "description": "Contains the 3D coordinates within which a data object is contained.",
       "properties": {
         "xmax": {
-          "description": "Maximum x-coordinate",
           "title": "Xmax",
           "type": "number"
         },
         "xmin": {
-          "description": "Minimum x-coordinate",
           "title": "Xmin",
           "type": "number"
         },
         "ymax": {
-          "description": "Maximum y-coordinate",
           "title": "Ymax",
           "type": "number"
         },
         "ymin": {
-          "description": "Minimum y-coordinate",
           "title": "Ymin",
           "type": "number"
         },
         "zmax": {
-          "description": "Maximum z-coordinate. For regular surfaces this field represents the maximum surface value and it will be absent if all values are undefined.",
           "title": "Zmax",
           "type": "number"
         },
         "zmin": {
-          "description": "Minimum z-coordinate. For regular surfaces this field represents the minimum surface value and it will be absent if all values are undefined.",
           "title": "Zmin",
           "type": "number"
         }
@@ -309,17 +300,14 @@
       "description": "Specifies relevant values describing a corner point grid property object.",
       "properties": {
         "ncol": {
-          "description": "The number of columns",
           "title": "Ncol",
           "type": "integer"
         },
         "nlay": {
-          "description": "The number of layers",
           "title": "Nlay",
           "type": "integer"
         },
         "nrow": {
-          "description": "The number of rows",
           "title": "Nrow",
           "type": "integer"
         }
@@ -336,47 +324,38 @@
       "description": "Specifies relevant values describing a corner point grid object.",
       "properties": {
         "ncol": {
-          "description": "The number of columns",
           "title": "Ncol",
           "type": "integer"
         },
         "nlay": {
-          "description": "The number of layers",
           "title": "Nlay",
           "type": "integer"
         },
         "nrow": {
-          "description": "The number of rows",
           "title": "Nrow",
           "type": "integer"
         },
         "xscale": {
-          "description": "Scaling factor for the x-axis",
           "title": "Xscale",
           "type": "number"
         },
         "xshift": {
-          "description": "Shift along the x-axis",
           "title": "Xshift",
           "type": "number"
         },
         "yscale": {
-          "description": "Scaling factor for the y-axis",
           "title": "Yscale",
           "type": "number"
         },
         "yshift": {
-          "description": "Shift along the y-axis",
           "title": "Yshift",
           "type": "number"
         },
         "zscale": {
-          "description": "Scaling factor for the z-axis",
           "title": "Zscale",
           "type": "number"
         },
         "zshift": {
-          "description": "Shift along the z-axis",
           "title": "Zshift",
           "type": "number"
         }
@@ -485,6 +464,7 @@
       "type": "object"
     },
     "Classification": {
+      "description": "The security classification for a given data object.",
       "enum": [
         "asset",
         "internal",
@@ -497,7 +477,7 @@
       "description": "The ``fmu.context`` block contains the FMU context in which this data object\nwas produced.",
       "properties": {
         "stage": {
-          "$ref": "#/$defs/FmuContext"
+          "$ref": "#/$defs/FMUContext"
         }
       },
       "required": [
@@ -562,73 +542,52 @@
       "description": "Specifies relevant values describing a cube object, i.e. a seismic cube.",
       "properties": {
         "ncol": {
-          "description": "The number of columns",
           "title": "Ncol",
           "type": "integer"
         },
         "nlay": {
-          "description": "The number of layers",
           "title": "Nlay",
           "type": "integer"
         },
         "nrow": {
-          "description": "The number of rows",
           "title": "Nrow",
           "type": "integer"
         },
         "rotation": {
-          "description": "Rotation angle",
           "title": "Rotation",
           "type": "number"
         },
         "undef": {
-          "description": "Value representing undefined data",
           "title": "Undef",
           "type": "number"
         },
         "xinc": {
-          "description": "Increment along the x-axis",
           "title": "Xinc",
           "type": "number"
         },
         "xori": {
-          "description": "Origin along the x-axis",
           "title": "Xori",
           "type": "number"
         },
         "yflip": {
-          "allOf": [
-            {
-              "$ref": "#/$defs/AxisOrientation"
-            }
-          ],
-          "description": "Flip along the y-axis, -1 or 1"
+          "$ref": "#/$defs/AxisOrientation"
         },
         "yinc": {
-          "description": "Increment along the y-axis",
           "title": "Yinc",
           "type": "number"
         },
         "yori": {
-          "description": "Origin along the y-axis",
           "title": "Yori",
           "type": "number"
         },
         "zflip": {
-          "allOf": [
-            {
-              "$ref": "#/$defs/AxisOrientation"
-            }
-          ],
-          "description": "Flip along the z-axis, -1 or 1"
+          "$ref": "#/$defs/AxisOrientation"
         },
         "zinc": {
-          "description": "Increment along the z-axis",
           "title": "Zinc",
           "type": "number"
         },
         "zori": {
-          "description": "Origin along the z-axis",
           "title": "Zori",
           "type": "number"
         }
@@ -1093,6 +1052,16 @@
       ],
       "title": "FMUCaseAttributes",
       "type": "object"
+    },
+    "FMUContext": {
+      "description": "The context in which FMU was being run when data were generated.",
+      "enum": [
+        "case",
+        "iteration",
+        "realization"
+      ],
+      "title": "FMUContext",
+      "type": "string"
     },
     "FaciesThicknessData": {
       "description": "The ``data`` block contains information about the data contained in this object.\nThis class contains metadata for facies thickness.",
@@ -1968,7 +1937,6 @@
       "description": "Specifies relevant values describing a Faultroom surface object.",
       "properties": {
         "faults": {
-          "description": "Names of faults",
           "items": {
             "type": "string"
           },
@@ -1976,7 +1944,6 @@
           "type": "array"
         },
         "horizons": {
-          "description": "List of horizon names",
           "items": {
             "type": "string"
           },
@@ -1984,7 +1951,6 @@
           "type": "array"
         },
         "juxtaposition_fw": {
-          "description": "List of zones included in footwall juxtaposition",
           "items": {
             "type": "string"
           },
@@ -1992,7 +1958,6 @@
           "type": "array"
         },
         "juxtaposition_hw": {
-          "description": "List of zones included in hangingwall juxtaposition",
           "items": {
             "type": "string"
           },
@@ -2000,12 +1965,10 @@
           "type": "array"
         },
         "name": {
-          "description": "A name id of the faultroom usage",
           "title": "Name",
           "type": "string"
         },
         "properties": {
-          "description": "List of properties along fault plane",
           "items": {
             "type": "string"
           },
@@ -2051,7 +2014,7 @@
       "type": "object"
     },
     "FieldOutline": {
-      "description": "Conditional field",
+      "description": "A block describing a field outline. Shall be present if ``data.content``\n== \"field_outline\"",
       "properties": {
         "contact": {
           "title": "Contact",
@@ -2359,10 +2322,9 @@
       "type": "object"
     },
     "FieldRegion": {
-      "description": "Conditional field",
+      "description": "A block describing a field region. Shall be present if ``data.content``\n== \"field_region\"",
       "properties": {
         "id": {
-          "description": "The ID of the region",
           "title": "Id",
           "type": "integer"
         }
@@ -2751,7 +2713,7 @@
       "type": "object"
     },
     "FluidContact": {
-      "description": "Conditional field",
+      "description": "A block describing a fluid contact. Shall be present if ``data.content``\n== ``fluid_contact``.",
       "properties": {
         "contact": {
           "enum": [
@@ -3073,16 +3035,8 @@
       "title": "FluidContactData",
       "type": "object"
     },
-    "FmuContext": {
-      "enum": [
-        "case",
-        "iteration",
-        "realization"
-      ],
-      "title": "FmuContext",
-      "type": "string"
-    },
     "Geometry": {
+      "description": "The geometry of the object, i.e. the grid that an object representing a grid\nproperty is derivative of.",
       "properties": {
         "name": {
           "examples": [
@@ -3107,6 +3061,7 @@
       "type": "object"
     },
     "GridModel": {
+      "description": "A block containing information pertaining to grid model content.\nSee :class:`GridModel`.\n\n.. warning:: This has currently no function and is likely to be deprecated.",
       "properties": {
         "name": {
           "examples": [
@@ -3494,6 +3449,7 @@
       "type": "object"
     },
     "Layout": {
+      "description": "The layout of a given data object.",
       "enum": [
         "regular",
         "unset",
@@ -5160,11 +5116,9 @@
               "type": "null"
             }
           ],
-          "description": "List of columns present in a table.",
           "title": "Attributes"
         },
         "size": {
-          "description": "Size of data object.",
           "examples": [
             1,
             9999
@@ -5184,7 +5138,6 @@
       "description": "Specifies relevant values describing a polygon object.",
       "properties": {
         "npolys": {
-          "description": "The number of individual polygons in the data object",
           "title": "Npolys",
           "type": "integer"
         }
@@ -6408,7 +6361,7 @@
       "type": "object"
     },
     "Seismic": {
-      "description": "Conditional field",
+      "description": "A block describing seismic data. Shall be present if ``data.content``\n== ``seismic``.",
       "properties": {
         "attribute": {
           "anyOf": [
@@ -7196,50 +7149,37 @@
       "description": "Specifies relevant values describing a regular surface object.",
       "properties": {
         "ncol": {
-          "description": "The number of columns",
           "title": "Ncol",
           "type": "integer"
         },
         "nrow": {
-          "description": "The number of rows",
           "title": "Nrow",
           "type": "integer"
         },
         "rotation": {
-          "description": "Rotation angle",
           "title": "Rotation",
           "type": "number"
         },
         "undef": {
-          "description": "Value representing undefined data",
           "title": "Undef",
           "type": "number"
         },
         "xinc": {
-          "description": "Increment along the x-axis",
           "title": "Xinc",
           "type": "number"
         },
         "xori": {
-          "description": "Origin along the x-axis",
           "title": "Xori",
           "type": "number"
         },
         "yflip": {
-          "allOf": [
-            {
-              "$ref": "#/$defs/AxisOrientation"
-            }
-          ],
-          "description": "Flip along the y-axis, -1 or 1"
+          "$ref": "#/$defs/AxisOrientation"
         },
         "yinc": {
-          "description": "Increment along the y-axis",
           "title": "Yinc",
           "type": "number"
         },
         "yori": {
-          "description": "Origin along the y-axis",
           "title": "Yori",
           "type": "number"
         }
@@ -7308,7 +7248,6 @@
       "description": "Specifies relevant values describing a generic tabular data object.",
       "properties": {
         "columns": {
-          "description": "List of columns present in a table.",
           "items": {
             "type": "string"
           },
@@ -7316,7 +7255,6 @@
           "type": "array"
         },
         "size": {
-          "description": "Size of data object.",
           "examples": [
             1,
             9999
@@ -7623,6 +7561,7 @@
       "type": "object"
     },
     "Time": {
+      "description": "A block containing lists of objects describing timestamp information for this\ndata object, if applicable, like Flow simulator restart dates, or dates for seismic\n4D surveys.  See :class:`Time`.\n\n.. note:: ``data.time`` items can currently hold a maximum of two values.",
       "properties": {
         "t0": {
           "anyOf": [
@@ -8231,7 +8170,7 @@
       "type": "object"
     },
     "Timestamp": {
-      "description": "Time stamp for data object.",
+      "description": "A timestamp object contains a datetime representation of the time\nbeing marked and a string label for this timestamp.",
       "properties": {
         "label": {
           "anyOf": [

--- a/src/fmu/dataio/aggregation.py
+++ b/src/fmu/dataio/aggregation.py
@@ -11,7 +11,7 @@ from pydantic import ValidationError
 from . import _utils, dataio, types
 from ._logging import null_logger
 from ._metadata import generate_meta_tracklog
-from .datastructure.meta.enums import FmuContext
+from .datastructure.meta.enums import FMUContext
 from .providers.objectdata._provider import objectdata_provider_factory
 
 logger: Final = null_logger(__name__)
@@ -230,7 +230,7 @@ class AggregatedData:
         template["fmu"]["aggregation"]["id"] = self.aggregation_id
 
         # fmu.context.stage should be 'iteration'
-        template["fmu"]["context"]["stage"] = FmuContext.iteration.value
+        template["fmu"]["context"]["stage"] = FMUContext.iteration.value
 
         # next, the new object will trigger update of: 'file', 'data' (some fields) and
         # 'tracklog'.

--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -28,7 +28,7 @@ from .aggregation import AggregatedData
 from .case import InitializeCase
 from .datastructure.configuration import global_configuration
 from .datastructure.meta import enums
-from .datastructure.meta.enums import FmuContext
+from .datastructure.meta.enums import FMUContext
 from .preprocessed import ExportPreprocessedData
 from .providers._fmu import FmuProvider, get_fmu_context_from_environment
 
@@ -662,15 +662,15 @@ class ExportData:
             self.fmu_context = None
 
         else:
-            self.fmu_context = FmuContext(self.fmu_context.lower())
+            self.fmu_context = FMUContext(self.fmu_context.lower())
             logger.info("FMU context is %s", self.fmu_context)
 
-        if self.preprocessed and self.fmu_context == FmuContext.realization:
+        if self.preprocessed and self.fmu_context == FMUContext.realization:
             raise ValueError(
                 "Can't export preprocessed data in a fmu_context='realization'."
             )
 
-        if self.fmu_context != FmuContext.case and env_fmu_context == FmuContext.case:
+        if self.fmu_context != FMUContext.case and env_fmu_context == FMUContext.case:
             warn(
                 "fmu_context is set to 'realization', but unable to detect "
                 "ERT runpath from environment variable. "
@@ -727,7 +727,7 @@ class ExportData:
         )
 
         if self._fmurun:
-            assert isinstance(self.fmu_context, FmuContext)
+            assert isinstance(self.fmu_context, FMUContext)
             if casepath := FmuProvider(
                 fmu_context=self.fmu_context,
                 casepath_proposed=Path(self.casepath) if self.casepath else None,
@@ -747,7 +747,7 @@ class ExportData:
         return self._pwd
 
     def _get_fmu_provider(self) -> FmuProvider:
-        assert isinstance(self.fmu_context, FmuContext)
+        assert isinstance(self.fmu_context, FMUContext)
         return FmuProvider(
             model=self.config.get("model"),
             fmu_context=self.fmu_context,

--- a/src/fmu/dataio/datastructure/_internal/internal.py
+++ b/src/fmu/dataio/datastructure/_internal/internal.py
@@ -70,7 +70,7 @@ class ContentRequireSpecific(BaseModel):
 
 
 class AllowedContent(BaseModel):
-    content: Union[meta.enums.ContentEnum, Literal["unset"]]
+    content: Union[meta.enums.Content, Literal["unset"]]
     content_incl_specific: Optional[ContentRequireSpecific] = Field(default=None)
 
     @model_validator(mode="before")
@@ -81,7 +81,7 @@ class AllowedContent(BaseModel):
 
         if content in ContentRequireSpecific.model_fields and not content_specific:
             # 'property' should be included below after a deprecation period
-            if content == meta.enums.ContentEnum.property:
+            if content == meta.enums.Content.property:
                 property_warn()
             else:
                 raise ValueError(f"Content {content} requires additional input")
@@ -113,7 +113,7 @@ class FMUModelCase(BaseModel):
 
 
 class Context(BaseModel, use_enum_values=True):
-    stage: meta.enums.FmuContext
+    stage: meta.enums.FMUContext
 
 
 # Remove the two models below when content is required as input.
@@ -122,7 +122,7 @@ class UnsetContent(meta.content.Data):
 
     @model_validator(mode="after")
     def _deprecation_warning(self) -> UnsetContent:
-        valid_contents = [m.value for m in meta.enums.ContentEnum]
+        valid_contents = [m.value for m in meta.enums.Content]
         warnings.warn(
             "The <content> is not provided which will produce invalid metadata. "
             "It is strongly recommended that content is given explicitly! "
@@ -147,15 +147,15 @@ class DataClassMeta(JsonSchemaMetadata):
     # TODO: aim to use meta.FMUDataClassMeta as base
     # class and disallow creating invalid metadata.
     class_: Literal[
-        meta.enums.FMUClassEnum.surface,
-        meta.enums.FMUClassEnum.table,
-        meta.enums.FMUClassEnum.cpgrid,
-        meta.enums.FMUClassEnum.cpgrid_property,
-        meta.enums.FMUClassEnum.polygons,
-        meta.enums.FMUClassEnum.cube,
-        meta.enums.FMUClassEnum.well,
-        meta.enums.FMUClassEnum.points,
-        meta.enums.FMUClassEnum.dictionary,
+        meta.enums.FMUClass.surface,
+        meta.enums.FMUClass.table,
+        meta.enums.FMUClass.cpgrid,
+        meta.enums.FMUClass.cpgrid_property,
+        meta.enums.FMUClass.polygons,
+        meta.enums.FMUClass.cube,
+        meta.enums.FMUClass.well,
+        meta.enums.FMUClass.points,
+        meta.enums.FMUClass.dictionary,
     ] = Field(alias="class")
     fmu: Optional[FMUClassMetaData]
     masterdata: Optional[meta.Masterdata]

--- a/src/fmu/dataio/datastructure/meta/content.py
+++ b/src/fmu/dataio/datastructure/meta/content.py
@@ -20,65 +20,73 @@ from . import enums, specification
 
 
 class Timestamp(BaseModel):
-    """
-    Time stamp for data object.
-    """
+    """A timestamp object contains a datetime representation of the time
+    being marked and a string label for this timestamp."""
 
     label: Optional[str] = Field(
         default=None,
         examples=["base", "monitor", "mylabel"],
     )
+    """A string label corresponding to the timestamp."""
+
     value: Optional[Union[NaiveDatetime, AwareDatetime]] = Field(
         default=None,
         examples=["2020-10-28T14:28:02"],
     )
+    """A datetime representation."""
 
 
 class Time(BaseModel):
+    """A block containing lists of objects describing timestamp information for this
+    data object, if applicable, like Flow simulator restart dates, or dates for seismic
+    4D surveys.  See :class:`Time`.
+
+    .. note:: ``data.time`` items can currently hold a maximum of two values."""
+
     t0: Optional[Timestamp] = None
+    """The first timestamp. See :class:`Timestamp`."""
+
     t1: Optional[Timestamp] = None
+    """The second timestamp. See :class:`Timestamp`."""
 
 
 class Seismic(BaseModel):
     """
-    Conditional field
+    A block describing seismic data. Shall be present if ``data.content``
+    == ``seismic``.
     """
 
-    attribute: Optional[str] = Field(
-        default=None,
-        examples=["amplitude_timeshifted"],
-    )
-    calculation: Optional[str] = Field(
-        default=None,
-        examples=["mean"],
-    )
-    filter_size: Optional[float] = Field(
-        allow_inf_nan=False,
-        default=None,
-    )
-    scaling_factor: Optional[float] = Field(
-        allow_inf_nan=False,
-        default=None,
-    )
-    stacking_offset: Optional[str] = Field(
-        default=None,
-        examples=["0-15"],
-    )
-    zrange: Optional[float] = Field(
-        allow_inf_nan=False,
-        default=None,
-    )
+    attribute: Optional[str] = Field(default=None, examples=["amplitude_timeshifted"])
+    """A known seismic attribute."""
+
+    calculation: Optional[str] = Field(default=None, examples=["mean"])
+    """The type of calculation applied."""
+
+    filter_size: Optional[float] = Field(allow_inf_nan=False, default=None)
+    """The filter size applied."""
+
+    scaling_factor: Optional[float] = Field(allow_inf_nan=False, default=None)
+    """The scaling factor applied."""
+
+    stacking_offset: Optional[str] = Field(default=None, examples=["0-15"])
+    """The stacking offset applied."""
+
+    zrange: Optional[float] = Field(allow_inf_nan=False, default=None)
+    """The z-range of these data."""
 
 
 class FluidContact(BaseModel):
     """
-    Conditional field
+    A block describing a fluid contact. Shall be present if ``data.content``
+    == ``fluid_contact``.
     """
 
-    contact: Literal["owc", "fwl", "goc", "fgl"] = Field(
-        examples=["owc", "fwl"],
-    )
+    contact: Literal["owc", "fwl", "goc", "fgl"] = Field(examples=["owc", "fwl"])
+    """A known type of contact."""
+
     truncated: bool = Field(default=False)
+    """If True, this is a representation of a contact surface which is truncated to
+    stratigraphy."""
 
     @field_validator("contact", mode="before")
     def contact_to_lowercase(cls, v: str) -> str:
@@ -95,29 +103,45 @@ class FluidContact(BaseModel):
 
 class FieldOutline(BaseModel):
     """
-    Conditional field
+    A block describing a field outline. Shall be present if ``data.content``
+    == "field_outline"
     """
 
     contact: str
+    """A known type of fluid contact used to define the field outline."""
 
 
 class FieldRegion(BaseModel):
     """
-    Conditional field
+    A block describing a field region. Shall be present if ``data.content``
+    == "field_region"
     """
 
-    id: int = Field(
-        description="The ID of the region",
-    )
+    id: int
+    """A known id of the region."""
 
 
 class Geometry(BaseModel):
+    """
+    The geometry of the object, i.e. the grid that an object representing a grid
+    property is derivative of.
+    """
+
     name: str = Field(examples=["MyGrid"])
+    """The name of the grid representing the geometry being linked to."""
+
     relative_path: str = Field(examples=["some/relative/path/mygrid.roff"])
+    """The relative path to the grid on disk."""
 
 
 class GridModel(BaseModel):
+    """A block containing information pertaining to grid model content.
+    See :class:`GridModel`.
+
+    .. warning:: This has currently no function and is likely to be deprecated."""
+
     name: str = Field(examples=["MyGrid"])
+    """A name reference to this data."""
 
 
 class Layer(BaseModel):
@@ -140,41 +164,29 @@ class Layer(BaseModel):
 class BoundingBox2D(BaseModel):
     """Contains the 2D coordinates within which a data object is contained."""
 
-    xmin: float = Field(
-        description="Minimum x-coordinate",
-        allow_inf_nan=False,
-    )
-    xmax: float = Field(
-        description="Maximum x-coordinate",
-        allow_inf_nan=False,
-    )
-    ymin: float = Field(
-        description="Minimum y-coordinate",
-        allow_inf_nan=False,
-    )
-    ymax: float = Field(
-        description="Maximum y-coordinate",
-        allow_inf_nan=False,
-    )
+    xmin: float = Field(allow_inf_nan=False)
+    """Minimum x-coordinate"""
+
+    xmax: float = Field(allow_inf_nan=False)
+    """Maximum x-coordinate"""
+
+    ymin: float = Field(allow_inf_nan=False)
+    """Minimum y-coordinate"""
+
+    ymax: float = Field(allow_inf_nan=False)
+    """Maximum y-coordinate"""
 
 
 class BoundingBox3D(BoundingBox2D):
     """Contains the 3D coordinates within which a data object is contained."""
 
-    zmin: float = Field(
-        description=(
-            "Minimum z-coordinate. For regular surfaces this field represents the "
-            "minimum surface value and it will be absent if all values are undefined."
-        ),
-        allow_inf_nan=False,
-    )
-    zmax: float = Field(
-        description=(
-            "Maximum z-coordinate. For regular surfaces this field represents the "
-            "maximum surface value and it will be absent if all values are undefined."
-        ),
-        allow_inf_nan=False,
-    )
+    zmin: float = Field(allow_inf_nan=False)
+    """Minimum z-coordinate. For regular surfaces this field represents the
+    "minimum surface value and it will be absent if all values are undefined."""
+
+    zmax: float = Field(allow_inf_nan=False)
+    """Maximum z-coordinate. For regular surfaces this field represents the
+    maximum surface value and it will be absent if all values are undefined."""
 
 
 class Data(BaseModel):
@@ -184,7 +196,7 @@ class Data(BaseModel):
     upon by the ``data.content`` field.
     """
 
-    content: enums.ContentEnum
+    content: enums.Content
     """The type of content these data represent."""
 
     name: str = Field(examples=["VIKING GP. Top"])
@@ -234,6 +246,7 @@ class Data(BaseModel):
     grid_model: Optional[GridModel] = Field(default=None)
     """A block containing information pertaining to grid model content.
     See :class:`GridModel`.
+
     .. warning:: This has currently no function and is likely to be deprecated."""
 
     is_observation: bool
@@ -260,6 +273,7 @@ class Data(BaseModel):
     """A block containing lists of objects describing timestamp information for this
     data object, if applicable, like Flow simulator restart dates, or dates for seismic
     4D surveys.  See :class:`Time`.
+
     .. note:: ``data.time`` items can currently hold a maximum of two values."""
 
     undef_is_zero: Optional[bool] = Field(default=None)
@@ -284,11 +298,13 @@ class Data(BaseModel):
     base: Optional[Layer] = None
     """If the data represent an interval, this field can be used to represent its base.
     See :class:`Layer`.
+
     .. note:: ``top`` is required to use with this."""
 
     top: Optional[Layer] = None
     """If the data represent an interval, this field can be used to represent its top.
     See :class:`Layer`.
+
     .. note:: ``base`` is required to use with this."""
 
 
@@ -298,7 +314,7 @@ class DepthData(Data):
     This class contains metadata for depth type.
     """
 
-    content: Literal[enums.ContentEnum.depth]
+    content: Literal[enums.Content.depth]
     """The type of content these data represent."""
 
     depth_reference: Literal["msl", "sb", "rkb"]
@@ -311,7 +327,7 @@ class FaciesThicknessData(Data):
     This class contains metadata for facies thickness.
     """
 
-    content: Literal[enums.ContentEnum.facies_thickness]
+    content: Literal[enums.Content.facies_thickness]
     """The type of content these data represent."""
 
 
@@ -321,7 +337,7 @@ class FaultLinesData(Data):
     This class contains metadata for fault lines.
     """
 
-    content: Literal[enums.ContentEnum.fault_lines]
+    content: Literal[enums.Content.fault_lines]
     """The type of content these data represent."""
 
 
@@ -331,7 +347,7 @@ class FaultPropertiesData(Data):
     This class contains metadata for fault properties.
     """
 
-    content: Literal[enums.ContentEnum.fault_properties]
+    content: Literal[enums.Content.fault_properties]
     """The type of content these data represent."""
 
 
@@ -341,7 +357,7 @@ class FieldOutlineData(Data):
     This class contains metadata for field outlines.
     """
 
-    content: Literal[enums.ContentEnum.field_outline]
+    content: Literal[enums.Content.field_outline]
     """The type of content these data represent."""
 
     field_outline: FieldOutline
@@ -354,7 +370,7 @@ class FieldRegionData(Data):
     This class contains metadata for field regions.
     """
 
-    content: Literal[enums.ContentEnum.field_region]
+    content: Literal[enums.Content.field_region]
     """The type of content these data represent."""
 
     field_region: FieldRegion
@@ -367,7 +383,7 @@ class FluidContactData(Data):
     This class contains metadata for fluid contacts.
     """
 
-    content: Literal[enums.ContentEnum.fluid_contact]
+    content: Literal[enums.Content.fluid_contact]
     """The type of content these data represent."""
 
     fluid_contact: FluidContact
@@ -380,7 +396,7 @@ class KPProductData(Data):
     This class contains metadata for KP products.
     """
 
-    content: Literal[enums.ContentEnum.khproduct]
+    content: Literal[enums.Content.khproduct]
     """The type of content these data represent."""
 
 
@@ -390,7 +406,7 @@ class LiftCurvesData(Data):
     This class contains metadata for lift curves.
     """
 
-    content: Literal[enums.ContentEnum.lift_curves]
+    content: Literal[enums.Content.lift_curves]
     """The type of content these data represent."""
 
 
@@ -400,7 +416,7 @@ class NamedAreaData(Data):
     This class contains metadata for named areas.
     """
 
-    content: Literal[enums.ContentEnum.named_area]
+    content: Literal[enums.Content.named_area]
     """The type of content these data represent."""
 
 
@@ -410,7 +426,7 @@ class ParametersData(Data):
     This class contains metadata for parameters.
     """
 
-    content: Literal[enums.ContentEnum.parameters]
+    content: Literal[enums.Content.parameters]
     """The type of content these data represent."""
 
 
@@ -420,7 +436,7 @@ class PinchoutData(Data):
     This class contains metadata for pinchouts.
     """
 
-    content: Literal[enums.ContentEnum.pinchout]
+    content: Literal[enums.Content.pinchout]
     """The type of content these data represent."""
 
 
@@ -430,7 +446,7 @@ class PropertyData(Data):
     This class contains metadata for property data.
     """
 
-    content: Literal[enums.ContentEnum.property]
+    content: Literal[enums.Content.property]
     """The type of content these data represent."""
 
 
@@ -440,7 +456,7 @@ class PVTData(Data):
     This class contains metadata for pvt data.
     """
 
-    content: Literal[enums.ContentEnum.pvt]
+    content: Literal[enums.Content.pvt]
     """The type of content these data represent."""
 
 
@@ -450,7 +466,7 @@ class RegionsData(Data):
     This class contains metadata for regions.
     """
 
-    content: Literal[enums.ContentEnum.regions]
+    content: Literal[enums.Content.regions]
     """The type of content these data represent."""
 
 
@@ -460,7 +476,7 @@ class RelpermData(Data):
     This class contains metadata for relperm.
     """
 
-    content: Literal[enums.ContentEnum.relperm]
+    content: Literal[enums.Content.relperm]
     """The type of content these data represent."""
 
 
@@ -470,7 +486,7 @@ class RFTData(Data):
     This class contains metadata for rft data.
     """
 
-    content: Literal[enums.ContentEnum.rft]
+    content: Literal[enums.Content.rft]
     """The type of content these data represent."""
 
 
@@ -480,7 +496,7 @@ class SeismicData(Data):
     This class contains metadata for seismics.
     """
 
-    content: Literal[enums.ContentEnum.seismic]
+    content: Literal[enums.Content.seismic]
     """The type of content these data represent."""
 
     seismic: Seismic
@@ -493,7 +509,7 @@ class SubcropData(Data):
     This class contains metadata for subcrops.
     """
 
-    content: Literal[enums.ContentEnum.subcrop]
+    content: Literal[enums.Content.subcrop]
     """The type of content these data represent."""
 
 
@@ -503,7 +519,7 @@ class ThicknessData(Data):
     This class contains metadata for thickness.
     """
 
-    content: Literal[enums.ContentEnum.thickness]
+    content: Literal[enums.Content.thickness]
     """The type of content these data represent."""
 
 
@@ -513,7 +529,7 @@ class TimeData(Data):
     This class contains metadata for time.
     """
 
-    content: Literal[enums.ContentEnum.time]
+    content: Literal[enums.Content.time]
     """The type of content these data represent."""
 
 
@@ -523,7 +539,7 @@ class TimeSeriesData(Data):
     This class contains metadata for time series.
     """
 
-    content: Literal[enums.ContentEnum.timeseries]
+    content: Literal[enums.Content.timeseries]
     """The type of content these data represent."""
 
 
@@ -533,7 +549,7 @@ class TransmissibilitiesData(Data):
     This class contains metadata for transmissibilities.
     """
 
-    content: Literal[enums.ContentEnum.transmissibilities]
+    content: Literal[enums.Content.transmissibilities]
     """The type of content these data represent."""
 
 
@@ -543,7 +559,7 @@ class VelocityData(Data):
     This class contains metadata for velocities.
     """
 
-    content: Literal[enums.ContentEnum.velocity]
+    content: Literal[enums.Content.velocity]
     """The type of content these data represent."""
 
 
@@ -553,7 +569,7 @@ class VolumesData(Data):
     This class contains metadata for volumes.
     """
 
-    content: Literal[enums.ContentEnum.volumes]
+    content: Literal[enums.Content.volumes]
     """The type of content these data represent."""
 
 
@@ -563,7 +579,7 @@ class WellPicksData(Data):
     This class contains metadata for well picks.
     """
 
-    content: Literal[enums.ContentEnum.wellpicks]
+    content: Literal[enums.Content.wellpicks]
     """The type of content these data represent."""
 
 

--- a/src/fmu/dataio/datastructure/meta/enums.py
+++ b/src/fmu/dataio/datastructure/meta/enums.py
@@ -5,17 +5,23 @@ from typing import Type
 
 
 class Classification(str, Enum):
+    """The security classification for a given data object."""
+
     asset = "asset"
     internal = "internal"
     restricted = "restricted"
 
 
 class AxisOrientation(IntEnum):
+    """The axis orientation for a given data object."""
+
     normal = 1
     flipped = -1
 
 
-class ContentEnum(str, Enum):
+class Content(str, Enum):
+    """The content type of a given data object."""
+
     depth = "depth"
     facies_thickness = "facies_thickness"
     fault_lines = "fault_lines"
@@ -44,13 +50,15 @@ class ContentEnum(str, Enum):
     wellpicks = "wellpicks"
 
     @classmethod
-    def _missing_(cls: Type[ContentEnum], value: object) -> None:
+    def _missing_(cls: Type[Content], value: object) -> None:
         raise ValueError(
             f"Invalid 'content' {value=}. Valid entries are {[m.value for m in cls]}"
         )
 
 
-class FMUClassEnum(str, Enum):
+class FMUClass(str, Enum):
+    """The class of a data object by FMU convention or standards."""
+
     case = "case"
     surface = "surface"
     table = "table"
@@ -64,6 +72,8 @@ class FMUClassEnum(str, Enum):
 
 
 class Layout(str, Enum):
+    """The layout of a given data object."""
+
     regular = "regular"
     unset = "unset"
     cornerpoint = "cornerpoint"
@@ -72,7 +82,9 @@ class Layout(str, Enum):
     faultroom_triangulated = "faultroom_triangulated"
 
 
-class FmuContext(str, Enum):
+class FMUContext(str, Enum):
+    """The context in which FMU was being run when data were generated."""
+
     case = "case"
     iteration = "iteration"
     realization = "realization"

--- a/src/fmu/dataio/datastructure/meta/meta.py
+++ b/src/fmu/dataio/datastructure/meta/meta.py
@@ -454,9 +454,9 @@ class Context(BaseModel):
     was produced.
     """
 
-    stage: enums.FmuContext
+    stage: enums.FMUContext
     """The stage of an FMU experiment in which this data was produced.
-    See :class:`enums.FmuContext`."""
+    See :class:`enums.FMUContext`."""
 
 
 class FMUCaseAttributes(BaseModel):
@@ -535,7 +535,7 @@ class FMUAttributes(FMUCaseAttributes):
 class MetadataBase(BaseModel):
     """Base model for all root metadata models generated."""
 
-    class_: enums.FMUClassEnum = Field(
+    class_: enums.FMUClass = Field(
         alias="class",
         title="metadata_class",
     )
@@ -563,7 +563,7 @@ class CaseMetadata(MetadataBase):
     corresponding to /scratch/<asset>/<user>/<my case name>/.
     """
 
-    class_: Literal[enums.FMUClassEnum.case] = Field(
+    class_: Literal[enums.FMUClass.case] = Field(
         alias="class",
         title="metadata_class",
     )
@@ -582,15 +582,15 @@ class ObjectMetadata(MetadataBase):
     """The FMU metadata model for a given data object."""
 
     class_: Literal[
-        enums.FMUClassEnum.surface,
-        enums.FMUClassEnum.table,
-        enums.FMUClassEnum.cpgrid,
-        enums.FMUClassEnum.cpgrid_property,
-        enums.FMUClassEnum.polygons,
-        enums.FMUClassEnum.cube,
-        enums.FMUClassEnum.well,
-        enums.FMUClassEnum.points,
-        enums.FMUClassEnum.dictionary,
+        enums.FMUClass.surface,
+        enums.FMUClass.table,
+        enums.FMUClass.cpgrid,
+        enums.FMUClass.cpgrid_property,
+        enums.FMUClass.polygons,
+        enums.FMUClass.cube,
+        enums.FMUClass.well,
+        enums.FMUClass.points,
+        enums.FMUClass.dictionary,
     ] = Field(
         alias="class",
         title="metadata_class",
@@ -633,7 +633,7 @@ class Root(
     @model_validator(mode="after")
     def _check_class_data_spec(self) -> Root:
         if (
-            self.root.class_ in (enums.FMUClassEnum.table, enums.FMUClassEnum.surface)
+            self.root.class_ in (enums.FMUClass.table, enums.FMUClass.surface)
             and hasattr(self.root, "data")
             and self.root.data.root.spec is None
         ):

--- a/src/fmu/dataio/datastructure/meta/specification.py
+++ b/src/fmu/dataio/datastructure/meta/specification.py
@@ -10,107 +10,85 @@ from . import enums
 class RowColumn(BaseModel):
     """Specifies the number of rows and columns in a regular surface object."""
 
-    nrow: int = Field(
-        description="The number of rows",
-    )
-    ncol: int = Field(
-        description="The number of columns",
-    )
+    nrow: int
+    """The number of rows."""
+
+    ncol: int
+    """The number of columns."""
 
 
 class RowColumnLayer(RowColumn):
     """Specifies the number of rows, columns, and layers in grid object."""
 
-    nlay: int = Field(
-        description="The number of layers",
-    )
+    nlay: int
+    """The number of layers."""
 
 
 class SurfaceSpecification(RowColumn):
     """Specifies relevant values describing a regular surface object."""
 
-    rotation: float = Field(
-        description="Rotation angle",
-        allow_inf_nan=False,
-    )
-    undef: float = Field(
-        description="Value representing undefined data",
-        allow_inf_nan=False,
-    )
-    xinc: float = Field(
-        description="Increment along the x-axis",
-        allow_inf_nan=False,
-    )
-    # ok to add yinc?
-    yinc: float = Field(
-        description="Increment along the y-axis",
-        allow_inf_nan=False,
-    )
-    xori: float = Field(
-        description="Origin along the x-axis",
-        allow_inf_nan=False,
-    )
-    yflip: enums.AxisOrientation = Field(
-        description="Flip along the y-axis, -1 or 1",
-    )
-    yori: float = Field(
-        description="Origin along the y-axis",
-        allow_inf_nan=False,
-    )
+    rotation: float = Field(allow_inf_nan=False)
+    """Rotation angle in degrees."""
+
+    undef: float = Field(allow_inf_nan=False)
+    """Value representing undefined data."""
+
+    xinc: float = Field(allow_inf_nan=False)
+    """Increment along the x-axis."""
+
+    yinc: float = Field(allow_inf_nan=False)
+    """Increment along the y-axis."""
+
+    xori: float = Field(allow_inf_nan=False)
+    """Origin along the x-axis."""
+
+    yflip: enums.AxisOrientation
+    """Flip along the y-axis, -1 or 1."""
+
+    yori: float = Field(allow_inf_nan=False)
+    """Origin along the y-axis."""
 
 
 class PointSpecification(BaseModel):
     """Specifies relevant values describing an xyz points object."""
 
-    attributes: Optional[List[str]] = Field(
-        description="List of columns present in a table.",
-    )
-    size: int = Field(
-        description="Size of data object.",
-        examples=[1, 9999],
-    )
+    attributes: Optional[List[str]]
+    """List of columns present in a table."""
+
+    size: int = Field(examples=[1, 9999])
+    """Size of data object."""
 
 
 class TableSpecification(BaseModel):
     """Specifies relevant values describing a generic tabular data object."""
 
-    columns: List[str] = Field(
-        description="List of columns present in a table.",
-    )
-    size: int = Field(
-        description="Size of data object.",
-        examples=[1, 9999],
-    )
+    columns: List[str]
+    """List of columns present in a table."""
+
+    size: int = Field(examples=[1, 9999])
+    """Size of data object."""
 
 
 class CPGridSpecification(RowColumnLayer):
     """Specifies relevant values describing a corner point grid object."""
 
-    xshift: float = Field(
-        description="Shift along the x-axis",
-        allow_inf_nan=False,
-    )
-    yshift: float = Field(
-        description="Shift along the y-axis",
-        allow_inf_nan=False,
-    )
-    zshift: float = Field(
-        description="Shift along the z-axis",
-        allow_inf_nan=False,
-    )
+    xshift: float = Field(allow_inf_nan=False)
+    """Shift along the x-axis."""
 
-    xscale: float = Field(
-        description="Scaling factor for the x-axis",
-        allow_inf_nan=False,
-    )
-    yscale: float = Field(
-        description="Scaling factor for the y-axis",
-        allow_inf_nan=False,
-    )
-    zscale: float = Field(
-        description="Scaling factor for the z-axis",
-        allow_inf_nan=False,
-    )
+    yshift: float = Field(allow_inf_nan=False)
+    """Shift along the y-axis."""
+
+    zshift: float = Field(allow_inf_nan=False)
+    """Shift along the z-axis."""
+
+    xscale: float = Field(allow_inf_nan=False)
+    """Scaling factor for the x-axis."""
+
+    yscale: float = Field(allow_inf_nan=False)
+    """Scaling factor for the y-axis."""
+
+    zscale: float = Field(allow_inf_nan=False)
+    """Scaling factor for the z-axis."""
 
 
 class CPGridPropertySpecification(RowColumnLayer):
@@ -120,83 +98,67 @@ class CPGridPropertySpecification(RowColumnLayer):
 class PolygonsSpecification(BaseModel):
     """Specifies relevant values describing a polygon object."""
 
-    npolys: int = Field(
-        description="The number of individual polygons in the data object",
-    )
+    npolys: int
+    """The number of individual polygons in the data object."""
 
 
 class FaultRoomSurfaceSpecification(BaseModel):
     """Specifies relevant values describing a Faultroom surface object."""
 
-    horizons: List[str] = Field(
-        description="List of horizon names",
-    )
-    faults: List[str] = Field(
-        description="Names of faults",
-    )
-    juxtaposition_hw: List[str] = Field(
-        description="List of zones included in hangingwall juxtaposition",
-    )
-    juxtaposition_fw: List[str] = Field(
-        description="List of zones included in footwall juxtaposition",
-    )
-    properties: List[str] = Field(
-        description="List of properties along fault plane",
-    )
-    name: str = Field(
-        description="A name id of the faultroom usage",
-    )
+    horizons: List[str]
+    """List of horizon names."""
+
+    faults: List[str]
+    """Names of faults."""
+
+    juxtaposition_hw: List[str]
+    """List of zones included in hangingwall juxtaposition."""
+
+    juxtaposition_fw: List[str]
+    """List of zones included in footwall juxtaposition."""
+
+    properties: List[str]
+    """List of properties along fault plane."""
+
+    name: str
+    """A name id of the faultroom usage."""
 
 
 class CubeSpecification(SurfaceSpecification):
     """Specifies relevant values describing a cube object, i.e. a seismic cube."""
 
-    nlay: int = Field(
-        description="The number of layers",
-    )
+    nlay: int
+    """The number of layers."""
 
-    # Increment
-    xinc: float = Field(
-        description="Increment along the x-axis",
-        allow_inf_nan=False,
-    )
-    yinc: float = Field(
-        description="Increment along the y-axis",
-        allow_inf_nan=False,
-    )
-    zinc: float = Field(
-        description="Increment along the z-axis",
-        allow_inf_nan=False,
-    )
+    xinc: float = Field(allow_inf_nan=False)
+    """Increment along the x-axis."""
 
-    # Origin
-    xori: float = Field(
-        description="Origin along the x-axis",
-        allow_inf_nan=False,
-    )
-    yori: float = Field(
-        description="Origin along the y-axis",
-        allow_inf_nan=False,
-    )
-    zori: float = Field(
-        description="Origin along the z-axis",
-        allow_inf_nan=False,
-    )
+    yinc: float = Field(allow_inf_nan=False)
+    """Increment along the y-axis."""
 
-    # Miscellaneous
-    yflip: enums.AxisOrientation = Field(
-        description="Flip along the y-axis, -1 or 1",
-    )
-    zflip: enums.AxisOrientation = Field(
-        description="Flip along the z-axis, -1 or 1",
-    )
-    rotation: float = Field(
-        description="Rotation angle",
-        allow_inf_nan=False,
-    )
-    undef: float = Field(
-        description="Value representing undefined data",
-    )
+    zinc: float = Field(allow_inf_nan=False)
+    """Increment along the z-axis."""
+
+    xori: float = Field(allow_inf_nan=False)
+    """Origin along the x-axis."""
+
+    yori: float = Field(allow_inf_nan=False)
+    """Origin along the y-axis."""
+
+    zori: float = Field(allow_inf_nan=False)
+    """Origin along the z-axis."""
+
+    yflip: enums.AxisOrientation
+    """Flip along the y-axis, -1 or 1."""
+
+    zflip: enums.AxisOrientation
+    """Flip along the z-axis, -1 or 1."""
+
+    rotation: float = Field(allow_inf_nan=False)
+    """Rotation angle in degrees."""
+
+    undef: float
+    """Value representing undefined data."""
 
 
 AnySpecification = Union[

--- a/src/fmu/dataio/preprocessed.py
+++ b/src/fmu/dataio/preprocessed.py
@@ -14,7 +14,7 @@ from ._metadata import generate_meta_tracklog
 from ._utils import export_metadata_file, md5sum
 from .datastructure._internal import internal
 from .datastructure.meta import meta
-from .datastructure.meta.enums import FmuContext
+from .datastructure.meta.enums import FMUContext
 from .exceptions import InvalidMetadataError
 from .providers._filedata import ShareFolder
 from .providers._fmu import (
@@ -61,14 +61,14 @@ class ExportPreprocessedData:
     _fmudata: FmuProvider | None = field(default=None)
 
     def __post_init__(self) -> None:
-        if get_fmu_context_from_environment() != FmuContext.case:
+        if get_fmu_context_from_environment() != FMUContext.case:
             raise RuntimeError(
                 "Only possible to run re-export of preprocessed data inside FMU "
                 "using a pre-simulation workflow in ERT."
             )
 
         self._fmudata = FmuProvider(
-            fmu_context=FmuContext.case,
+            fmu_context=FMUContext.case,
             casepath_proposed=Path(self.casepath),
             workflow=None,
         )

--- a/src/fmu/dataio/providers/_filedata.py
+++ b/src/fmu/dataio/providers/_filedata.py
@@ -76,7 +76,7 @@ class FileDataProvider(Provider):
         rootpath = (
             self.runpath
             if self.runpath
-            and self.dataio.fmu_context == meta.enums.FmuContext.realization
+            and self.dataio.fmu_context == meta.enums.FMUContext.realization
             else self.dataio._rootpath
         )
         share_folders = self._get_share_folders()

--- a/src/fmu/dataio/providers/_fmu.py
+++ b/src/fmu/dataio/providers/_fmu.py
@@ -40,7 +40,7 @@ from fmu.dataio import _utils
 from fmu.dataio._logging import null_logger
 from fmu.dataio.datastructure._internal import internal
 from fmu.dataio.datastructure.meta import meta
-from fmu.dataio.datastructure.meta.enums import FmuContext
+from fmu.dataio.datastructure.meta.enums import FMUContext
 from fmu.dataio.exceptions import InvalidMetadataError
 
 from ._base import Provider
@@ -55,12 +55,12 @@ RESTART_PATH_ENVNAME: Final = "RESTART_FROM_PATH"
 logger: Final = null_logger(__name__)
 
 
-def get_fmu_context_from_environment() -> FmuContext | None:
-    """return the ERT run context as an FmuContext"""
+def get_fmu_context_from_environment() -> FMUContext | None:
+    """return the ERT run context as an FMUContext"""
     if FmuEnv.RUNPATH.value:
-        return FmuContext.realization
+        return FMUContext.realization
     if FmuEnv.EXPERIMENT_ID.value:
-        return FmuContext.case
+        return FMUContext.case
     return None
 
 
@@ -98,13 +98,13 @@ class FmuProvider(Provider):
 
     Args:
         model: Name of the model (usually from global config)
-        fmu_context: The FMU context this is ran in; see FmuContext enum class
-        casepath_proposed: Proposed casepath. Needed if FmuContext is CASE
+        fmu_context: The FMU context this is ran in; see FMUContext enum class
+        casepath_proposed: Proposed casepath. Needed if FMUContext is CASE
         workflow: Descriptive work flow info
     """
 
     model: dict | None = None
-    fmu_context: FmuContext = FmuContext.realization
+    fmu_context: FMUContext = FMUContext.realization
     casepath_proposed: Optional[Path] = None
     workflow: Optional[Union[str, dict[str, str]]] = None
 
@@ -135,7 +135,7 @@ class FmuProvider(Provider):
         if self._casepath:
             self._case_name = self._casepath.name
 
-            if self._runpath and self.fmu_context != FmuContext.case:
+            if self._runpath and self.fmu_context != FMUContext.case:
                 missing_iter_folder = self._casepath == self._runpath.parent
                 if not missing_iter_folder:
                     logger.debug("Iteration folder found")
@@ -174,7 +174,7 @@ class FmuProvider(Provider):
 
         case_meta = self._get_case_meta()
 
-        if self.fmu_context != FmuContext.realization:
+        if self.fmu_context != FMUContext.realization:
             return internal.FMUClassMetaData(
                 case=case_meta.fmu.case,
                 context=self._get_fmucontext_meta(),
@@ -220,7 +220,7 @@ class FmuProvider(Provider):
             if _casepath_has_metadata(self._runpath.parent):
                 return self._runpath.parent
 
-        if self.fmu_context == FmuContext.case:
+        if self.fmu_context == FMUContext.case:
             # TODO: Change to ValueError when no longer kwargs are accepted in export()
             warn("Could not auto detect the casepath, please provide it as input.")
 

--- a/src/fmu/dataio/providers/objectdata/_base.py
+++ b/src/fmu/dataio/providers/objectdata/_base.py
@@ -16,7 +16,7 @@ from fmu.dataio.datastructure.meta.content import (
     Time,
     Timestamp,
 )
-from fmu.dataio.datastructure.meta.enums import ContentEnum
+from fmu.dataio.datastructure.meta.enums import Content
 from fmu.dataio.providers._base import Provider
 
 if TYPE_CHECKING:
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
         BoundingBox3D,
         Geometry,
     )
-    from fmu.dataio.datastructure.meta.enums import FMUClassEnum, Layout
+    from fmu.dataio.datastructure.meta.enums import FMUClass, Layout
     from fmu.dataio.datastructure.meta.specification import AnySpecification
     from fmu.dataio.types import Inferrable
 
@@ -126,7 +126,7 @@ class ObjectDataProvider(Provider):
 
     @property
     @abstractmethod
-    def classname(self) -> FMUClassEnum:
+    def classname(self) -> FMUClass:
         raise NotImplementedError
 
     @property
@@ -179,7 +179,7 @@ class ObjectDataProvider(Provider):
             return AllowedContent(content="unset")
 
         if isinstance(content, str):
-            return AllowedContent(content=ContentEnum(content))
+            return AllowedContent(content=Content(content))
 
         if len(content) > 1:
             raise ValueError(
@@ -192,7 +192,7 @@ class ObjectDataProvider(Provider):
         logger.debug("content_specific is %s", content_specific)
 
         return AllowedContent.model_validate(
-            {"content": ContentEnum(usecontent), "content_incl_specific": content}
+            {"content": Content(usecontent), "content_incl_specific": content}
         )
 
     def _get_named_stratigraphy(self) -> NamedStratigraphy:

--- a/src/fmu/dataio/providers/objectdata/_faultroom.py
+++ b/src/fmu/dataio/providers/objectdata/_faultroom.py
@@ -6,7 +6,7 @@ from typing import Final
 from fmu.dataio._definitions import ExportFolder, ValidFormats
 from fmu.dataio._logging import null_logger
 from fmu.dataio.datastructure.meta.content import BoundingBox3D
-from fmu.dataio.datastructure.meta.enums import FMUClassEnum, Layout
+from fmu.dataio.datastructure.meta.enums import FMUClass, Layout
 from fmu.dataio.datastructure.meta.specification import FaultRoomSurfaceSpecification
 from fmu.dataio.readers import FaultRoomSurface
 
@@ -22,8 +22,8 @@ class FaultRoomSurfaceProvider(ObjectDataProvider):
     obj: FaultRoomSurface
 
     @property
-    def classname(self) -> FMUClassEnum:
-        return FMUClassEnum.surface
+    def classname(self) -> FMUClass:
+        return FMUClass.surface
 
     @property
     def efolder(self) -> str:

--- a/src/fmu/dataio/providers/objectdata/_provider.py
+++ b/src/fmu/dataio/providers/objectdata/_provider.py
@@ -94,7 +94,7 @@ import xtgeo
 
 from fmu.dataio._definitions import ExportFolder, ValidFormats
 from fmu.dataio._logging import null_logger
-from fmu.dataio.datastructure.meta.enums import FMUClassEnum, Layout
+from fmu.dataio.datastructure.meta.enums import FMUClass, Layout
 from fmu.dataio.readers import FaultRoomSurface
 
 from ._base import (
@@ -164,8 +164,8 @@ class DictionaryDataProvider(ObjectDataProvider):
     obj: dict
 
     @property
-    def classname(self) -> FMUClassEnum:
-        return FMUClassEnum.dictionary
+    def classname(self) -> FMUClass:
+        return FMUClass.dictionary
 
     @property
     def efolder(self) -> str:

--- a/src/fmu/dataio/providers/objectdata/_tables.py
+++ b/src/fmu/dataio/providers/objectdata/_tables.py
@@ -11,7 +11,7 @@ from fmu.dataio._definitions import (
     ValidFormats,
 )
 from fmu.dataio._logging import null_logger
-from fmu.dataio.datastructure.meta.enums import FMUClassEnum, Layout
+from fmu.dataio.datastructure.meta.enums import FMUClass, Layout
 from fmu.dataio.datastructure.meta.specification import TableSpecification
 
 from ._base import (
@@ -64,8 +64,8 @@ class DataFrameDataProvider(ObjectDataProvider):
     obj: pd.DataFrame
 
     @property
-    def classname(self) -> FMUClassEnum:
-        return FMUClassEnum.table
+    def classname(self) -> FMUClass:
+        return FMUClass.table
 
     @property
     def efolder(self) -> str:
@@ -108,8 +108,8 @@ class ArrowTableDataProvider(ObjectDataProvider):
     obj: pyarrow.Table
 
     @property
-    def classname(self) -> FMUClassEnum:
-        return FMUClassEnum.table
+    def classname(self) -> FMUClass:
+        return FMUClass.table
 
     @property
     def efolder(self) -> str:

--- a/src/fmu/dataio/providers/objectdata/_xtgeo.py
+++ b/src/fmu/dataio/providers/objectdata/_xtgeo.py
@@ -13,7 +13,7 @@ from fmu.dataio._definitions import ExportFolder, ValidFormats
 from fmu.dataio._logging import null_logger
 from fmu.dataio._utils import get_geometry_ref, npfloat_to_float
 from fmu.dataio.datastructure.meta.content import BoundingBox2D, BoundingBox3D, Geometry
-from fmu.dataio.datastructure.meta.enums import FMUClassEnum, Layout
+from fmu.dataio.datastructure.meta.enums import FMUClass, Layout
 from fmu.dataio.datastructure.meta.specification import (
     CPGridPropertySpecification,
     CPGridSpecification,
@@ -51,8 +51,8 @@ class RegularSurfaceDataProvider(ObjectDataProvider):
     obj: xtgeo.RegularSurface
 
     @property
-    def classname(self) -> FMUClassEnum:
-        return FMUClassEnum.surface
+    def classname(self) -> FMUClass:
+        return FMUClass.surface
 
     @property
     def efolder(self) -> str:
@@ -125,8 +125,8 @@ class PolygonsDataProvider(ObjectDataProvider):
     obj: xtgeo.Polygons
 
     @property
-    def classname(self) -> FMUClassEnum:
-        return FMUClassEnum.polygons
+    def classname(self) -> FMUClass:
+        return FMUClass.polygons
 
     @property
     def efolder(self) -> str:
@@ -181,8 +181,8 @@ class PointsDataProvider(ObjectDataProvider):
     obj: xtgeo.Points
 
     @property
-    def classname(self) -> FMUClassEnum:
-        return FMUClassEnum.points
+    def classname(self) -> FMUClass:
+        return FMUClass.points
 
     @property
     def efolder(self) -> str:
@@ -242,8 +242,8 @@ class CubeDataProvider(ObjectDataProvider):
     obj: xtgeo.Cube
 
     @property
-    def classname(self) -> FMUClassEnum:
-        return FMUClassEnum.cube
+    def classname(self) -> FMUClass:
+        return FMUClass.cube
 
     @property
     def efolder(self) -> str:
@@ -325,8 +325,8 @@ class CPGridDataProvider(ObjectDataProvider):
     obj: xtgeo.Grid
 
     @property
-    def classname(self) -> FMUClassEnum:
-        return FMUClassEnum.cpgrid
+    def classname(self) -> FMUClass:
+        return FMUClass.cpgrid
 
     @property
     def efolder(self) -> str:
@@ -392,8 +392,8 @@ class CPGridPropertyDataProvider(ObjectDataProvider):
     obj: xtgeo.GridProperty
 
     @property
-    def classname(self) -> FMUClassEnum:
-        return FMUClassEnum.cpgrid_property
+    def classname(self) -> FMUClass:
+        return FMUClass.cpgrid_property
 
     @property
     def efolder(self) -> str:

--- a/tests/test_units/test_dataio.py
+++ b/tests/test_units/test_dataio.py
@@ -12,7 +12,7 @@ import pytest
 import yaml
 from fmu.dataio._utils import prettyprint_dict
 from fmu.dataio.dataio import ExportData, read_metadata
-from fmu.dataio.datastructure.meta.enums import FmuContext
+from fmu.dataio.datastructure.meta.enums import FMUContext
 from fmu.dataio.providers._fmu import FmuEnv
 
 # pylint: disable=no-member
@@ -596,7 +596,7 @@ def test_fmu_context_not_given_fetch_from_env_realization(
 
     edata = ExportData(config=rmsglobalconfig, content="depth")
     assert edata._fmurun is True
-    assert edata.fmu_context == FmuContext.realization
+    assert edata.fmu_context == FMUContext.realization
 
 
 def test_fmu_context_not_given_fetch_from_env_case(
@@ -616,7 +616,7 @@ def test_fmu_context_not_given_fetch_from_env_case(
     # test that it runs properly when casepath is provided
     edata = ExportData(config=rmsglobalconfig, content="depth", casepath=fmurun_prehook)
     assert edata._fmurun is True
-    assert edata.fmu_context == FmuContext.case
+    assert edata.fmu_context == FMUContext.case
     assert edata._rootpath == fmurun_prehook
 
 
@@ -689,7 +689,7 @@ def test_fmu_context_preprocessed_deprecation_inside_fmu(
             casepath=fmurun_prehook,
         )
     assert edata.preprocessed is True
-    assert edata.fmu_context == FmuContext.case
+    assert edata.fmu_context == FMUContext.case
 
     meta = edata.generate_metadata(regsurf)
     assert meta["file"]["relative_path"] == "share/preprocessed/maps/unknown.gri"
@@ -727,7 +727,7 @@ def test_preprocessed_inside_fmu(fmurun_w_casemetadata, rmsglobalconfig, regsurf
     )
     assert edata._fmurun is True
     assert edata.preprocessed is True
-    assert edata.fmu_context == FmuContext.case
+    assert edata.fmu_context == FMUContext.case
 
     meta = edata.generate_metadata(regsurf)
     # check that the relative file is at case level and has a preprocessed folder

--- a/tests/test_units/test_fmuprovider_class.py
+++ b/tests/test_units/test_fmuprovider_class.py
@@ -8,7 +8,7 @@ import pydantic
 import pytest
 
 # from conftest import pretend_ert_env_run1
-from fmu.dataio.datastructure.meta.enums import FmuContext
+from fmu.dataio.datastructure.meta.enums import FMUContext
 from fmu.dataio.exceptions import InvalidMetadataError
 from fmu.dataio.providers._fmu import RESTART_PATH_ENVNAME, FmuEnv, FmuProvider
 
@@ -23,7 +23,7 @@ def test_fmuprovider_no_provider():
 
     myfmu = FmuProvider(
         model=GLOBAL_CONFIG_MODEL,
-        fmu_context=FmuContext.realization,
+        fmu_context=FMUContext.realization,
         casepath_proposed="",
         workflow=WORKFLOW,
     )
@@ -36,7 +36,7 @@ def test_fmuprovider_model_info_in_metadata(fmurun_w_casemetadata):
 
     myfmu = FmuProvider(
         model=GLOBAL_CONFIG_MODEL,
-        fmu_context=FmuContext.realization,
+        fmu_context=FMUContext.realization,
         workflow=WORKFLOW,
     )
     meta = myfmu.get_metadata()
@@ -49,7 +49,7 @@ def test_fmuprovider_no_model_info_use_case(fmurun_w_casemetadata):
 
     myfmu = FmuProvider(
         model=None,
-        fmu_context=FmuContext.realization,
+        fmu_context=FMUContext.realization,
         workflow=WORKFLOW,
     )
 
@@ -68,7 +68,7 @@ def test_fmuprovider_ert_provider_guess_casemeta_path(fmurun):
     with pytest.warns(UserWarning, match="Case metadata does not exist"):
         myfmu = FmuProvider(
             model=GLOBAL_CONFIG_MODEL,
-            fmu_context=FmuContext.realization,
+            fmu_context=FMUContext.realization,
             casepath_proposed="",  # if casepath is undef, try deduce from, _ERT_RUNPATH
             workflow=WORKFLOW,
         )
@@ -87,7 +87,7 @@ def test_fmuprovider_ert_provider_missing_parameter_txt(fmurun_w_casemetadata):
     (fmurun_w_casemetadata / "parameters.txt").unlink()
     myfmu = FmuProvider(
         model=GLOBAL_CONFIG_MODEL,
-        fmu_context=FmuContext.realization,
+        fmu_context=FMUContext.realization,
         workflow=WORKFLOW,
     )
     with pytest.warns(UserWarning, match="parameters.txt file was not found"):
@@ -104,7 +104,7 @@ def test_fmuprovider_arbitrary_iter_name(fmurun_w_casemetadata_pred):
     os.chdir(fmurun_w_casemetadata_pred)
     myfmu = FmuProvider(
         model=GLOBAL_CONFIG_MODEL,
-        fmu_context=FmuContext.realization,
+        fmu_context=FMUContext.realization,
         workflow=WORKFLOW,
     )
     assert myfmu._case_name == "ertrun1"
@@ -123,7 +123,7 @@ def test_fmuprovider_get_real_and_iter_from_env(fmurun_non_equal_real_and_iter):
     os.chdir(fmurun_non_equal_real_and_iter)
     myfmu = FmuProvider(
         model=GLOBAL_CONFIG_MODEL,
-        fmu_context=FmuContext.realization,
+        fmu_context=FMUContext.realization,
         workflow=WORKFLOW,
     )
     assert myfmu._runpath == fmurun_non_equal_real_and_iter
@@ -139,7 +139,7 @@ def test_fmuprovider_no_iter_folder(fmurun_no_iter_folder):
 
     os.chdir(fmurun_no_iter_folder)
     myfmu = FmuProvider(
-        model=GLOBAL_CONFIG_MODEL, fmu_context=FmuContext.realization, workflow=WORKFLOW
+        model=GLOBAL_CONFIG_MODEL, fmu_context=FMUContext.realization, workflow=WORKFLOW
     )
     assert myfmu._runpath == fmurun_no_iter_folder
     assert myfmu._casepath == fmurun_no_iter_folder.parent
@@ -190,7 +190,7 @@ def test_fmuprovider_prehook_case(tmp_path, globalconfig2, fmurun_prehook):
     logger.debug("Case root proposed is: %s", caseroot)
     myfmu = FmuProvider(
         model=GLOBAL_CONFIG_MODEL,
-        fmu_context=FmuContext.case,
+        fmu_context=FMUContext.case,
         workflow=WORKFLOW,
         casepath_proposed=caseroot,
     )
@@ -209,7 +209,7 @@ def test_fmuprovider_detect_no_case_metadata(fmurun):
     with pytest.warns(UserWarning, match="Case metadata does not exist"):
         myfmu = FmuProvider(
             model=GLOBAL_CONFIG_MODEL,
-            fmu_context=FmuContext.realization,
+            fmu_context=FMUContext.realization,
         )
     with pytest.raises(InvalidMetadataError, match="Missing casepath"):
         myfmu.get_metadata()
@@ -230,13 +230,13 @@ def test_fmuprovider_case_run(fmurun_prehook):
     with pytest.warns(UserWarning, match="Could not auto detect the casepath"):
         FmuProvider(
             model=GLOBAL_CONFIG_MODEL,
-            fmu_context=FmuContext.case,
+            fmu_context=FMUContext.case,
         )
 
     # providing the casepath is the solution, and no error is thrown
     myfmu = FmuProvider(
         model=GLOBAL_CONFIG_MODEL,
-        fmu_context=FmuContext.case,
+        fmu_context=FMUContext.case,
         casepath_proposed=fmurun_prehook,
     )
     meta = myfmu.get_metadata()
@@ -251,7 +251,7 @@ def test_fmuprovider_valid_restart_env(monkeypatch, fmurun_w_casemetadata, fmuru
     """
     os.chdir(fmurun_w_casemetadata)
     fmu_restart_from = FmuProvider(
-        model=GLOBAL_CONFIG_MODEL, fmu_context=FmuContext.realization
+        model=GLOBAL_CONFIG_MODEL, fmu_context=FMUContext.realization
     )
     meta_restart_from = fmu_restart_from.get_metadata()
 
@@ -259,7 +259,7 @@ def test_fmuprovider_valid_restart_env(monkeypatch, fmurun_w_casemetadata, fmuru
 
     os.chdir(fmurun_pred)
     fmu_restart = FmuProvider(
-        model=GLOBAL_CONFIG_MODEL, fmu_context=FmuContext.realization
+        model=GLOBAL_CONFIG_MODEL, fmu_context=FMUContext.realization
     )
 
     meta_restart = fmu_restart.get_metadata()
@@ -276,13 +276,13 @@ def test_fmuprovider_invalid_restart_env(
     """
     os.chdir(fmurun_w_casemetadata)
 
-    _ = FmuProvider(model=GLOBAL_CONFIG_MODEL, fmu_context=FmuContext.realization)
+    _ = FmuProvider(model=GLOBAL_CONFIG_MODEL, fmu_context=FMUContext.realization)
 
     monkeypatch.setenv(RESTART_PATH_ENVNAME, "/path/to/somewhere/invalid")
 
     os.chdir(fmurun_pred)
     fmu_restart = FmuProvider(
-        model=GLOBAL_CONFIG_MODEL, fmu_context=FmuContext.realization
+        model=GLOBAL_CONFIG_MODEL, fmu_context=FMUContext.realization
     )
     meta = fmu_restart.get_metadata()
     assert meta.iteration.restart_from is None
@@ -295,14 +295,14 @@ def test_fmuprovider_no_restart_env(monkeypatch, fmurun_w_casemetadata, fmurun_p
     """
     os.chdir(fmurun_w_casemetadata)
 
-    _ = FmuProvider(model=GLOBAL_CONFIG_MODEL, fmu_context=FmuContext.realization)
+    _ = FmuProvider(model=GLOBAL_CONFIG_MODEL, fmu_context=FMUContext.realization)
 
     monkeypatch.setenv(RESTART_PATH_ENVNAME, "/path/to/somewhere/invalid")
     monkeypatch.delenv(RESTART_PATH_ENVNAME)
 
     os.chdir(fmurun_pred)
     restart_meta = FmuProvider(
-        model=GLOBAL_CONFIG_MODEL, fmu_context=FmuContext.realization
+        model=GLOBAL_CONFIG_MODEL, fmu_context=FMUContext.realization
     ).get_metadata()
     assert restart_meta.iteration.restart_from is None
 


### PR DESCRIPTION
Resolves #696 

Also adds them to enums, and renames some classes to remove the redundant `Enum` in the name or align with other names (i.e. FMUSomething as opposed to FmuSomething).

Removing descriptions from the `Field(description="...")` also removes these descriptions from the schema right now. However, with Pydantic 2.7 (when we are able to upgrade to it), moving these descriptions to docstrings will add them back into the schema description. So this loss of fidelity is temporary.