### PR TITLE
ENH: Use Pydantic models to validate metadata in aggregation.py and remove drop_nones

### DIFF
--- a/examples/s/d/nn/_project/aggregate_surfaces.py
+++ b/examples/s/d/nn/_project/aggregate_surfaces.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import fmu.dataio
+import fmu.dataio._utils
 import numpy as np
 import xtgeo
 import yaml
@@ -54,7 +55,7 @@ def main():
     operations = ["mean", "min", "max", "std"]
 
     # This is the ID we assign to this set of aggregations
-    aggregation_id = "something_very_unique"  # IRL this will usually be a uuid
+    aggregation_id = str(fmu.dataio._utils.uuid_from_string("something_very_unique"))
 
     # Initialize an AggregatedData object for this set of aggregations
     exp = fmu.dataio.AggregatedData(

--- a/src/fmu/dataio/_utils.py
+++ b/src/fmu/dataio/_utils.py
@@ -7,7 +7,6 @@ import hashlib
 import json
 import os
 import uuid
-from copy import deepcopy
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Any, Final, Literal
@@ -369,32 +368,6 @@ def some_config_from_env(envvar: str = "FMU_GLOBAL_CONFIG") -> dict | None:
 def read_named_envvar(envvar: str) -> str | None:
     """Read a specific (named) environment variable."""
     return os.environ.get(envvar, None)
-
-
-def filter_validate_metadata(metadata_in: dict) -> dict:
-    """Validate metadatadict at topmost_level and strip away any alien keys."""
-
-    valids = [
-        "$schema",
-        "version",
-        "source",
-        "tracklog",
-        "class",
-        "fmu",
-        "file",
-        "data",
-        "display",
-        "access",
-        "masterdata",
-    ]
-
-    metadata = deepcopy(metadata_in)
-
-    for key in metadata_in:
-        if key not in valids:
-            del metadata[key]
-
-    return metadata
 
 
 def generate_description(desc: str | list | None = None) -> list | None:

--- a/src/fmu/dataio/aggregation.py
+++ b/src/fmu/dataio/aggregation.py
@@ -64,7 +64,7 @@ class AggregatedData:
     tagname: str = ""
     verbosity: str = "DEPRECATED"  # keep for while
 
-    _metadata: dict = field(default_factory=dict, init=False)
+    _metadata: internal.DataClassMeta = field(init=False)
     _metafile: Path = field(default_factory=Path, init=False)
 
     def __post_init__(self) -> None:

--- a/tests/test_units/test_aggregated_surfaces.py
+++ b/tests/test_units/test_aggregated_surfaces.py
@@ -20,15 +20,17 @@ def test_regsurf_aggregated(fmurun_w_casemetadata, aggr_surfs_mean):
     aggr_mean, metas = aggr_surfs_mean  # xtgeo_object, list-of-metadata-dicts
     logger.info("Aggr. mean is %s", aggr_mean.values.mean())
 
+    aggregation_uuid = str(utils.uuid_from_string("1234"))
+
     aggdata = dataio.AggregatedData(
         source_metadata=metas,
         operation="mean",
         name="myaggrd",
-        aggregation_id="1234",
+        aggregation_id=aggregation_uuid,
     )
     newmeta = aggdata.generate_metadata(aggr_mean)
     logger.debug("New metadata:\n%s", utils.prettyprint_dict(newmeta))
-    assert newmeta["fmu"]["aggregation"]["id"] == "1234"
+    assert newmeta["fmu"]["aggregation"]["id"] == aggregation_uuid
     assert newmeta["fmu"]["context"]["stage"] == "iteration"
 
 
@@ -46,15 +48,17 @@ def test_regsurf_aggregated_content_seismic(
     aggr_mean, metas = aggr_sesimic_surfs_mean  # xtgeo_object, list-of-metadata-dicts
     logger.info("Aggr. mean is %s", aggr_mean.values.mean())
 
+    aggregation_uuid = str(utils.uuid_from_string("1234"))
+
     aggdata = dataio.AggregatedData(
         source_metadata=metas,
         operation="mean",
         name="myaggrd",
-        aggregation_id="1234",
+        aggregation_id=aggregation_uuid,
     )
     newmeta = aggdata.generate_metadata(aggr_mean)
     logger.debug("New metadata:\n%s", utils.prettyprint_dict(newmeta))
-    assert newmeta["fmu"]["aggregation"]["id"] == "1234"
+    assert newmeta["fmu"]["aggregation"]["id"] == aggregation_uuid
     assert newmeta["fmu"]["context"]["stage"] == "iteration"
 
 
@@ -71,20 +75,25 @@ def test_regsurf_aggregated_export(fmurun_w_casemetadata, aggr_surfs_mean):
     aggr_mean, metas = aggr_surfs_mean  # xtgeo_object, list-of-metadata-dicts
     logger.info("Aggr. mean is %s", aggr_mean.values.mean())
 
+    aggregation_uuid = str(utils.uuid_from_string("1234"))
+
     aggdata = dataio.AggregatedData(
         source_metadata=metas,
         operation="mean",
         name="myaggrd",
         tagname="mean",
-        aggregation_id="1234",
+        aggregation_id=aggregation_uuid,
     )
 
     mypath = aggdata.export(aggr_mean)
 
-    logger.info("Relative path: %s", aggdata._metadata["file"]["relative_path"])
-    logger.info("Absolute path: %s", aggdata._metadata["file"]["absolute_path"])
+    logger.info("Relative path: %s", aggdata._metadata.file.relative_path)
+    logger.info("Absolute path: %s", aggdata._metadata.file.absolute_path)
     logger.debug(
-        "Final metadata after export:\n%s", utils.prettyprint_dict(aggdata._metadata)
+        "Final metadata after export:\n%s",
+        utils.prettyprint_dict(
+            aggdata._metadata.model_dump(mode="json", exclude_none=True, by_alias=True)
+        ),
     )
 
     assert "iter-0/share/results/maps/myaggrd--mean.gri" in mypath
@@ -99,12 +108,14 @@ def test_regsurf_aggregated_alt_keys(fmurun_w_casemetadata, aggr_surfs_mean):
     aggr_mean, metas = aggr_surfs_mean  # xtgeo_object, list-of-metadata-dicts
     logger.info("Aggr. mean is %s", aggr_mean.values.mean())
 
+    aggregation_uuid = str(utils.uuid_from_string("1234"))
+
     meta1 = dataio.AggregatedData(
         source_metadata=metas,
         operation="mean",
         name="myaggrd",
         tagname="mean",
-        aggregation_id="1234",
+        aggregation_id=aggregation_uuid,
     ).generate_metadata(aggr_mean)
 
     # alternative
@@ -114,7 +125,7 @@ def test_regsurf_aggregated_alt_keys(fmurun_w_casemetadata, aggr_surfs_mean):
         operation="mean",
         name="myaggrd",
         tagname="mean",
-        aggregation_id="1234",
+        aggregation_id=aggregation_uuid,
     )
 
     # alternative with export
@@ -125,9 +136,9 @@ def test_regsurf_aggregated_alt_keys(fmurun_w_casemetadata, aggr_surfs_mean):
         operation="mean",
         name="myaggrd",
         tagname="mean",
-        aggregation_id="1234",
+        aggregation_id=aggregation_uuid,
     )
