### PR TITLE
MAINT: Rename 'InitialCase" class to 'CreateCaseMetadata'

### DIFF
--- a/src/fmu/dataio/__init__.py
+++ b/src/fmu/dataio/__init__.py
@@ -2,7 +2,7 @@
 
 from fmu.dataio.dataio import (
     AggregatedData,
-    CreateCaseMetada,
+    CreateCaseMetadata,
     ExportData,
     read_metadata,
 )
@@ -18,7 +18,7 @@ except ImportError:
 __all__ = [
     "AggregatedData",
     "ExportData",
-    "CreateCaseMetada",
+    "CreateCaseMetadata",
     "read_metadata",
     "ExportPreprocessedData",
 ]

--- a/src/fmu/dataio/__init__.py
+++ b/src/fmu/dataio/__init__.py
@@ -2,8 +2,8 @@
 
 from fmu.dataio.dataio import (
     AggregatedData,
+    CreateCaseMetada,
     ExportData,
-    InitializeCase,
     read_metadata,
 )
 from fmu.dataio.preprocessed import ExportPreprocessedData
@@ -18,7 +18,7 @@ except ImportError:
 __all__ = [
     "AggregatedData",
     "ExportData",
-    "InitializeCase",
+    "CreateCaseMetada",
     "read_metadata",
     "ExportPreprocessedData",
 ]

--- a/src/fmu/dataio/case.py
+++ b/src/fmu/dataio/case.py
@@ -17,17 +17,17 @@ from ._model.fields import Access, Case, Masterdata, Model, User
 logger: Final = null_logger(__name__)
 
 # ######################################################################################
-# InitializeCase.
+# CreateCaseMetada.
 #
-# The InitializeCase is used for making the case matadata prior to any other actions,
+# The CreateCaseMetada is used for making the case matadata prior to any other actions,
 # e.g. forward jobs. However, case metadata file may already exist, and in that case
 # this class should only emit a message or warning.
 # ######################################################################################
 
 
 @dataclass
-class InitializeCase:  # pylint: disable=too-few-public-methods
-    """Initialize metadata for an FMU Case.
+class CreateCaseMetada:  # pylint: disable=too-few-public-methods
+    """Create metadata for an FMU Case.
 
     In ERT this is typically ran as an hook workflow in advance.
 
@@ -69,7 +69,7 @@ class InitializeCase:  # pylint: disable=too-few-public-methods
         except ValidationError as e:
             global_configuration.validation_error_warning(e)
             raise
-        logger.info("Ran __post_init__ for InitializeCase")
+        logger.info("Ran __post_init__ for CreateCaseMetada")
 
     def _establish_metadata_files(self) -> bool:
         """Checks if the metadata files and directories are established and creates
@@ -88,7 +88,7 @@ class InitializeCase:  # pylint: disable=too-few-public-methods
         """
         Generates and persists a unique UUID for a new case.
 
-        Upon initialization of a new case, this UUID is stored in case
+        Upon creation of a new case, this UUID is stored in case
         metadata and written to disk, ensuring it remains constant for the case across
         runs and exports. It is foundational for tracking cases and embedding
         identifiers into file metadata.

--- a/src/fmu/dataio/case.py
+++ b/src/fmu/dataio/case.py
@@ -17,16 +17,16 @@ from ._model.fields import Access, Case, Masterdata, Model, User
 logger: Final = null_logger(__name__)
 
 # ######################################################################################
-# CreateCaseMetada.
+# CreateCaseMetadata.
 #
-# The CreateCaseMetada is used for making the case matadata prior to any other actions,
-# e.g. forward jobs. However, case metadata file may already exist, and in that case
-# this class should only emit a message or warning.
+# The CreateCaseMetadata is used for making the case matadata prior to any other
+# actions, e.g. forward jobs. However, case metadata file may already exist,
+# and in that case this class should only emit a message or warning.
 # ######################################################################################
 
 
 @dataclass
-class CreateCaseMetada:  # pylint: disable=too-few-public-methods
+class CreateCaseMetadata:  # pylint: disable=too-few-public-methods
     """Create metadata for an FMU Case.
 
     In ERT this is typically ran as an hook workflow in advance.
@@ -69,7 +69,7 @@ class CreateCaseMetada:  # pylint: disable=too-few-public-methods
         except ValidationError as e:
             global_configuration.validation_error_warning(e)
             raise
-        logger.info("Ran __post_init__ for CreateCaseMetada")
+        logger.info("Ran __post_init__ for CreateCaseMetadata")
 
     def _establish_metadata_files(self) -> bool:
         """Checks if the metadata files and directories are established and creates

