### PR TITLE
FIX: Allow user input on vertical_domain

### DIFF
--- a/schema/definitions/0.8.0/schema/fmu_meta.json
+++ b/schema/definitions/0.8.0/schema/fmu_meta.json
@@ -658,15 +658,6 @@
           "const": "depth",
           "title": "Content"
         },
-        "depth_reference": {
-          "enum": [
-            "msl",
-            "sb",
-            "rkb"
-          ],
-          "title": "Depth Reference",
-          "type": "string"
-        },
         "description": {
           "anyOf": [
             {
@@ -681,6 +672,22 @@
           ],
           "default": null,
           "title": "Description"
+        },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
         },
         "format": {
           "examples": [
@@ -878,23 +885,7 @@
           "type": "string"
         },
         "vertical_domain": {
-          "anyOf": [
-            {
-              "enum": [
-                "depth",
-                "time"
-              ],
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "examples": [
-            "depth",
-            "time"
-          ],
+          "const": "depth",
           "title": "Vertical Domain"
         }
       },
@@ -905,7 +896,7 @@
         "format",
         "is_observation",
         "is_prediction",
-        "depth_reference"
+        "vertical_domain"
       ],
       "title": "DepthData",
       "type": "object"
@@ -954,6 +945,15 @@
       },
       "title": "Display",
       "type": "object"
