### PR TITLE
ENH: Create enum for tracklog event type

### DIFF
--- a/schema/definitions/0.8.0/schema/fmu_meta.json
+++ b/schema/definitions/0.8.0/schema/fmu_meta.json
@@ -8430,6 +8430,16 @@
       "title": "Timestamp",
       "type": "object"
     },
+    "TrackLogEventType": {
+      "description": "The type of event being logged",
+      "enum": [
+        "created",
+        "updated",
+        "merged"
+      ],
+      "title": "TrackLogEventType",
+      "type": "string"
+    },
     "TracklogEvent": {
       "description": "The ``tracklog`` block contains a record of events recorded on these data.\nThis data object describes a tracklog event.",
       "properties": {
@@ -8442,13 +8452,7 @@
           "type": "string"
         },
         "event": {
-          "examples": [
-            "created",
-            "updated",
-            "merged"
-          ],
-          "title": "Event",
-          "type": "string"
+          "$ref": "#/$defs/TrackLogEventType"
         },
         "sysinfo": {
           "anyOf": [

--- a/src/fmu/dataio/_metadata.py
+++ b/src/fmu/dataio/_metadata.py
@@ -10,13 +10,13 @@ import getpass
 import os
 import platform
 from datetime import timezone
-from typing import TYPE_CHECKING, Final, Literal
+from typing import TYPE_CHECKING, Final
 
 from pydantic import AnyHttpUrl, TypeAdapter
 
 from ._definitions import SCHEMA, SOURCE, VERSION
 from ._logging import null_logger
-from ._model import fields, internal
+from ._model import enums, fields, internal
 from .exceptions import InvalidMetadataError
 from .providers._filedata import FileDataProvider
 from .providers.objectdata._provider import objectdata_provider_factory
@@ -32,7 +32,7 @@ logger: Final = null_logger(__name__)
 
 
 def generate_meta_tracklog(
-    event: Literal["created", "merged"] = "created",
+    event: enums.TrackLogEventType = enums.TrackLogEventType.created,
 ) -> list[fields.TracklogEvent]:
     """Initialize the tracklog with the 'created' event only."""
     return [

--- a/src/fmu/dataio/_model/enums.py
+++ b/src/fmu/dataio/_model/enums.py
@@ -99,3 +99,11 @@ class DomainReference(str, Enum):
     msl = "msl"
     sb = "sb"
     rkb = "rkb"
+
+
+class TrackLogEventType(str, Enum):
+    """The type of event being logged"""
+
+    created = "created"
+    updated = "updated"
+    merged = "merged"

--- a/src/fmu/dataio/_model/fields.py
+++ b/src/fmu/dataio/_model/fields.py
@@ -418,8 +418,8 @@ class TracklogEvent(BaseModel):
     )
     """A datetime representation recording when the event occurred."""
 
-    event: str = Field(examples=["created", "updated", "merged"])
-    """A string containing a reference to the type of event being logged."""
+    event: enums.TrackLogEventType
+    """The type of event being logged. See :class:`enums.TrackLogEventType`."""
 
     user: User
     """The user who caused the event to happen. See :class:`User`."""

--- a/src/fmu/dataio/preprocessed.py
+++ b/src/fmu/dataio/preprocessed.py
@@ -11,7 +11,7 @@ from pydantic import ValidationError
 
 from ._logging import null_logger
 from ._metadata import generate_meta_tracklog
-from ._model import internal
+from ._model import enums, internal
 from ._model.enums import FMUContext
 from ._model.fields import File
 from ._utils import export_metadata_file, md5sum
@@ -185,7 +185,7 @@ class ExportPreprocessedData:
         meta_existing["file"] = self._get_meta_file(objfile, checksum_md5_file)
 
         # update the tracklog block
-        tracklog_entry = generate_meta_tracklog(event="merged")
+        tracklog_entry = generate_meta_tracklog(enums.TrackLogEventType.merged)
         meta_existing["tracklog"].extend(tracklog_entry)
 
         try:

--- a/tests/test_units/test_metadata_class.py
+++ b/tests/test_units/test_metadata_class.py
@@ -11,6 +11,7 @@ from fmu.dataio._metadata import (
     VERSION,
     generate_export_metadata,
 )
+from fmu.dataio._model import enums
 from fmu.dataio._model.fields import (
     OperatingSystem,
     TracklogEvent,
@@ -47,10 +48,10 @@ def test_generate_meta_tracklog_fmu_dataio_version(regsurf, edataobj1):
     tracklog = mymeta.tracklog
 
     assert isinstance(tracklog, list)
-    assert len(tracklog) == 1  # assume "created"
+    assert len(tracklog) == 1  # assume enums.TrackLogEventType.created
 
     parsed = TracklogEvent.model_validate(tracklog[0])
-    assert parsed.event == "created"
+    assert parsed.event == enums.TrackLogEventType.created
 
     # datetime in tracklog shall include time zone offset
     assert parsed.datetime.tzinfo is not None
@@ -70,10 +71,10 @@ def test_generate_meta_tracklog_komodo_version(edataobj1, regsurf, monkeypatch):
     tracklog = mymeta.tracklog
 
     assert isinstance(tracklog, list)
-    assert len(tracklog) == 1  # assume "created"
+    assert len(tracklog) == 1  # assume enums.TrackLogEventType.created
 
     parsed = TracklogEvent.model_validate(tracklog[0])
-    assert parsed.event == "created"
+    assert parsed.event == enums.TrackLogEventType.created
 
     # datetime in tracklog shall include time zone offset
     assert parsed.datetime.tzinfo is not None
@@ -90,7 +91,7 @@ def test_generate_meta_tracklog_operating_system(edataobj1, regsurf):
     tracklog = mymeta.tracklog
 
     assert isinstance(tracklog, list)
-    assert len(tracklog) == 1  # assume "created"
+    assert len(tracklog) == 1  # assume enums.TrackLogEventType.created
 
     parsed = TracklogEvent.model_validate(tracklog[0])
     assert isinstance(


### PR DESCRIPTION
Resolves first task in #662 

Create an enum `TracelogEventTypes` for the three valid event types of the `TracklogEvent` module: 
* `created`
* `updated`
*  or `merged`

and use that as the type for the field `event`.