### PR TITLE
MAINT: Unpin pyarrow-stubs package version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dev = [
     "hypothesis",
     "mypy",
     "pandas-stubs",
-    "pyarrow-stubs==10.0.1.9",
+    "pyarrow-stubs",
     "pydocstyle",
     "pytest-cov",
     "pytest-mock",


### PR DESCRIPTION
Resolves #770 

Unpin pyarrow-stubs package version.

In PR https://github.com/equinor/fmu-dataio/pull/769 the version of 'pyarrow-subs' was pinned to version 10.0.1.9 as the latest version was not stable. A new stable version has now been released and hence the package version has been unpinned. 