--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -38,7 +38,7 @@ from ._utils import (
     some_config_from_env,
 )
 from .aggregation import AggregatedData
-from .case import CreateCaseMetada
+from .case import CreateCaseMetadata
 from .preprocessed import ExportPreprocessedData
 from .providers._fmu import FmuProvider, get_fmu_context_from_environment
 
@@ -54,7 +54,7 @@ SETTINGS_ENVNAME: Final = (
 logger: Final = null_logger(__name__)
 
 AggregatedData: Final = AggregatedData  # Backwards compatibility alias
-CreateCaseMetada: Final = CreateCaseMetada  # Backwards compatibility alias
+CreateCaseMetadata: Final = CreateCaseMetadata  # Backwards compatibility alias
 
 
 # ======================================================================================

--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -38,7 +38,7 @@ from ._utils import (
     some_config_from_env,
 )
 from .aggregation import AggregatedData
-from .case import InitializeCase
+from .case import CreateCaseMetada
 from .preprocessed import ExportPreprocessedData
 from .providers._fmu import FmuProvider, get_fmu_context_from_environment
 
@@ -54,7 +54,7 @@ SETTINGS_ENVNAME: Final = (
 logger: Final = null_logger(__name__)
 
 AggregatedData: Final = AggregatedData  # Backwards compatibility alias
-InitializeCase: Final = InitializeCase  # Backwards compatibility alias
+CreateCaseMetada: Final = CreateCaseMetada  # Backwards compatibility alias
 
 
 # ======================================================================================

--- a/src/fmu/dataio/providers/_fmu.py
+++ b/src/fmu/dataio/providers/_fmu.py
@@ -7,7 +7,7 @@ Note that FMU may potentially have different providers, e.g. ERT versions
 or it can detect that no FMU providers are present (e.g. just ran from RMS interactive)
 
 Note that establishing the FMU case metadata for a run, is currently *not* done
-here; this is done by code in the InitializeCase class.
+here; this is done by code in the CreateCaseMetada class.
 
 From ERT v. 5 (?), the following env variables are provided in startup (example):
 

--- a/src/fmu/dataio/providers/_fmu.py
+++ b/src/fmu/dataio/providers/_fmu.py
@@ -7,7 +7,7 @@ Note that FMU may potentially have different providers, e.g. ERT versions
 or it can detect that no FMU providers are present (e.g. just ran from RMS interactive)
 
 Note that establishing the FMU case metadata for a run, is currently *not* done
-here; this is done by code in the CreateCaseMetada class.
+here; this is done by code in the CreateCaseMetadata class.
 
 From ERT v. 5 (?), the following env variables are provided in startup (example):
 

--- a/src/fmu/dataio/scripts/create_case_metadata.py
+++ b/src/fmu/dataio/scripts/create_case_metadata.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING, Final
 
 import yaml
 
-from fmu.dataio import InitializeCase
+from fmu.dataio import CreateCaseMetada
 
 try:
     from ert.shared.plugins.plugin_manager import hook_implementation
@@ -115,7 +115,7 @@ def create_metadata(args: argparse.Namespace) -> str:
     ) as f:
         global_variables = yaml.safe_load(f)
 
-    return InitializeCase(
+    return CreateCaseMetada(
         config=global_variables,
         rootfolder=args.ert_caseroot,
         casename=args.ert_casename,

--- a/src/fmu/dataio/scripts/create_case_metadata.py
+++ b/src/fmu/dataio/scripts/create_case_metadata.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING, Final
 
 import yaml
 
-from fmu.dataio import CreateCaseMetada
+from fmu.dataio import CreateCaseMetadata
 
 try:
     from ert.shared.plugins.plugin_manager import hook_implementation
@@ -115,7 +115,7 @@ def create_metadata(args: argparse.Namespace) -> str:
     ) as f:
         global_variables = yaml.safe_load(f)
 
-    return CreateCaseMetada(
+    return CreateCaseMetadata(
         config=global_variables,
         rootfolder=args.ert_caseroot,
         casename=args.ert_casename,

--- a/tests/test_units/test_fmuprovider_class.py
+++ b/tests/test_units/test_fmuprovider_class.py
@@ -159,7 +159,7 @@ def test_fmuprovider_no_iter_folder(fmurun_no_iter_folder):
 
 
 def test_fmuprovider_prehook_case(tmp_path, globalconfig2, fmurun_prehook):
-    """The fmu run case metadata is initialized with Initialize case; then get provider.
+    """The fmu run case metadata is created with Create case; then get provider.
 
     A typical prehook section in a ERT run is to establish case metadata, and then
     subsequent hook workflows should still recognize this as an ERT run, altough
@@ -173,7 +173,7 @@ def test_fmuprovider_prehook_case(tmp_path, globalconfig2, fmurun_prehook):
     caseroot.mkdir(parents=True)
     os.chdir(caseroot)
 
-    icase = dataio.InitializeCase(
+    icase = dataio.CreateCaseMetada(
         config=globalconfig2,
         rootfolder=caseroot,
         casename="MyCaseName",

--- a/tests/test_units/test_fmuprovider_class.py
+++ b/tests/test_units/test_fmuprovider_class.py
@@ -173,7 +173,7 @@ def test_fmuprovider_prehook_case(tmp_path, globalconfig2, fmurun_prehook):
     caseroot.mkdir(parents=True)
     os.chdir(caseroot)
 
-    icase = dataio.CreateCaseMetada(
+    icase = dataio.CreateCaseMetadata(
         config=globalconfig2,
         rootfolder=caseroot,
         casename="MyCaseName",

--- a/tests/test_units/test_initialize_case.py
+++ b/tests/test_units/test_initialize_case.py
@@ -10,14 +10,14 @@ from pathlib import Path
 
 import pytest
 import yaml
-from fmu.dataio import InitializeCase
+from fmu.dataio import CreateCaseMetada
 from pydantic import ValidationError
 
 logger = logging.getLogger(__name__)
 
 
-def test_initialize_case_barebone(globalconfig2):
-    icase = InitializeCase(
+def test_crease_case_metadata_barebone(globalconfig2):
+    icase = CreateCaseMetada(
         config=globalconfig2, rootfolder="", casename="", caseuser="MyUser"
     )
     assert icase.config == globalconfig2
@@ -27,12 +27,12 @@ def test_initialize_case_barebone(globalconfig2):
     assert not icase.description
 
 
-def test_initialize_case_post_init(monkeypatch, fmurun, globalconfig2):
+def test_create_case_metadata_post_init(monkeypatch, fmurun, globalconfig2):
     monkeypatch.chdir(fmurun)
     caseroot = fmurun.parent.parent
     logger.info("Active folder is %s", fmurun)
 
-    icase = InitializeCase(
+    icase = CreateCaseMetada(
         config=globalconfig2,
         rootfolder=caseroot,
         casename="mycase",
@@ -47,7 +47,9 @@ def test_initialize_case_post_init(monkeypatch, fmurun, globalconfig2):
 
 
 @pytest.mark.filterwarnings("ignore:The global configuration")
-def test_initialize_case_post_init_bad_globalconfig(monkeypatch, fmurun, globalconfig2):
+def test_create_case_metadata_post_init_bad_globalconfig(
+    monkeypatch, fmurun, globalconfig2
+):
     monkeypatch.chdir(fmurun)
     logger.info("Active folder is %s", fmurun)
     caseroot = fmurun.parent.parent
@@ -57,7 +59,7 @@ def test_initialize_case_post_init_bad_globalconfig(monkeypatch, fmurun, globalc
     del config["masterdata"]
 
     with pytest.raises(ValidationError, match="masterdata"):
-        InitializeCase(
+        CreateCaseMetada(
             config=config,
             rootfolder=caseroot,
             casename="mycase",
@@ -65,14 +67,16 @@ def test_initialize_case_post_init_bad_globalconfig(monkeypatch, fmurun, globalc
         )
 
 
-def test_initialize_case_establish_metadata_files(monkeypatch, fmurun, globalconfig2):
+def test_create_case_metadata_establish_metadata_files(
+    monkeypatch, fmurun, globalconfig2
+):
     """Tests that the required directories are made when establishing the case"""
     monkeypatch.chdir(fmurun)
     logger.info("Active folder is %s", fmurun)
     caseroot = fmurun.parent.parent
     logger.info("Case folder is now %s", caseroot)
 
-    icase = InitializeCase(
+    icase = CreateCaseMetada(
         config=globalconfig2, rootfolder=caseroot, casename="mycase", caseuser="user"
     )
     share_metadata = caseroot / "share/metadata"
@@ -82,7 +86,7 @@ def test_initialize_case_establish_metadata_files(monkeypatch, fmurun, globalcon
     assert not icase._metafile.exists()
 
 
-def test_initialize_case_establish_metadata_files_exists(
+def test_create_case_metadata_establish_metadata_files_exists(
     monkeypatch, fmurun, globalconfig2
 ):
     """Tests that _establish_metadata_files returns correctly if the share/metadata
@@ -92,7 +96,7 @@ def test_initialize_case_establish_metadata_files_exists(
     caseroot = fmurun.parent.parent
     logger.info("Case folder is now %s", caseroot)
 
-    icase = InitializeCase(
+    icase = CreateCaseMetada(
         config=globalconfig2, rootfolder=caseroot, casename="mycase", caseuser="user"
     )
     (caseroot / "share/metadata").mkdir(parents=True, exist_ok=True)
@@ -104,13 +108,13 @@ def test_initialize_case_establish_metadata_files_exists(
     assert icase._metafile.exists()
 
 
-def test_initialize_case_generate_metadata(monkeypatch, fmurun, globalconfig2):
+def test_create_case_metadata_generate_metadata(monkeypatch, fmurun, globalconfig2):
     monkeypatch.chdir(fmurun)
     logger.info("Active folder is %s", fmurun)
     myroot = fmurun.parent.parent.parent / "mycase"
     logger.info("Case folder is now %s", myroot)
 
-    icase = InitializeCase(
+    icase = CreateCaseMetada(
         config=globalconfig2, rootfolder=myroot, casename="mycase", caseuser="user"
     )
     metadata = icase.generate_metadata()
@@ -119,14 +123,14 @@ def test_initialize_case_generate_metadata(monkeypatch, fmurun, globalconfig2):
     assert metadata["fmu"]["case"]["user"]["id"] == "user"
 
 
-def test_initialize_case_generate_metadata_warn_if_exists(
+def test_create_case_metadata_generate_metadata_warn_if_exists(
     monkeypatch, fmurun_w_casemetadata, globalconfig2
 ):
     monkeypatch.chdir(fmurun_w_casemetadata)
     logger.info("Active folder is %s", fmurun_w_casemetadata)
     casemetafolder = fmurun_w_casemetadata.parent.parent
 
-    icase = InitializeCase(
+    icase = CreateCaseMetada(
         config=globalconfig2,
         rootfolder=casemetafolder,
         casename="abc",
@@ -136,11 +140,11 @@ def test_initialize_case_generate_metadata_warn_if_exists(
         icase.generate_metadata()
 
 
-def test_initialize_case_with_export(monkeypatch, globalconfig2, fmurun):
+def test_create_case_metadata_with_export(monkeypatch, globalconfig2, fmurun):
     monkeypatch.chdir(fmurun)
     caseroot = fmurun.parent.parent
 
-    icase = InitializeCase(
+    icase = CreateCaseMetada(
         config=globalconfig2,
         rootfolder=caseroot,
         casename="MyCaseName",
@@ -158,11 +162,13 @@ def test_initialize_case_with_export(monkeypatch, globalconfig2, fmurun):
     assert metadata["masterdata"]["smda"]["field"][0]["identifier"] == "DROGON"
 
 
-def test_initialize_case_export_with_norsk_alphabet(monkeypatch, globalconfig2, fmurun):
+def test_create_case_metadata_export_with_norsk_alphabet(
+    monkeypatch, globalconfig2, fmurun
+):
     monkeypatch.chdir(fmurun)
     caseroot = fmurun.parent.parent
 
-    icase = InitializeCase(
+    icase = CreateCaseMetada(
         config=globalconfig2,
         rootfolder=caseroot,
         casename="MyCaseName_with_Æ",

--- a/tests/test_units/test_initialize_case.py
+++ b/tests/test_units/test_initialize_case.py
@@ -10,14 +10,14 @@ from pathlib import Path
 
 import pytest
 import yaml
-from fmu.dataio import CreateCaseMetada
+from fmu.dataio import CreateCaseMetadata
 from pydantic import ValidationError
 
 logger = logging.getLogger(__name__)
 
 
 def test_crease_case_metadata_barebone(globalconfig2):
-    icase = CreateCaseMetada(
+    icase = CreateCaseMetadata(
         config=globalconfig2, rootfolder="", casename="", caseuser="MyUser"
     )
     assert icase.config == globalconfig2
@@ -32,7 +32,7 @@ def test_create_case_metadata_post_init(monkeypatch, fmurun, globalconfig2):
     caseroot = fmurun.parent.parent
     logger.info("Active folder is %s", fmurun)
 
-    icase = CreateCaseMetada(
+    icase = CreateCaseMetadata(
         config=globalconfig2,
         rootfolder=caseroot,
         casename="mycase",
@@ -59,7 +59,7 @@ def test_create_case_metadata_post_init_bad_globalconfig(
     del config["masterdata"]
 
     with pytest.raises(ValidationError, match="masterdata"):
-        CreateCaseMetada(
+        CreateCaseMetadata(
             config=config,
             rootfolder=caseroot,
             casename="mycase",
@@ -76,7 +76,7 @@ def test_create_case_metadata_establish_metadata_files(
     caseroot = fmurun.parent.parent
     logger.info("Case folder is now %s", caseroot)
 
-    icase = CreateCaseMetada(
+    icase = CreateCaseMetadata(
         config=globalconfig2, rootfolder=caseroot, casename="mycase", caseuser="user"
     )
     share_metadata = caseroot / "share/metadata"
@@ -96,7 +96,7 @@ def test_create_case_metadata_establish_metadata_files_exists(
     caseroot = fmurun.parent.parent
     logger.info("Case folder is now %s", caseroot)
 
-    icase = CreateCaseMetada(
+    icase = CreateCaseMetadata(
         config=globalconfig2, rootfolder=caseroot, casename="mycase", caseuser="user"
     )
     (caseroot / "share/metadata").mkdir(parents=True, exist_ok=True)
@@ -114,7 +114,7 @@ def test_create_case_metadata_generate_metadata(monkeypatch, fmurun, globalconfi
     myroot = fmurun.parent.parent.parent / "mycase"
     logger.info("Case folder is now %s", myroot)
 
-    icase = CreateCaseMetada(
+    icase = CreateCaseMetadata(
         config=globalconfig2, rootfolder=myroot, casename="mycase", caseuser="user"
     )
     metadata = icase.generate_metadata()
@@ -130,7 +130,7 @@ def test_create_case_metadata_generate_metadata_warn_if_exists(
     logger.info("Active folder is %s", fmurun_w_casemetadata)
     casemetafolder = fmurun_w_casemetadata.parent.parent
 
-    icase = CreateCaseMetada(
+    icase = CreateCaseMetadata(
         config=globalconfig2,
         rootfolder=casemetafolder,
         casename="abc",
@@ -144,7 +144,7 @@ def test_create_case_metadata_with_export(monkeypatch, globalconfig2, fmurun):
     monkeypatch.chdir(fmurun)
     caseroot = fmurun.parent.parent
 
-    icase = CreateCaseMetada(
+    icase = CreateCaseMetadata(
         config=globalconfig2,
         rootfolder=caseroot,
         casename="MyCaseName",
@@ -168,7 +168,7 @@ def test_create_case_metadata_export_with_norsk_alphabet(
     monkeypatch.chdir(fmurun)
     caseroot = fmurun.parent.parent
 
-    icase = CreateCaseMetada(
+    icase = CreateCaseMetadata(
         config=globalconfig2,
         rootfolder=caseroot,
         casename="MyCaseName_with_Æ",


### PR DESCRIPTION
Resolves #171 

The class ```InitializeCase``` in ```fmu/datio/case.py``` has been renamed to ```CreateCaseMetadata```. This has been done to be more precise on what is actual created in the code in fmu-datio, and to avoid confusion as case initialization is something that is done in ERT.

Tests has also been renamed to match the new name of the class.