### PR TITLE
TST: Suppress Pydantic serializer warning

### DIFF
--- a/tests/test_units/test_dataio.py
+++ b/tests/test_units/test_dataio.py
@@ -419,6 +419,7 @@ def test_unit_is_none(globalconfig1, regsurf):
     assert meta["data"]["unit"] == ""
 
 
+@pytest.mark.filterwarnings("ignore:Pydantic serializer warnings")
 def test_content_not_given(globalconfig1, regsurf):
     """When content is not explicitly given, warning shall be issued."""
     eobj = ExportData(config=globalconfig1)


### PR DESCRIPTION
Resolves #790 

This test issues serialization warnings because we are serializing `InternalUnsetData` through `AnyData` which does not expect to do so. It is a valid warning, but will persist until creating `content="unset"` metadata is fully removed.