### PR TITLE
BLD: Pin package pyarrow-stubs to version 10.0.1.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dev = [
     "hypothesis",
     "mypy",
     "pandas-stubs",
-    "pyarrow-stubs",
+    "pyarrow-stubs==10.0.1.9",
     "pydocstyle",
     "pytest-cov",
     "pytest-mock",


### PR DESCRIPTION
Pin package of `pyarrow-stubs` to version `10.0.1.9` as we are waiting for the latest version to be stable. 

There seems to be an issue in the latest release of `pyarrow-stubs` that is causing the mypy check of the CI to fail.

Have pinned the version to version "10.0.1.9" now until the latest version is stable. 