### PR TITLE
BLD: Pin sphinx-rtd-theme<3.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ docs = [
     "myst-parser",
     "pydocstyle",
     "sphinx-autodoc-typehints<1.23",
-    "sphinx-rtd-theme",
+    "sphinx-rtd-theme<3.0.0",
     "sphinx-togglebutton",
     "Sphinx",
     "sphinxcontrib-apidoc",


### PR DESCRIPTION
The `sphinx-rtd-theme 3.0.0` causes documentation build to fail #836 

Not sure why yet, but to get tests to pass we should pin the version while investigating.