### PR TITLE
FIX: Give Optionals a default value

### DIFF
--- a/schema/definitions/0.8.0/schema/fmu_results.json
+++ b/schema/definitions/0.8.0/schema/fmu_results.json
@@ -5487,6 +5487,7 @@
               "type": "null"
             }
           ],
+          "default": null,
           "title": "Attributes"
         },
         "size": {
@@ -5499,7 +5500,6 @@
         }
       },
       "required": [
-        "attributes",
         "size"
       ],
       "title": "PointSpecification",
@@ -7792,6 +7792,7 @@
               "type": "null"
             }
           ],
+          "default": null,
           "examples": [
             1,
             9999
@@ -7807,6 +7808,7 @@
               "type": "null"
             }
           ],
+          "default": null,
           "examples": [
             1,
             9999
@@ -7824,8 +7826,6 @@
       },
       "required": [
         "columns",
-        "num_columns",
-        "num_rows",
         "size"
       ],
       "title": "TableSpecification",

--- a/src/fmu/dataio/_model/data.py
+++ b/src/fmu/dataio/_model/data.py
@@ -46,10 +46,10 @@ class Time(BaseModel):
 
     .. note:: ``data.time`` items can currently hold a maximum of two values."""
 
-    t0: Optional[Timestamp] = None
+    t0: Optional[Timestamp] = Field(default=None)
     """The first timestamp. See :class:`Timestamp`."""
 
-    t1: Optional[Timestamp] = None
+    t1: Optional[Timestamp] = Field(default=None)
     """The second timestamp. See :class:`Timestamp`."""
 
 
@@ -65,16 +65,16 @@ class Seismic(BaseModel):
     calculation: Optional[str] = Field(default=None, examples=["mean"])
     """The type of calculation applied."""
 
-    filter_size: Optional[float] = Field(allow_inf_nan=False, default=None)
+    filter_size: Optional[float] = Field(default=None, allow_inf_nan=False)
     """The filter size applied."""
 
-    scaling_factor: Optional[float] = Field(allow_inf_nan=False, default=None)
+    scaling_factor: Optional[float] = Field(default=None, allow_inf_nan=False)
     """The scaling factor applied."""
 
     stacking_offset: Optional[str] = Field(default=None, examples=["0-15"])
     """The stacking offset applied."""
 
-    zrange: Optional[float] = Field(allow_inf_nan=False, default=None)
+    zrange: Optional[float] = Field(default=None, allow_inf_nan=False)
     """The z-range of these data."""
 
 
@@ -305,13 +305,13 @@ class Data(BaseModel):
     """Column names in the table which can be used for indexing. Only applicable if the
     data object is a table."""
 
-    base: Optional[Layer] = None
+    base: Optional[Layer] = Field(default=None)
     """If the data represent an interval, this field can be used to represent its base.
     See :class:`Layer`.
 
     .. note:: ``top`` is required to use with this."""
 
-    top: Optional[Layer] = None
+    top: Optional[Layer] = Field(default=None)
     """If the data represent an interval, this field can be used to represent its top.
     See :class:`Layer`.
 

--- a/src/fmu/dataio/_model/specification.py
+++ b/src/fmu/dataio/_model/specification.py
@@ -52,7 +52,7 @@ class SurfaceSpecification(RowColumn):
 class PointSpecification(BaseModel):
     """Specifies relevant values describing an xyz points object."""
 
-    attributes: Optional[List[str]]
+    attributes: Optional[List[str]] = Field(default=None)
     """List of columns present in a table."""
 
     size: int = Field(examples=[1, 9999])
@@ -65,10 +65,10 @@ class TableSpecification(BaseModel):
     columns: List[str]
     """List of columns present in a table."""
 
-    num_columns: Optional[int] = Field(examples=[1, 9999])
+    num_columns: Optional[int] = Field(default=None, examples=[1, 9999])
     """The number of columns in a table."""
 
-    num_rows: Optional[int] = Field(examples=[1, 9999])
+    num_rows: Optional[int] = Field(default=None, examples=[1, 9999])
     """The number of rows in a table.."""
 
     size: int = Field(examples=[1, 9999])


### PR DESCRIPTION
Resolves #814 
Resolves #815 

I still have a bit uncertainty about some fields. In some cases we give optional lists a default value of an empty list, in some cases it's `null`.

A few instances I added the `Field` or sorted the keyword arguments to it to make the default show first.

I'm working on a test that will run through all the models and fail if an optional doesn't provide a default value... but figured I can put this up before that is working.