### PR TITLE
DEP: Change to deprecation warning for content not provided

### DIFF
--- a/docs/src/dataio_3_migration.rst
+++ b/docs/src/dataio_3_migration.rst
@@ -20,6 +20,7 @@ but with replacements inplace.
    a dictionary form to provide a reference together with the ``vertical_domain`` is deprecated, use 
    the ``domain_reference`` argument instead.
  - ``workflow`` now only supports string input, example ``workflow='Structural modelling'``.
+ - ``content`` was previously optional, it should now be explicitly provided.
  - ``content={'seismic': {'offset': '0-15'}}`` no longer works, use the key ``stacking_offset`` instead 
    of ``offset``.
 
@@ -44,6 +45,7 @@ Change to this instead 👇:
     from fmu.dataio import ExportData
 
     ExportData(
+        content='depth', # ✅ content must explicitly be provided
         preprocessed=True, # ✅
         classification='restricted', # ✅ note the use of 'restricted' instead of 'asset'
         rep_include=True, # ✅

--- a/src/fmu/dataio/_model/schema.py
+++ b/src/fmu/dataio/_model/schema.py
@@ -121,10 +121,10 @@ class InternalUnsetData(data.Data):
         valid_contents = [m.value for m in enums.Content]
         warnings.warn(
             "The <content> is not provided which will produce invalid metadata. "
-            "It is strongly recommended that content is given explicitly! "
+            "In the future 'content' will be required explicitly! "
             f"\n\nValid contents are: {', '.join(valid_contents)} "
             "\n\nThis list can be extended upon request and need.",
-            UserWarning,
+            FutureWarning,
         )
         return self
 

--- a/tests/test_units/test_dataio.py
+++ b/tests/test_units/test_dataio.py
@@ -330,7 +330,7 @@ def test_unit_is_none(globalconfig1, regsurf):
 def test_content_not_given(globalconfig1, regsurf):
     """When content is not explicitly given, warning shall be issued."""
     eobj = ExportData(config=globalconfig1)
-    with pytest.warns(UserWarning, match="The <content> is not provided"):
+    with pytest.warns(FutureWarning, match="The <content> is not provided"):
         mymeta = eobj.generate_metadata(regsurf)
 
     assert mymeta["data"]["content"] == "unset"


### PR DESCRIPTION
PR to change to a deprecation warning for `content=None` and document it in the migration guide.