### PR TITLE
FIX: Do not convert alias as string to list of characters

### DIFF
--- a/src/fmu/dataio/_model/global_configuration.py
+++ b/src/fmu/dataio/_model/global_configuration.py
@@ -98,9 +98,26 @@ class StratigraphyElement(BaseModel):
 
     @field_validator("alias", "stratigraphic_alias", mode="before")
     @classmethod
-    def _prune_nones(cls, values: Any) -> Any:
-        # For backwards compatibility.
-        return None if values is None else [v for v in values if v is not None]
+    def _prune_nones_and_adjust_input(cls, values: Any) -> Any:
+        # For backwards compatibility, remove after a deprecation period
+        if isinstance(values, list) and not all(values):
+            warnings.warn(
+                "The global config contains an empty list element in one of the "
+                "'alias' fields in the 'stratigraphy' section. Please remove the empty "
+                "element, and be aware that this will not be supported in the future.",
+                FutureWarning,
+            )
+            return [v for v in values if v is not None]
+
+        if isinstance(values, str):
+            warnings.warn(
+                "The global config contains string input for one of the 'alias' fields "
+                "in the 'stratigraphy' section. Please convert to a list instead as "
+                "this will not be supported in the future.",
+                FutureWarning,
+            )
+            return [values]
+        return values
 
 
 class Stratigraphy(RootModel[Dict[str, StratigraphyElement]]):

--- a/tests/test_units/test_dataio.py
+++ b/tests/test_units/test_dataio.py
@@ -83,12 +83,28 @@ def test_config_miss_required_fields(monkeypatch, tmp_path, globalconfig1, regsu
         read_metadata(out)
 
 
+def test_config_stratigraphy_alias_as_string(globalconfig2):
+    """
+    Test that 'alias' as string gives FutureWarning and is
+    correctly converted to a list.
+    """
+    cfg = deepcopy(globalconfig2)
+    cfg["stratigraphy"]["TopVolantis"]["alias"] = "TV"
+
+    with pytest.warns(FutureWarning, match="string input"):
+        exp = ExportData(config=cfg, content="depth", name="TopVolantis")
+
+    assert exp._config_is_valid
+    assert exp.config["stratigraphy"]["TopVolantis"]["alias"] == ["TV"]
+
+
 def test_config_stratigraphy_empty_entries_alias(globalconfig2, regsurf):
     """Test that empty entries in 'alias' is detected and warned and removed."""
     cfg = deepcopy(globalconfig2)
     cfg["stratigraphy"]["TopVolantis"]["alias"] += [None]
 
-    exp = ExportData(config=cfg, content="depth", name="TopVolantis")
+    with pytest.warns(FutureWarning, match="empty list element"):
+        exp = ExportData(config=cfg, content="depth", name="TopVolantis")
     metadata = exp.generate_metadata(regsurf)
 
     assert None not in metadata["data"]["alias"]
@@ -103,7 +119,8 @@ def test_config_stratigraphy_empty_entries_stratigraphic_alias(globalconfig2, re
     cfg = deepcopy(globalconfig2)
     cfg["stratigraphy"]["TopVolantis"]["stratigraphic_alias"] += [None]
 
-    exp = ExportData(config=cfg, content="depth")
+    with pytest.warns(FutureWarning, match="empty list element"):
+        exp = ExportData(config=cfg, content="depth")
     metadata = exp.generate_metadata(regsurf)
 
     assert None not in metadata["data"]["stratigraphic_alias"]


### PR DESCRIPTION
Resolves #775 

Also added deprecation warnings so that we in the future can get rid of the entire `field_validator` here