### PR TITLE
ENH: Do not call generate_metadata() on export when config is not valid

### DIFF
--- a/docs/src/dataio_3_migration.rst
+++ b/docs/src/dataio_3_migration.rst
@@ -197,6 +197,14 @@ Additionally
  - The ``return_symlink`` argument to ``export()`` is deprecated. It is redundant and can be removed.
 
 
+Getting partial metadata from generate_metadata() when config is invalid
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+It was previously possible to get partial metadata from ``generate_metadata()``
+when the global config file was invalid. This partial metadata was not valid according
+to the datamodel and could not be uploaded to Sumo. Creating invalid metadata is no
+longer supported, if the config is invalid an empty dictionary is returned instead.
+
+
 Providing settings through environment
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 It was previously possible to have a yml-file specifying global input arguments to 

--- a/src/fmu/dataio/_utils.py
+++ b/src/fmu/dataio/_utils.py
@@ -90,6 +90,9 @@ def export_file(
 ) -> str:
     """Export a valid object to file"""
 
+    # create output folder if not existing
+    filename.parent.mkdir(parents=True, exist_ok=True)
+
     if filename.suffix == ".gri" and isinstance(obj, xtgeo.RegularSurface):
         obj.to_file(filename, fformat="irap_binary")
     elif filename.suffix == ".csv" and isinstance(obj, (xtgeo.Polygons, xtgeo.Points)):

--- a/tests/test_units/test_preprocessed.py
+++ b/tests/test_units/test_preprocessed.py
@@ -317,10 +317,7 @@ def test_export_preprocessed_file_exportdata_casepath_on_export(
         edata = dataio.ExportData(config=rmsglobalconfig, is_observation=True)
 
     # test that error is thrown when missing casepath
-    # (UserWarning initially in ExportData)
-    with pytest.warns(UserWarning, match="case metadata"), pytest.raises(
-        TypeError, match="No 'casepath' argument provided"
-    ):
+    with pytest.raises(TypeError, match="No 'casepath' argument provided"):
         edata.export(surfacepath)
 
     # test that export() works if casepath is provided


### PR DESCRIPTION
Closes #602 

- Added a new function to get the export path of an object without having to fetch it from the metadata. This is used when invoking the `export` function and the config is not valid (i.e. no metadata should be exported)
- Added deprecation warning for the `generate_metadata` function saying in the future no metadata will be returned if the config is invalid
  - once the deprecation period has ended we can remove checks of the validity of the config inside the `generate_export_metadata,` and remove `masterdata` and `access` as optional fields in the pydantic model used to generate metadata.

