### PR TITLE
FIX: Set file.checksum_md5 non optional

### DIFF
--- a/schema/definitions/0.8.0/schema/fmu_results.json
+++ b/schema/definitions/0.8.0/schema/fmu_results.json
@@ -2859,18 +2859,11 @@
           "title": "Absolute Path Symlink"
         },
         "checksum_md5": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
           "examples": [
             "kjhsdfvsdlfk23knerknvk23"
           ],
-          "title": "Checksum Md5"
+          "title": "Checksum Md5",
+          "type": "string"
         },
         "relative_path": {
           "examples": [

--- a/src/fmu/dataio/_model/fields.py
+++ b/src/fmu/dataio/_model/fields.py
@@ -103,7 +103,7 @@ class File(BaseModel):
     )
     """The path of a file relative to the case root."""
 
-    checksum_md5: Optional[str] = Field(examples=["kjhsdfvsdlfk23knerknvk23"])
+    checksum_md5: str = Field(examples=["kjhsdfvsdlfk23knerknvk23"])
     """A valid MD5 checksum of the file."""
 
     size_bytes: Optional[int] = Field(default=None)


### PR DESCRIPTION
PR to set `file.checksum_md5` non optional. It was non optional in the legacy schema, and was introduced in https://github.com/equinor/fmu-dataio/pull/512/files, probably by mistake.

Closes #835 