### PR TITLE
MAINT: Replace global_configuration.Asset with fields.Asset

### DIFF
--- a/src/fmu/dataio/_model/global_configuration.py
+++ b/src/fmu/dataio/_model/global_configuration.py
@@ -48,20 +48,12 @@ class Ssdl(BaseModel):
     rep_include: Optional[bool] = Field(default=None)
 
 
-class Asset(BaseModel):
-    """
-    Represents an asset configuration with a name.
-    """
-
-    name: str
-
-
 class Access(BaseModel, use_enum_values=True):
     """
     Manages access configurations, combining asset and SSDL information.
     """
 
-    asset: Asset
+    asset: fields.Asset
     ssdl: Optional[Ssdl] = Field(default=None)
     classification: Optional[enums.Classification] = Field(default=None)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -321,7 +321,7 @@ def fixture_globalconfig1():
             )
         ),
         access=global_configuration.Access(
-            asset=global_configuration.Asset(name="Test"),
+            asset=fields.Asset(name="Test"),
             classification=global_configuration.enums.Classification.internal,
         ),
         model=fields.Model(


### PR DESCRIPTION
Replace duplicate pydantic `global_configuration.Asset` with `fields.Asset` 