### PR TITLE
ENH: Represent the metadata tracklog as a Pydantic RootModel `Tracklog`

### DIFF
--- a/schema/definitions/0.8.0/schema/fmu_meta.json
+++ b/schema/definitions/0.8.0/schema/fmu_meta.json
@@ -8433,7 +8433,7 @@
       "type": "string"
     },
     "Tracklog": {
-      "description": "The ``tracklog`` block contains a record of events recorded on these data.\nThis data object describes the list of tracklog events, in addition to functionality\nfor consturcting a tracklog and adding new records to it.",
+      "description": "The ``tracklog`` block contains a record of events recorded on these data.\nThis data object describes the list of tracklog events, in addition to functionality\nfor constructing a tracklog and adding new records to it.",
       "items": {
         "$ref": "#/$defs/TracklogEvent"
       },

--- a/schema/definitions/0.8.0/schema/fmu_meta.json
+++ b/schema/definitions/0.8.0/schema/fmu_meta.json
@@ -440,11 +440,7 @@
           "title": "Source"
         },
         "tracklog": {
-          "items": {
-            "$ref": "#/$defs/TracklogEvent"
-          },
-          "title": "Tracklog",
-          "type": "array"
+          "$ref": "#/$defs/Tracklog"
         },
         "version": {
           "const": "0.8.0",
@@ -4234,11 +4230,7 @@
           "title": "Source"
         },
         "tracklog": {
-          "items": {
-            "$ref": "#/$defs/TracklogEvent"
-          },
-          "title": "Tracklog",
-          "type": "array"
+          "$ref": "#/$defs/Tracklog"
         },
         "version": {
           "const": "0.8.0",
@@ -8439,6 +8431,14 @@
       ],
       "title": "TrackLogEventType",
       "type": "string"
