### PR TITLE
MAINT: Guard type checking imports in TYPE_CHECKING block

### DIFF
--- a/src/fmu/dataio/_metadata.py
+++ b/src/fmu/dataio/_metadata.py
@@ -14,19 +14,19 @@ from typing import TYPE_CHECKING, Final, Literal
 
 from pydantic import AnyHttpUrl, TypeAdapter
 
-from . import types
 from ._definitions import SCHEMA, SOURCE, VERSION
 from ._logging import null_logger
 from .datastructure._internal import internal
 from .datastructure.meta import meta
 from .exceptions import InvalidMetadataError
 from .providers._filedata import FileDataProvider
-from .providers._fmu import FmuProvider
 from .providers.objectdata._provider import objectdata_provider_factory
 from .version import __version__
 
 if TYPE_CHECKING:
+    from . import types
     from .dataio import ExportData
+    from .providers._fmu import FmuProvider
     from .providers.objectdata._base import ObjectDataProvider
 
 logger: Final = null_logger(__name__)

--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -9,10 +9,22 @@ import os
 import warnings
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, ClassVar, Dict, Final, List, Literal, Optional, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ClassVar,
+    Dict,
+    Final,
+    List,
+    Literal,
+    Optional,
+    Union,
+)
 from warnings import warn
 
-from . import types
+if TYPE_CHECKING:
+    from . import types
+
 from ._definitions import ValidationError
 from ._logging import null_logger
 from ._metadata import generate_export_metadata

--- a/src/fmu/dataio/datastructure/meta/content.py
+++ b/src/fmu/dataio/datastructure/meta/content.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union
 
 from pydantic import (
     AwareDatetime,
@@ -13,10 +13,12 @@ from pydantic import (
     field_validator,
     model_validator,
 )
-from pydantic_core import CoreSchema
 from typing_extensions import Annotated
 
 from . import enums, specification
+
+if TYPE_CHECKING:
+    from pydantic_core import CoreSchema
 
 
 class Timestamp(BaseModel):

--- a/src/fmu/dataio/datastructure/meta/meta.py
+++ b/src/fmu/dataio/datastructure/meta/meta.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections import ChainMap
 from pathlib import Path
-from typing import Dict, List, Literal, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Dict, List, Literal, Optional, TypeVar, Union
 from uuid import UUID
 
 from pydantic import (
@@ -14,10 +14,12 @@ from pydantic import (
     RootModel,
     model_validator,
 )
-from pydantic_core import CoreSchema
 from typing_extensions import Annotated
 
 from . import content, enums
+
+if TYPE_CHECKING:
+    from pydantic_core import CoreSchema
 
 T = TypeVar("T", Dict, List, object)
 

--- a/src/fmu/dataio/providers/objectdata/_faultroom.py
+++ b/src/fmu/dataio/providers/objectdata/_faultroom.py
@@ -1,18 +1,20 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Final
+from typing import TYPE_CHECKING, Final
 
 from fmu.dataio._definitions import ExportFolder, ValidFormats
 from fmu.dataio._logging import null_logger
 from fmu.dataio.datastructure.meta.content import BoundingBox3D
 from fmu.dataio.datastructure.meta.enums import FMUClass, Layout
 from fmu.dataio.datastructure.meta.specification import FaultRoomSurfaceSpecification
-from fmu.dataio.readers import FaultRoomSurface
 
 from ._base import (
     ObjectDataProvider,
 )
+
+if TYPE_CHECKING:
+    from fmu.dataio.readers import FaultRoomSurface
 
 logger: Final = null_logger(__name__)
 

--- a/src/fmu/dataio/providers/objectdata/_tables.py
+++ b/src/fmu/dataio/providers/objectdata/_tables.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Final
 
-import pandas as pd
-
 from fmu.dataio._definitions import (
     STANDARD_TABLE_INDEX_COLUMNS,
     ExportFolder,
@@ -19,6 +17,7 @@ from ._base import (
 )
 
 if TYPE_CHECKING:
+    import pandas as pd
     import pyarrow
 
 logger: Final = null_logger(__name__)

--- a/src/fmu/dataio/providers/objectdata/_xtgeo.py
+++ b/src/fmu/dataio/providers/objectdata/_xtgeo.py
@@ -6,8 +6,6 @@ from textwrap import dedent
 from typing import TYPE_CHECKING, Final
 
 import numpy as np
-import pandas as pd
-import xtgeo
 
 from fmu.dataio._definitions import ExportFolder, ValidFormats
 from fmu.dataio._logging import null_logger
@@ -27,6 +25,7 @@ from ._base import ObjectDataProvider
 
 if TYPE_CHECKING:
     import pandas as pd
+    import xtgeo
 
 logger: Final = null_logger(__name__)
 

--- a/src/fmu/dataio/types.py
+++ b/src/fmu/dataio/types.py
@@ -1,19 +1,21 @@
 from __future__ import annotations
 
-import pathlib
 from typing import TYPE_CHECKING, Literal, MutableMapping, Union
 
 from typing_extensions import Annotated, TypeAlias
 
-from .readers import FaultRoomSurface
-
 if TYPE_CHECKING:
+    import pathlib
+
     from pandas import DataFrame
     from pyarrow import Table
     from xtgeo.cube import Cube
     from xtgeo.grid3d import Grid, GridProperty
     from xtgeo.surface import RegularSurface
     from xtgeo.xyz import Points, Polygons
+
+    from .readers import FaultRoomSurface
+
 
     # Local proxies due to xtgeo at the time of writing
     # not having stubs/marked itself as a typed library.

--- a/src/fmu/dataio/types.py
+++ b/src/fmu/dataio/types.py
@@ -16,7 +16,6 @@ if TYPE_CHECKING:
 
     from .readers import FaultRoomSurface
 
-
     # Local proxies due to xtgeo at the time of writing
     # not having stubs/marked itself as a typed library.
     # Ref.: https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-library-stubs-or-py-typed-marker


### PR DESCRIPTION
Resolves #725 

Imports that are only used to annotate types in static type-checking, are moved into a type-checking block:
```python
if TYPE_CHECKING:
    ...
```
The block ensures that these imports will only be imported when we are doing static type checking with mypy.

NB! As stated in #725 imports that are used by Pydantic at runtime can not be moved to the TYPE_CHECKING block