### PR TITLE
ENH: Add --force option to script tools/update_schema

### DIFF
--- a/tools/update_schema
+++ b/tools/update_schema
@@ -81,7 +81,7 @@ def _load_json(filepath: Path) -> dict[str, Any]:
                 "to overwrite with the new schema.\n"
                 f"{FAILURE} Json parsing error: '{json_decode_error.msg}.'"
             )
-            sys.exit() 
+            sys.exit(1) 
 
 
 def _check_output_filepath(filepath: Path, new_schema: dict[str, Any]) -> None:

--- a/tools/update_schema
+++ b/tools/update_schema
@@ -56,6 +56,11 @@ def _get_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Run as normal, but don't write the file.",
     )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Force the script to overwrite the current schema with the new schema.",
+    )
     return parser
 
 
@@ -67,7 +72,16 @@ def _get_output_path(version: str) -> Path:
 
 def _load_json(filepath: Path) -> dict[str, Any]:
     with open(filepath, encoding="utf-8") as f:
-        return json.load(f)
+        try:
+            return json.load(f)
+        except json.JSONDecodeError as json_decode_error:
+            print(
+                f"{FAILURE} Parsing existing json schema failed: The json is malformed. "
+                "If you know why, re-run the command with argument '--force' "
+                "to overwrite with the new schema.\n"
+                f"{FAILURE} Json parsing error: '{json_decode_error.msg}.'"
+            )
+            sys.exit() 
 
 
 def _check_output_filepath(filepath: Path, new_schema: dict[str, Any]) -> None:
@@ -110,8 +124,14 @@ def main() -> None:
     output_filepath = output_path / args.filename
 
     _check_output_path(output_path, args.test)
-    _check_output_filepath(output_filepath, new_schema)
-
+    if not args.force:
+        _check_output_filepath(output_filepath, new_schema)
+    else:
+        print(
+            f"{INFO} The '--force' argument flag has been set: "
+            "Forcing override and skipping check of current json schema."
+        )
+    
     print(
         f"{INFO} writing schema version {BOLD}{args.version}{NC} "
         f"as {BOLD}{args.filename}{NC} ...",


### PR DESCRIPTION
Resolving #740 

Adds a new argument ```--force``` to the t**ools/update_schema** script that is used to update **fmu_meta.json** schema. 

This has been added to have a way to force an overwrite of the current json schema, if the current json schema has been malformed for some reason, e.g. because of a merge conflict.

**Changes :** 
1. ```--force``` has been added as a new valid argument to the script
2. When running the script with the ```--force``` argument, the script will skip checking/validating the current schema and overwrite with the new one. 
2. In case of a json parsing error of the current json schema, the script will exit and inform the user about the possibility of running the script with the ```--force``` argument. 

**Local testing**
The changes has been testes locally by:
1. Editing the current schema **fmu_meta.json** to be an unvalid json, followed by running the script to see that the json parse error was outputted to the user, in addition to the suggestion of running the script with the ```--force``` argument.
2. Running the script with the new argument ```--force``` to see if the schema was overridden. 