+    },
+    "Tracklog": {
+      "description": "The ``tracklog`` block contains a record of events recorded on these data.\nThis data object describes the list of tracklog events, in addition to functionality\nfor consturcting a tracklog and adding new records to it.",
+      "items": {
+        "$ref": "#/$defs/TracklogEvent"
+      },
+      "title": "Tracklog",
+      "type": "array"
     },
     "TracklogEvent": {
       "description": "The ``tracklog`` block contains a record of events recorded on these data.\nThis data object describes a tracklog event.",

--- a/src/fmu/dataio/_metadata.py
+++ b/src/fmu/dataio/_metadata.py
@@ -118,7 +118,7 @@ def generate_export_metadata(
         access=_get_meta_access(dataio),
         data=objdata.get_metadata(),
         file=_get_meta_filedata(dataio, obj, objdata, fmudata, compute_md5),
-        tracklog=fields.Tracklog.initialize_metadata_tracklog(),
+        tracklog=fields.Tracklog.initialize(),
         display=_get_meta_display(dataio, objdata),
         preprocessed=dataio.preprocessed,
     )

--- a/src/fmu/dataio/_model/fields.py
+++ b/src/fmu/dataio/_model/fields.py
@@ -421,7 +421,7 @@ class SystemInformation(BaseModel):
 class Tracklog(RootModel):
     """The ``tracklog`` block contains a record of events recorded on these data.
     This data object describes the list of tracklog events, in addition to functionality
-    for consturcting a tracklog and adding new records to it.
+    for constructing a tracklog and adding new records to it.
     """
 
     root: List[TracklogEvent]
@@ -437,19 +437,17 @@ class Tracklog(RootModel):
         return iter(self.root)
 
     @classmethod
-    def initialize_metadata_tracklog(cls) -> Tracklog:
-        """Initialize the tracklog object with a list of TracklogEvents
-        with event type 'created'"""
-        return cls(
-            cls._generate_metadata_tracklog_events(enums.TrackLogEventType.created)
-        )
+    def initialize(cls) -> Tracklog:
+        """Initialize the tracklog object with a list containing one
+        TracklogEvent of type 'created'"""
+        return cls(cls._generate_tracklog_events(enums.TrackLogEventType.created))
 
     def extend(self, event: enums.TrackLogEventType) -> None:
         """Extend the tracklog with a new tracklog record."""
-        self.root.extend(self._generate_metadata_tracklog_events(event))
+        self.root.extend(self._generate_tracklog_events(event))
 
     @staticmethod
-    def _generate_metadata_tracklog_events(
+    def _generate_tracklog_events(
         event: enums.TrackLogEventType,
     ) -> list[fields.TracklogEvent]:
         """Generate new tracklog events with the given event type"""

--- a/src/fmu/dataio/_model/internal.py
+++ b/src/fmu/dataio/_model/internal.py
@@ -164,7 +164,7 @@ class DataClassMeta(JsonSchemaMetadata):
     data: Union[data.AnyData, UnsetAnyContent]
     file: fields.File
     display: fields.Display
-    tracklog: List[fields.TracklogEvent]
+    tracklog: fields.Tracklog
     preprocessed: Optional[bool] = Field(alias="_preprocessed", default=None)
 
 
@@ -174,4 +174,4 @@ class CaseSchema(JsonSchemaMetadata):
     access: fields.Access
     fmu: FMUModelCase
     description: Optional[List[str]] = Field(default=None)
-    tracklog: List[fields.TracklogEvent]
+    tracklog: fields.Tracklog

--- a/src/fmu/dataio/_model/root.py
+++ b/src/fmu/dataio/_model/root.py
@@ -22,7 +22,7 @@ from .fields import (
     FMUBase,
     Masterdata,
     SsdlAccess,
-    TracklogEvent,
+    Tracklog,
 )
 
 if TYPE_CHECKING:
@@ -41,9 +41,9 @@ class MetadataBase(BaseModel):
     """The ``masterdata`` block contains information related to masterdata.
     See :class:`Masterdata`."""
 
-    tracklog: List[TracklogEvent]
+    tracklog: Tracklog
     """The ``tracklog`` block contains a record of events recorded on these data.
-    See :class:`TracklogEvent`."""
+    See :class:`Tracklog`."""
 
     source: Literal["fmu"]
     """The source of this data. Defaults to 'fmu'."""

--- a/src/fmu/dataio/aggregation.py
+++ b/src/fmu/dataio/aggregation.py
@@ -8,9 +8,10 @@ from typing import ClassVar, Final, Literal, Optional, Union
 
 from pydantic import ValidationError
 
+from fmu.dataio._model import fields
+
 from . import _utils, dataio, types
 from ._logging import null_logger
-from ._metadata import generate_meta_tracklog
 from ._model import internal
 from ._model.enums import FMUContext
 from .exceptions import InvalidMetadataError
@@ -253,7 +254,7 @@ class AggregatedData:
 
         objdata = objectdata_provider_factory(obj=obj, dataio=etemp)
 
-        template["tracklog"] = [generate_meta_tracklog()[0]]
+        template["tracklog"] = [fields.Tracklog.initialize_metadata_tracklog()[0]]
         template["file"] = {
             "relative_path": str(relpath),
             "absolute_path": str(abspath) if abspath else None,

--- a/src/fmu/dataio/aggregation.py
+++ b/src/fmu/dataio/aggregation.py
@@ -254,7 +254,7 @@ class AggregatedData:
 
         objdata = objectdata_provider_factory(obj=obj, dataio=etemp)
 
-        template["tracklog"] = [fields.Tracklog.initialize_metadata_tracklog()[0]]
+        template["tracklog"] = [fields.Tracklog.initialize()[0]]
         template["file"] = {
             "relative_path": str(relpath),
             "absolute_path": str(abspath) if abspath else None,

--- a/src/fmu/dataio/case.py
+++ b/src/fmu/dataio/case.py
@@ -132,7 +132,7 @@ class CreateCaseMetadata:  # pylint: disable=too-few-public-methods
                     description=None,
                 ),
             ),
-            tracklog=fields.Tracklog.initialize_metadata_tracklog(),
+            tracklog=fields.Tracklog.initialize(),
             description=_utils.generate_description(self.description),
         ).model_dump(
             mode="json",

--- a/src/fmu/dataio/case.py
+++ b/src/fmu/dataio/case.py
@@ -9,7 +9,9 @@ from typing import ClassVar, Final, Literal, Optional, Union
 
 from pydantic import ValidationError
 
-from . import _metadata, _utils
+from fmu.dataio._model import fields
+
+from . import _utils
 from ._logging import null_logger
 from ._model import global_configuration, internal
 from ._model.fields import Access, Case, Masterdata, Model, User
@@ -130,7 +132,7 @@ class CreateCaseMetadata:  # pylint: disable=too-few-public-methods
                     description=None,
                 ),
             ),
-            tracklog=_metadata.generate_meta_tracklog(),
+            tracklog=fields.Tracklog.initialize_metadata_tracklog(),
             description=_utils.generate_description(self.description),
         ).model_dump(
             mode="json",

--- a/src/fmu/dataio/preprocessed.py
+++ b/src/fmu/dataio/preprocessed.py
@@ -10,7 +10,6 @@ import yaml
 from pydantic import ValidationError
 
 from ._logging import null_logger
-from ._metadata import generate_meta_tracklog
 from ._model import enums, internal
 from ._model.enums import FMUContext
 from ._model.fields import File
@@ -184,14 +183,12 @@ class ExportPreprocessedData:
         meta_existing["fmu"] = self._fmudata.get_metadata()
         meta_existing["file"] = self._get_meta_file(objfile, checksum_md5_file)
 
-        # update the tracklog block
-        tracklog_entry = generate_meta_tracklog(enums.TrackLogEventType.merged)
-        meta_existing["tracklog"].extend(tracklog_entry)
-
         try:
             # TODO: Would like to use meta.Root.model_validate() here
             # but then the '$schema' field is dropped from the meta_existing
-            return internal.DataClassMeta.model_validate(meta_existing).model_dump(
+            validated_metadata = internal.DataClassMeta.model_validate(meta_existing)
+            validated_metadata.tracklog.extend(enums.TrackLogEventType.merged)
+            return validated_metadata.model_dump(
                 mode="json", exclude_none=True, by_alias=True
             )
         except ValidationError as err:

--- a/tests/test_units/test_metadata_class.py
+++ b/tests/test_units/test_metadata_class.py
@@ -47,8 +47,8 @@ def test_generate_meta_tracklog_fmu_dataio_version(regsurf, edataobj1):
     mymeta = generate_export_metadata(regsurf, edataobj1)
     tracklog = mymeta.tracklog
 
-    assert isinstance(tracklog, list)
-    assert len(tracklog) == 1  # assume enums.TrackLogEventType.created
+    assert isinstance(tracklog.root, list)
+    assert len(tracklog.root) == 1  # assume enums.TrackLogEventType.created
 
     parsed = TracklogEvent.model_validate(tracklog[0])
     assert parsed.event == enums.TrackLogEventType.created
@@ -70,8 +70,8 @@ def test_generate_meta_tracklog_komodo_version(edataobj1, regsurf, monkeypatch):
     mymeta = generate_export_metadata(regsurf, edataobj1)
     tracklog = mymeta.tracklog
 
-    assert isinstance(tracklog, list)
-    assert len(tracklog) == 1  # assume enums.TrackLogEventType.created
+    assert isinstance(tracklog.root, list)
+    assert len(tracklog.root) == 1  # assume enums.TrackLogEventType.created
 
     parsed = TracklogEvent.model_validate(tracklog[0])
     assert parsed.event == enums.TrackLogEventType.created
@@ -90,8 +90,8 @@ def test_generate_meta_tracklog_operating_system(edataobj1, regsurf):
     mymeta = generate_export_metadata(regsurf, edataobj1)
     tracklog = mymeta.tracklog
 
-    assert isinstance(tracklog, list)
-    assert len(tracklog) == 1  # assume enums.TrackLogEventType.created
+    assert isinstance(tracklog.root, list)
+    assert len(tracklog.root) == 1  # assume enums.TrackLogEventType.created
 
     parsed = TracklogEvent.model_validate(tracklog[0])
     assert isinstance(


### PR DESCRIPTION
Resolves #662 

Represent the metadata tracklog as a Pydantic RootModel with the name `Tracklog`.

A new class `Tracklog` has been created which inherits the Pydantic class `RootModel`. The new class `Tracklock` encapsulates:
* The list of tracklog events as the root property of the `RootModel`
* Functionality for constructing a tracklog and adding new records to it. 
* Dunder methods `__getitem__` and `__iter__` for getting and iterate over the items of the list in the `RootModel`

Tests have been updated accordingly.