### PR TITLE
ENH: Calculate hashes in memory

### DIFF
--- a/src/fmu/dataio/aggregation.py
+++ b/src/fmu/dataio/aggregation.py
@@ -262,11 +262,20 @@ class AggregatedData:
 
         objdata = objectdata_provider_factory(obj=obj, dataio=etemp)
 
+        try:
+            checksum_md5 = _utils.compute_md5(obj, objdata.extension)
+        except Exception as e:
+            logger.debug(
+                f"Exception {e} occured when trying to compute md5 from memory stream "
+                f"for an object of type {type(obj)}. Will use tempfile instead."
+            )
+            checksum_md5 = _utils.compute_md5_using_temp_file(obj, objdata.extension)
+
         template["tracklog"] = [fields.Tracklog.initialize()[0]]
         template["file"] = {
             "relative_path": str(relpath),
             "absolute_path": str(abspath) if abspath else None,
-            "checksum_md5": _utils.compute_md5_using_temp_file(obj, objdata.extension),
+            "checksum_md5": checksum_md5,
         }
 
         # data section

--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -821,7 +821,8 @@ class ExportData:
         ).get_metadata()
 
         assert filemeta.absolute_path is not None  # for mypy
-        return export_file(obj, filename=filemeta.absolute_path, fmt=objdata.fmt)
+        export_file(obj, file=filemeta.absolute_path, fmt=objdata.fmt)
+        return str(filemeta.absolute_path)
 
     # ==================================================================================
     # Public methods:

--- a/src/fmu/dataio/providers/_filedata.py
+++ b/src/fmu/dataio/providers/_filedata.py
@@ -15,9 +15,7 @@ from typing import TYPE_CHECKING, Final
 
 from fmu.dataio._logging import null_logger
 from fmu.dataio._model import enums, fields
-from fmu.dataio._utils import (
-    compute_md5_using_temp_file,
-)
+from fmu.dataio._utils import compute_md5, compute_md5_using_temp_file
 
 from ._base import Provider
 
@@ -108,11 +106,20 @@ class FileDataProvider(Provider):
 
     def _compute_md5(self) -> str:
         """Compute an MD5 sum using a temporary file."""
-        if self.obj is None:
-            raise ValueError("Can't compute MD5 sum without an object.")
-        return compute_md5_using_temp_file(
-            self.obj, self.objdata.extension, fmt=self.objdata.fmt
-        )
+        try:
+            return compute_md5(
+                obj=self.obj,
+                file_suffix=self.objdata.extension,
+                fmt=self.objdata.fmt,
+            )
+        except Exception as e:
+            logger.debug(
+                f"Exception {e} occured when trying to compute md5 from memory stream "
+                f"for an object of type {type(self.obj)}. Will use tempfile instead."
+            )
+            return compute_md5_using_temp_file(
+                self.obj, self.objdata.extension, fmt=self.objdata.fmt
+            )
 
     def _add_filename_to_path(self, path: Path) -> Path:
         stem = self._get_filestem()

