### PR TITLE
DEP: Always compute md5 for aggregated objects

### DIFF
--- a/docs/src/dataio_3_migration.rst
+++ b/docs/src/dataio_3_migration.rst
@@ -303,7 +303,9 @@ Changes to input arguments
 
 Changes to method arguments  
  - The ``skip_null`` argument to ``generate_metadata()`` is deprecated. It is redundant and can be removed.
-
+ - The ``compute_md5`` argument to ``generate_metadata()`` is deprecated and can be removed, as 
+   an MD5 checksum is always computed by default.
+   
 Deprecated methods
  - The ``generate_aggregation_metadata()`` method is deprecated. Replace it with the identical 
    ``generate_metadata()`` method instead.

--- a/src/fmu/dataio/aggregation.py
+++ b/src/fmu/dataio/aggregation.py
@@ -210,6 +210,14 @@ class AggregatedData:
             type(self.aggregation_id),
         )
 
+        if not compute_md5:
+            warnings.warn(
+                "Using the 'compute_md5=False' option to prevent an MD5 checksum "
+                "from being computed is now deprecated. This option has no longer "
+                "an effect and will be removed in the near future.",
+                UserWarning,
+            )
+
         if self.aggregation_id is None:
             self.aggregation_id = self._generate_aggr_uuid(uuids)
         else:
@@ -258,11 +266,7 @@ class AggregatedData:
         template["file"] = {
             "relative_path": str(relpath),
             "absolute_path": str(abspath) if abspath else None,
-            "checksum_md5": (
-                None
-                if not compute_md5
-                else _utils.compute_md5_using_temp_file(obj, objdata.extension)
-            ),
+            "checksum_md5": _utils.compute_md5_using_temp_file(obj, objdata.extension),
         }
 
         # data section


### PR DESCRIPTION
PR that changes to always calculate an MD5 sum for aggregated objects.
This was recently done for exports through `ExportData` in #844

Addresses #842