-    meta3 = aggdata3._metadata
+    meta3 = aggdata3._metadata.model_dump(mode="json", exclude_none=True, by_alias=True)
 
     del meta1["tracklog"]
     del meta2["tracklog"]
@@ -152,13 +163,15 @@ def test_regsurf_aggr_export_give_casepath(fmurun_w_casemetadata, aggr_surfs_mea
     aggr_mean, metas = aggr_surfs_mean  # xtgeo_object, list-of-metadata-dicts
     logger.info("Aggr. mean is %s", aggr_mean.values.mean())
 
+    aggregation_uuid = str(utils.uuid_from_string("1234abcd"))
+
     aggdata = dataio.AggregatedData(
         source_metadata=metas,
         casepath=casepath,
         operation="mean",
         name="myaggrd",
         tagname="mean",
-        aggregation_id="1234abcd",
+        aggregation_id=aggregation_uuid,
     )
 
     mypath = aggdata.export(aggr_mean)
@@ -210,12 +223,14 @@ def test_regsurf_aggr_export_abspath_none(fmurun_w_casemetadata, aggr_surfs_mean
     # manipulate first metadata record so mimic abspath is None
     metas[0]["file"]["absolute_path"] = None
 
+    aggregation_uuid = str(utils.uuid_from_string("1234abcd"))
+
     aggdata = dataio.AggregatedData(
         source_metadata=metas,
         operation="mean",
         name="myaggrd",
         tagname="mean",
-        aggregation_id="1234abcd",
+        aggregation_id=aggregation_uuid,
     )
 
     newmeta = aggdata.generate_metadata(aggr_mean)
@@ -257,18 +272,20 @@ def test_regsurf_aggregated_aggregation_id(fmurun_w_casemetadata, aggr_surfs_mea
     assert "id" in newmeta["fmu"]["aggregation"]
     assert newmeta["fmu"]["aggregation"]["id"] != "1234"  # shall be uuid
 
+    aggregation_uuid = str(utils.uuid_from_string("1234"))
+
     # let aggregation_id argument be used as aggregation_id
     aggdata = dataio.AggregatedData(
         source_metadata=metas,
         operation="mean",
         name="myaggrd2",
-        aggregation_id="1234",
+        aggregation_id=aggregation_uuid,
     )
     newmeta = aggdata.generate_metadata(aggr_mean)
     logger.debug("New metadata:\n%s", utils.prettyprint_dict(newmeta))
-    assert newmeta["fmu"]["aggregation"]["id"] == "1234"
+    assert newmeta["fmu"]["aggregation"]["id"] == aggregation_uuid
 
-    # Raise when given aggregation_id is not a string 1
+    # Raise when given aggregation_id is not a uuid string
     with pytest.raises(ValueError):
         aggdata = dataio.AggregatedData(
             source_metadata=metas,
@@ -278,7 +295,7 @@ def test_regsurf_aggregated_aggregation_id(fmurun_w_casemetadata, aggr_surfs_mea
         )
         newmeta = aggdata.generate_metadata(aggr_mean)
 
-    # Raise when given aggregation_id is not a string 2
+    # Raise when given aggregation_id is not a uuid string 2
     with pytest.raises(ValueError):
         aggdata = dataio.AggregatedData(
             source_metadata=metas,
@@ -351,11 +368,13 @@ def test_regsurf_aggregated_diffdata(fmurun_w_casemetadata, rmsglobalconfig, reg
     aggregated = surfs.statistics()
     logger.info("Aggr. mean is %s", aggregated["mean"].values.mean())  # shall be 1238.5
 
+    aggregation_uuid = str(utils.uuid_from_string("789politipoliti"))
+
     aggdata = dataio.AggregatedData(
         source_metadata=metas,
         operation="mean",
         name="myaggrd",
-        aggregation_id="789politipoliti",
+        aggregation_id=aggregation_uuid,
     )
     newmeta = aggdata.generate_metadata(aggregated["mean"])
     logger.info("New metadata:\n%s", utils.prettyprint_dict(newmeta))


### PR DESCRIPTION
Resolves #730 and #693 

Now using Pydantic models in aggregation.py to validate metadata. In addition, the following refactoring and changes has been made:

- The internal method `_generate_aggrd_metadata` has been renamed to `_set_metadata`
- Remove the method `filter_validate_metadata` in `_utils` as validation will be taken care of by Pydantic
- If the validation of the metadata with the Pydantic models fail, we raise an exception
- We do the model_dump only when the metadata is returned. The internal metadata object will be stored as a Pydantic base model
- The input parameter `skip_null` has been deprecated and will always be set to True. A deprecation warning will be raised if it is being used. 

Tests have been updated/fixed to match the new changes and use the correct types as enforced by Pydantic.