--- a/tests/test_units/test_checksum_md5.py
+++ b/tests/test_units/test_checksum_md5.py
@@ -1,0 +1,204 @@
+from pathlib import Path
+
+import fmu.dataio.readers as readers
+from fmu.dataio._utils import md5sum
+from fmu.dataio.dataio import ExportData, read_metadata
+
+
+def test_checksum_md5_for_regsurf(monkeypatch, tmp_path, globalconfig1, regsurf):
+    """
+    Test that the MD5 hash in the metadata is equal to one computed for
+    the exported file for an xtgeo.RegularSurface
+    """
+    monkeypatch.chdir(tmp_path)
+
+    export_path = Path(
+        ExportData(
+            config=globalconfig1,
+            content="depth",
+            name="myname",
+        ).export(regsurf)
+    )
+
+    meta = read_metadata(export_path)
+    assert meta["file"]["checksum_md5"] == md5sum(export_path)
+
+
+def test_checksum_md5_for_gridproperty(
+    monkeypatch, tmp_path, globalconfig1, gridproperty
+):
+    """
+    Test that the MD5 hash in the metadata is equal to one computed for
+    the exported file for an xtgeo.GridProperty
+    """
+    monkeypatch.chdir(tmp_path)
+
+    export_path = Path(
+        ExportData(
+            config=globalconfig1,
+            content="depth",
+            name="myname",
+        ).export(gridproperty)
+    )
+
+    meta = read_metadata(export_path)
+    assert meta["file"]["checksum_md5"] == md5sum(export_path)
+
+
+def test_checksum_md5_for_grid(monkeypatch, tmp_path, globalconfig1, grid):
+    """
+    Test that the MD5 hash in the metadata is equal to one computed for
+    the exported file for an xtgeo.Grid
+    """
+    monkeypatch.chdir(tmp_path)
+
+    export_path = Path(
+        ExportData(
+            config=globalconfig1,
+            content="depth",
+            name="myname",
+        ).export(grid)
+    )
+
+    meta = read_metadata(export_path)
+    assert meta["file"]["checksum_md5"] == md5sum(export_path)
+
+
+def test_checksum_md5_for_points(monkeypatch, tmp_path, globalconfig1, points):
+    """
+    Test that the MD5 hash in the metadata is equal to one computed for
+    the exported file for an xtgeo.Points
+    """
+    monkeypatch.chdir(tmp_path)
+
+    export_path = Path(
+        ExportData(
+            config=globalconfig1,
+            content="depth",
+            name="myname",
+        ).export(points)
+    )
+
+    meta = read_metadata(export_path)
+    assert meta["file"]["checksum_md5"] == md5sum(export_path)
+
+
+def test_checksum_md5_for_polygons(monkeypatch, tmp_path, globalconfig1, polygons):
+    """
+    Test that the MD5 hash in the metadata is equal to one computed for
+    the exported file for an xtgeo.Polygons
+    """
+    monkeypatch.chdir(tmp_path)
+
+    export_path = Path(
+        ExportData(
+            config=globalconfig1,
+            content="depth",
+            name="myname",
+        ).export(polygons)
+    )
+
+    meta = read_metadata(export_path)
+    assert meta["file"]["checksum_md5"] == md5sum(export_path)
+
+
+def test_checksum_md5_for_cube(monkeypatch, tmp_path, globalconfig1, cube):
+    """
+    Test that the MD5 hash in the metadata is equal to one computed for
+    the exported file for an xtgeo.Cube
+    """
+    monkeypatch.chdir(tmp_path)
+
+    export_path = Path(
+        ExportData(
+            config=globalconfig1,
+            content="depth",
+            name="myname",
+        ).export(cube)
+    )
+
+    meta = read_metadata(export_path)
+    assert meta["file"]["checksum_md5"] == md5sum(export_path)
+
+
+def test_checksum_md5_for_dataframe(monkeypatch, tmp_path, globalconfig1, dataframe):
+    """
+    Test that the MD5 hash in the metadata is equal to one computed for
+    the exported file for an pandas.DataFrame
+    """
+    monkeypatch.chdir(tmp_path)
+
+    export_path = Path(
+        ExportData(
+            config=globalconfig1,
+            content="depth",
+            name="myname",
+        ).export(dataframe)
+    )
+
+    meta = read_metadata(export_path)
+    assert meta["file"]["checksum_md5"] == md5sum(export_path)
+
+
+def test_checksum_md5_for_arrowtable(monkeypatch, tmp_path, globalconfig1, arrowtable):
+    """
+    Test that the MD5 hash in the metadata is equal to one computed for
+    the exported file for an pyarrow.Table
+    """
+    monkeypatch.chdir(tmp_path)
+
+    export_path = Path(
+        ExportData(
+            config=globalconfig1,
+            content="depth",
+            name="myname",
+        ).export(arrowtable)
+    )
+
+    meta = read_metadata(export_path)
+    assert meta["file"]["checksum_md5"] == md5sum(export_path)
+
+
+def test_checksum_md5_for_dictionary(monkeypatch, tmp_path, globalconfig1):
+    """
+    Test that the MD5 hash in the metadata is equal to one computed for
+    the exported file for a dictionary
+    """
+    monkeypatch.chdir(tmp_path)
+
+    mydict = {"test": 3, "test2": "string", "test3": {"test4": 100.89}}
+
+    export_path = Path(
+        ExportData(
+            config=globalconfig1,
+            content="depth",
+            name="myname",
+        ).export(mydict)
+    )
+
+    meta = read_metadata(export_path)
+    assert meta["file"]["checksum_md5"] == md5sum(export_path)
+
+
+def test_checksum_md5_for_faultroom(monkeypatch, tmp_path, globalconfig1, rootpath):
+    """
+    Test that the MD5 hash in the metadata is equal to one computed for
+    the exported file for a FaultRoomSurface
+    """
+    monkeypatch.chdir(tmp_path)
+
+    faultroom_files = (rootpath / "tests/data/drogon/rms/output/faultroom").glob(
+        "*.json"
+    )
+    fault_room_surface = readers.read_faultroom_file(next(faultroom_files))
+
+    export_path = Path(
+        ExportData(
+            config=globalconfig1,
+            content="depth",
+            name="myname",
+        ).export(fault_room_surface)
+    )
+
+    meta = read_metadata(export_path)
+    assert meta["file"]["checksum_md5"] == md5sum(export_path)


### PR DESCRIPTION
PR that adds relevant functionality and changes from calculating MD5 hashes from file stream to memory stream when  populating the `checksum_md5` field _if possible._ 

For objects that do not support writing to memory streams they will still be written to temporary file before computing MD5, for dataio supported datatypes this applies to the `xtgeo.Cube` on `SEGY` format.

Improves performance by dropping the need for doing a temporary export the object to disk in order to get the MD5 sum.

Closes #552 