+    },
+    "DomainReference": {
+      "enum": [
+        "msl",
+        "sb",
+        "rkb"
+      ],
+      "title": "DomainReference",
+      "type": "string"
     },
     "FMUAttributes": {
       "dependencies": {
@@ -1126,6 +1126,22 @@
           "default": null,
           "title": "Description"
         },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
         "format": {
           "examples": [
             "irap_binary"
@@ -1324,11 +1340,7 @@
         "vertical_domain": {
           "anyOf": [
             {
-              "enum": [
-                "depth",
-                "time"
-              ],
-              "type": "string"
+              "$ref": "#/$defs/VerticalDomain"
             },
             {
               "type": "null"
@@ -1338,8 +1350,7 @@
           "examples": [
             "depth",
             "time"
-          ],
-          "title": "Vertical Domain"
+          ]
         }
       },
       "required": [
@@ -1416,6 +1427,22 @@
           "default": null,
           "title": "Description"
         },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
         "format": {
           "examples": [
             "irap_binary"
@@ -1614,11 +1641,7 @@
         "vertical_domain": {
           "anyOf": [
             {
-              "enum": [
-                "depth",
-                "time"
-              ],
-              "type": "string"
+              "$ref": "#/$defs/VerticalDomain"
             },
             {
               "type": "null"
@@ -1628,8 +1651,7 @@
           "examples": [
             "depth",
             "time"
-          ],
-          "title": "Vertical Domain"
+          ]
         }
       },
       "required": [
@@ -1706,6 +1728,22 @@
           "default": null,
           "title": "Description"
         },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
         "format": {
           "examples": [
             "irap_binary"
@@ -1904,11 +1942,7 @@
         "vertical_domain": {
           "anyOf": [
             {
-              "enum": [
-                "depth",
-                "time"
-              ],
-              "type": "string"
+              "$ref": "#/$defs/VerticalDomain"
             },
             {
               "type": "null"
@@ -1918,8 +1952,7 @@
           "examples": [
             "depth",
             "time"
-          ],
-          "title": "Vertical Domain"
+          ]
         }
       },
       "required": [
@@ -2089,6 +2122,22 @@
           ],
           "default": null,
           "title": "Description"
+        },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
         },
         "field_outline": {
           "$ref": "#/$defs/FieldOutline"
@@ -2291,11 +2340,7 @@
         "vertical_domain": {
           "anyOf": [
             {
-              "enum": [
-                "depth",
-                "time"
-              ],
-              "type": "string"
+              "$ref": "#/$defs/VerticalDomain"
             },
             {
               "type": "null"
@@ -2305,8 +2350,7 @@
           "examples": [
             "depth",
             "time"
-          ],
-          "title": "Vertical Domain"
+          ]
         }
       },
       "required": [
@@ -2397,6 +2441,22 @@
           ],
           "default": null,
           "title": "Description"
+        },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
         },
         "field_region": {
           "$ref": "#/$defs/FieldRegion"
@@ -2599,11 +2659,7 @@
         "vertical_domain": {
           "anyOf": [
             {
-              "enum": [
-                "depth",
-                "time"
-              ],
-              "type": "string"
+              "$ref": "#/$defs/VerticalDomain"
             },
             {
               "type": "null"
@@ -2613,8 +2669,7 @@
           "examples": [
             "depth",
             "time"
-          ],
-          "title": "Vertical Domain"
+          ]
         }
       },
       "required": [
@@ -2803,6 +2858,22 @@
           ],
           "default": null,
           "title": "Description"
+        },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
         },
         "fluid_contact": {
           "$ref": "#/$defs/FluidContact"
@@ -3005,11 +3076,7 @@
         "vertical_domain": {
           "anyOf": [
             {
-              "enum": [
-                "depth",
-                "time"
-              ],
-              "type": "string"
+              "$ref": "#/$defs/VerticalDomain"
             },
             {
               "type": "null"
@@ -3019,8 +3086,7 @@
           "examples": [
             "depth",
             "time"
-          ],
-          "title": "Vertical Domain"
+          ]
         }
       },
       "required": [
@@ -3194,6 +3260,22 @@
           "default": null,
           "title": "Description"
         },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
         "format": {
           "examples": [
             "irap_binary"
@@ -3392,11 +3474,7 @@
         "vertical_domain": {
           "anyOf": [
             {
-              "enum": [
-                "depth",
-                "time"
-              ],
-              "type": "string"
+              "$ref": "#/$defs/VerticalDomain"
             },
             {
               "type": "null"
@@ -3406,8 +3484,7 @@
           "examples": [
             "depth",
             "time"
-          ],
-          "title": "Vertical Domain"
+          ]
         }
       },
       "required": [
@@ -3524,6 +3601,22 @@
           "default": null,
           "title": "Description"
         },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
         "format": {
           "examples": [
             "irap_binary"
@@ -3722,11 +3815,7 @@
         "vertical_domain": {
           "anyOf": [
             {
-              "enum": [
-                "depth",
-                "time"
-              ],
-              "type": "string"
+              "$ref": "#/$defs/VerticalDomain"
             },
             {
               "type": "null"
@@ -3736,8 +3825,7 @@
           "examples": [
             "depth",
             "time"
-          ],
-          "title": "Vertical Domain"
+          ]
         }
       },
       "required": [
@@ -3867,6 +3955,22 @@
           "default": null,
           "title": "Description"
         },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
         "format": {
           "examples": [
             "irap_binary"
@@ -4065,11 +4169,7 @@
         "vertical_domain": {
           "anyOf": [
             {
-              "enum": [
-                "depth",
-                "time"
-              ],
-              "type": "string"
+              "$ref": "#/$defs/VerticalDomain"
             },
             {
               "type": "null"
@@ -4079,8 +4179,7 @@
           "examples": [
             "depth",
             "time"
-          ],
-          "title": "Vertical Domain"
+          ]
         }
       },
       "required": [
@@ -4273,6 +4372,22 @@
           "default": null,
           "title": "Description"
         },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
         "format": {
           "examples": [
             "irap_binary"
@@ -4471,11 +4586,7 @@
         "vertical_domain": {
           "anyOf": [
             {
-              "enum": [
-                "depth",
-                "time"
-              ],
-              "type": "string"
+              "$ref": "#/$defs/VerticalDomain"
             },
             {
               "type": "null"
@@ -4485,8 +4596,7 @@
           "examples": [
             "depth",
             "time"
-          ],
-          "title": "Vertical Domain"
+          ]
         }
       },
       "required": [
@@ -4584,6 +4694,22 @@
           "default": null,
           "title": "Description"
         },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
         "format": {
           "examples": [
             "irap_binary"
@@ -4782,11 +4908,7 @@
         "vertical_domain": {
           "anyOf": [
             {
-              "enum": [
-                "depth",
-                "time"
-              ],
-              "type": "string"
+              "$ref": "#/$defs/VerticalDomain"
             },
             {
               "type": "null"
@@ -4796,8 +4918,7 @@
           "examples": [
             "depth",
             "time"
-          ],
-          "title": "Vertical Domain"
+          ]
         }
       },
       "required": [
@@ -4874,6 +4995,22 @@
           "default": null,
           "title": "Description"
         },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
         "format": {
           "examples": [
             "irap_binary"
@@ -5072,11 +5209,7 @@
         "vertical_domain": {
           "anyOf": [
             {
-              "enum": [
-                "depth",
-                "time"
-              ],
-              "type": "string"
+              "$ref": "#/$defs/VerticalDomain"
             },
             {
               "type": "null"
@@ -5086,8 +5219,7 @@
           "examples": [
             "depth",
             "time"
-          ],
-          "title": "Vertical Domain"
+          ]
         }
       },
       "required": [
@@ -5211,6 +5343,22 @@
           "default": null,
           "title": "Description"
         },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
         "format": {
           "examples": [
             "irap_binary"
@@ -5409,11 +5557,7 @@
         "vertical_domain": {
           "anyOf": [
             {
-              "enum": [
-                "depth",
-                "time"
-              ],
-              "type": "string"
+              "$ref": "#/$defs/VerticalDomain"
             },
             {
               "type": "null"
@@ -5423,8 +5567,7 @@
           "examples": [
             "depth",
             "time"
-          ],
-          "title": "Vertical Domain"
+          ]
         }
       },
       "required": [
@@ -5501,6 +5644,22 @@
           "default": null,
           "title": "Description"
         },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
         "format": {
           "examples": [
             "irap_binary"
@@ -5699,11 +5858,7 @@
         "vertical_domain": {
           "anyOf": [
             {
-              "enum": [
-                "depth",
-                "time"
-              ],
-              "type": "string"
+              "$ref": "#/$defs/VerticalDomain"
             },
             {
               "type": "null"
@@ -5713,8 +5868,7 @@
           "examples": [
             "depth",
             "time"
-          ],
-          "title": "Vertical Domain"
+          ]
         }
       },
       "required": [
@@ -5843,6 +5997,22 @@
           "default": null,
           "title": "Description"
         },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
         "format": {
           "examples": [
             "irap_binary"
@@ -6041,11 +6211,7 @@
         "vertical_domain": {
           "anyOf": [
             {
-              "enum": [
-                "depth",
-                "time"
-              ],
-              "type": "string"
+              "$ref": "#/$defs/VerticalDomain"
             },
             {
               "type": "null"
@@ -6055,8 +6221,7 @@
           "examples": [
             "depth",
             "time"
-          ],
-          "title": "Vertical Domain"
+          ]
         }
       },
       "required": [
@@ -6133,6 +6298,22 @@
           "default": null,
           "title": "Description"
         },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
         "format": {
           "examples": [
             "irap_binary"
@@ -6331,11 +6512,7 @@
         "vertical_domain": {
           "anyOf": [
             {
-              "enum": [
-                "depth",
-                "time"
-              ],
-              "type": "string"
+              "$ref": "#/$defs/VerticalDomain"
             },
             {
               "type": "null"
@@ -6345,8 +6522,7 @@
           "examples": [
             "depth",
             "time"
-          ],
-          "title": "Vertical Domain"
+          ]
         }
       },
       "required": [
@@ -6510,6 +6686,22 @@
           ],
           "default": null,
           "title": "Description"
+        },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
         },
         "format": {
           "examples": [
@@ -6712,11 +6904,7 @@
         "vertical_domain": {
           "anyOf": [
             {
-              "enum": [
-                "depth",
-                "time"
-              ],
-              "type": "string"
+              "$ref": "#/$defs/VerticalDomain"
             },
             {
               "type": "null"
@@ -6726,8 +6914,7 @@
           "examples": [
             "depth",
             "time"
-          ],
-          "title": "Vertical Domain"
+          ]
         }
       },
       "required": [
@@ -6917,6 +7104,22 @@
           ],
           "default": null,
           "title": "Description"
+        },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
         },
         "format": {
           "examples": [
@@ -7116,11 +7319,7 @@
         "vertical_domain": {
           "anyOf": [
             {
-              "enum": [
-                "depth",
-                "time"
-              ],
-              "type": "string"
+              "$ref": "#/$defs/VerticalDomain"
             },
             {
               "type": "null"
@@ -7130,8 +7329,7 @@
           "examples": [
             "depth",
             "time"
-          ],
-          "title": "Vertical Domain"
+          ]
         }
       },
       "required": [
@@ -7333,6 +7531,22 @@
           "default": null,
           "title": "Description"
         },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
         "format": {
           "examples": [
             "irap_binary"
@@ -7531,11 +7745,7 @@
         "vertical_domain": {
           "anyOf": [
             {
-              "enum": [
-                "depth",
-                "time"
-              ],
-              "type": "string"
+              "$ref": "#/$defs/VerticalDomain"
             },
             {
               "type": "null"
@@ -7545,8 +7755,7 @@
           "examples": [
             "depth",
             "time"
-          ],
-          "title": "Vertical Domain"
+          ]
         }
       },
       "required": [
@@ -7652,6 +7861,22 @@
           "default": null,
           "title": "Description"
         },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
         "format": {
           "examples": [
             "irap_binary"
@@ -7848,23 +8073,7 @@
           "type": "string"
         },
         "vertical_domain": {
-          "anyOf": [
-            {
-              "enum": [
-                "depth",
-                "time"
-              ],
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "examples": [
-            "depth",
-            "time"
-          ],
+          "const": "time",
           "title": "Vertical Domain"
         }
       },
@@ -7874,7 +8083,8 @@
         "stratigraphic",
         "format",
         "is_observation",
-        "is_prediction"
+        "is_prediction",
+        "vertical_domain"
       ],
       "title": "TimeData",
       "type": "object"
@@ -7942,6 +8152,22 @@
           "default": null,
           "title": "Description"
         },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
         "format": {
           "examples": [
             "irap_binary"
@@ -8140,11 +8366,7 @@
         "vertical_domain": {
           "anyOf": [
             {
-              "enum": [
-                "depth",
-                "time"
-              ],
-              "type": "string"
+              "$ref": "#/$defs/VerticalDomain"
             },
             {
               "type": "null"
@@ -8154,8 +8376,7 @@
           "examples": [
             "depth",
             "time"
-          ],
-          "title": "Vertical Domain"
+          ]
         }
       },
       "required": [
@@ -8332,6 +8553,22 @@
           "default": null,
           "title": "Description"
         },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
         "format": {
           "examples": [
             "irap_binary"
@@ -8530,11 +8767,7 @@
         "vertical_domain": {
           "anyOf": [
             {
-              "enum": [
-                "depth",
-                "time"
-              ],
-              "type": "string"
+              "$ref": "#/$defs/VerticalDomain"
             },
             {
               "type": "null"
@@ -8544,8 +8777,7 @@
           "examples": [
             "depth",
             "time"
-          ],
-          "title": "Vertical Domain"
+          ]
         }
       },
       "required": [
@@ -8572,6 +8804,14 @@
       ],
       "title": "Version",
       "type": "object"
+    },
+    "VerticalDomain": {
+      "enum": [
+        "depth",
+        "time"
+      ],
+      "title": "VerticalDomain",
+      "type": "string"
     },
     "VolumesData": {
       "description": "The ``data`` block contains information about the data contained in this object.\nThis class contains metadata for volumes.",
@@ -8636,6 +8876,22 @@
           "default": null,
           "title": "Description"
         },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
         "format": {
           "examples": [
             "irap_binary"
@@ -8834,11 +9090,7 @@
         "vertical_domain": {
           "anyOf": [
             {
-              "enum": [
-                "depth",
-                "time"
-              ],
-              "type": "string"
+              "$ref": "#/$defs/VerticalDomain"
             },
             {
               "type": "null"
@@ -8848,8 +9100,7 @@
           "examples": [
             "depth",
             "time"
-          ],
-          "title": "Vertical Domain"
+          ]
         }
       },
       "required": [
@@ -8926,6 +9177,22 @@
           "default": null,
           "title": "Description"
         },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
         "format": {
           "examples": [
             "irap_binary"
@@ -9124,11 +9391,7 @@
         "vertical_domain": {
           "anyOf": [
             {
-              "enum": [
-                "depth",
-                "time"
-              ],
-              "type": "string"
+              "$ref": "#/$defs/VerticalDomain"
             },
             {
               "type": "null"
@@ -9138,8 +9401,7 @@
           "examples": [
             "depth",
             "time"
-          ],
-          "title": "Vertical Domain"
+          ]
         }
       },
       "required": [

--- a/src/fmu/dataio/datastructure/meta/content.py
+++ b/src/fmu/dataio/datastructure/meta/content.py
@@ -282,11 +282,17 @@ class Data(BaseModel):
     unit: str = Field(default="", examples=["m"])
     """A reference to a known unit."""
 
-    vertical_domain: Optional[Literal["depth", "time"]] = Field(
+    vertical_domain: Optional[enums.VerticalDomain] = Field(
         default=None,
         examples=["depth", "time"],
     )
     """A reference to a known vertical domain."""
+
+    domain_reference: Optional[enums.DomainReference] = Field(
+        default=None,
+        examples=["msl", "sb", "rkb"],
+    )
+    """The reference for the vertical scale of the data."""
 
     table_index: Optional[List[str]] = Field(
         default=None,
@@ -317,8 +323,19 @@ class DepthData(Data):
     content: Literal[enums.Content.depth]
     """The type of content these data represent."""
 
-    depth_reference: Literal["msl", "sb", "rkb"]
-    """A reference to a known depth reference."""
+    vertical_domain: Literal[enums.VerticalDomain.depth]
+    """A reference to a known vertical domain."""
+
+    @field_validator("vertical_domain", mode="before")
+    @classmethod
+    def set_vertical_domain(cls, v: str) -> Literal[enums.VerticalDomain.depth]:
+        """For DepthData the domain should be 'depth'"""
+        if v and v != enums.VerticalDomain.depth:
+            warnings.warn(
+                f"The value of 'vertical_domain' is '{v}'. Since this is a "
+                "'depth' content the 'vertical_domain' will be set to 'depth'."
+            )
+        return enums.VerticalDomain.depth
 
 
 class FaciesThicknessData(Data):
@@ -531,6 +548,20 @@ class TimeData(Data):
 
     content: Literal[enums.Content.time]
     """The type of content these data represent."""
+
+    vertical_domain: Literal[enums.VerticalDomain.time]
+    """A reference to a known vertical domain."""
+
+    @field_validator("vertical_domain", mode="before")
+    @classmethod
+    def set_vertical_domain(cls, v: str) -> Literal[enums.VerticalDomain.time]:
+        """For TimeData the domain should be 'time'"""
+        if v and v != enums.VerticalDomain.time:
+            warnings.warn(
+                f"The value of 'vertical_domain' is '{v}'. Since this is a "
+                "'time' content the 'vertical_domain' will be set to 'time'."
+            )
+        return enums.VerticalDomain.time
 
 
 class TimeSeriesData(Data):

--- a/src/fmu/dataio/datastructure/meta/enums.py
+++ b/src/fmu/dataio/datastructure/meta/enums.py
@@ -88,3 +88,14 @@ class FMUContext(str, Enum):
     case = "case"
     iteration = "iteration"
     realization = "realization"
+
+
+class VerticalDomain(str, Enum):
+    depth = "depth"
+    time = "time"
+
+
+class DomainReference(str, Enum):
+    msl = "msl"
+    sb = "sb"
+    rkb = "rkb"

--- a/src/fmu/dataio/providers/objectdata/_base.py
+++ b/src/fmu/dataio/providers/objectdata/_base.py
@@ -103,8 +103,8 @@ class ObjectDataProvider(Provider):
         metadata["format"] = self.fmt
         metadata["layout"] = self.layout
         metadata["unit"] = self.dataio.unit or ""
-        metadata["vertical_domain"] = list(self.dataio.vertical_domain.keys())[0]
-        metadata["depth_reference"] = list(self.dataio.vertical_domain.values())[0]
+        metadata["vertical_domain"] = self.dataio.vertical_domain
+        metadata["domain_reference"] = self.dataio.domain_reference
 
         metadata["spec"] = self.get_spec()
         metadata["geometry"] = self.get_geometry()

--- a/src/fmu/dataio/providers/objectdata/_provider.py
+++ b/src/fmu/dataio/providers/objectdata/_provider.py
@@ -49,7 +49,7 @@ data:
     layout: regular # / cornerpoint / structured / etc
     unit: m
     vertical_domain: depth # / time / null
-    depth_reference: msl # / seabed / etc # mandatory when vertical_domain is depth?
+    domain_reference: msl # / seabed / etc # mandatory when vertical_domain is depth?
     grid_model: # Making this an object to allow for expanding in the future
         name: MyGrid # important for data identification, also for other data types
     spec: # class/layout dependent, optional? Can spec be expanded to work for all


### PR DESCRIPTION
PR that closes #624.


Main problems were:
- `vertical_domain`  were hardcoded to `{"depth": "msl"}` where the dict value was the `depth_reference`
 - the `depth_reference` was previously only possible to input for `content="depth"` (according to the schema)

I have been very much back and forth on how to best solve this one. But after discussions with @jcrivenaes we landed on adding a new general `domain_reference` argument in `ExportData` and as field in the schema as the best solution. This will be applicable both for time/depth domains. 

Other changes
- deprecate unused `depth_reference` argument in `ExportData` 
 - support giving in `vertical_domain` as string ("time" or "depth") and deprecate dictionary input
 - set  the `vertical_domain` according to the `content` if `content` is `depth/time`, 
 
