### PR TITLE
ENH: Add zonation with layer range info to grid metadata

### DIFF
--- a/schema/definitions/0.8.0/schema/fmu_results.json
+++ b/schema/definitions/0.8.0/schema/fmu_results.json
@@ -356,6 +356,21 @@
           "title": "Yshift",
           "type": "number"
         },
+        "zonation": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/ZoneDefinition"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Zonation"
+        },
         "zscale": {
           "title": "Zscale",
           "type": "number"
@@ -10145,6 +10160,32 @@
         "reference"
       ],
       "title": "Workflow",
+      "type": "object"
+    },
+    "ZoneDefinition": {
+      "description": "Zone name and corresponding layer index min/max",
+      "properties": {
+        "max_layer_idx": {
+          "minimum": 0,
+          "title": "Max Layer Idx",
+          "type": "integer"
+        },
+        "min_layer_idx": {
+          "minimum": 0,
+          "title": "Min Layer Idx",
+          "type": "integer"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "min_layer_idx",
+        "max_layer_idx"
+      ],
+      "title": "ZoneDefinition",
       "type": "object"
     }
   },

--- a/src/fmu/dataio/_model/specification.py
+++ b/src/fmu/dataio/_model/specification.py
@@ -96,6 +96,26 @@ class CPGridSpecification(RowColumnLayer):
     zscale: float = Field(allow_inf_nan=False)
     """Scaling factor for the z-axis."""
 
+    zonation: Optional[List[ZoneDefinition]] = Field(default=None)
+    """
+    Zone names and corresponding layer index ranges. The list is ordered from
+    shallowest to deepest zone. Note the layer indices are zero-based; add 1 to
+    convert to corresponding layer number.
+    """
+
+
+class ZoneDefinition(BaseModel):
+    """Zone name and corresponding layer index min/max"""
+
+    name: str
+    """Name of zone"""
+
+    min_layer_idx: int = Field(ge=0)
+    """Minimum layer index for the zone"""
+
+    max_layer_idx: int = Field(ge=0)
+    """Maximum layer index for the zone"""
+
 
 class CPGridPropertySpecification(RowColumnLayer):
     """Specifies relevant values describing a corner point grid property object."""

--- a/src/fmu/dataio/providers/objectdata/_xtgeo.py
+++ b/src/fmu/dataio/providers/objectdata/_xtgeo.py
@@ -18,6 +18,7 @@ from fmu.dataio._model.specification import (
     PointSpecification,
     PolygonsSpecification,
     SurfaceSpecification,
+    ZoneDefinition,
 )
 from fmu.dataio._utils import get_geometry_ref, npfloat_to_float
 
@@ -383,6 +384,24 @@ class CPGridDataProvider(ObjectDataProvider):
             xscale=npfloat_to_float(required["xscale"]),
             yscale=npfloat_to_float(required["yscale"]),
             zscale=npfloat_to_float(required["zscale"]),
+            zonation=self._get_zonation() if self.obj.subgrids else None,
+        )
+
+    def _get_zonation(self) -> list[ZoneDefinition]:
+        """
+        Get the zonation for the grid as a list of zone definitions.
+        The list will be ordered from shallowest zone to deepest.
+        """
+        return sorted(
+            [
+                ZoneDefinition(
+                    name=zone,
+                    min_layer_idx=min(layerlist) - 1,
+                    max_layer_idx=max(layerlist) - 1,
+                )
+                for zone, layerlist in self.obj.subgrids.items()
+            ],
+            key=lambda x: x.min_layer_idx,
         )
 
 


### PR DESCRIPTION
PR to add a `data.spec.zonation` entry for `xtgeo.Grid` objects.

- utilizes the `xtgeo.Grid.subgrids` functionality and sets zonation if subgrids are set
- The zonation list are ordered on shallowest to deepest zone.  

Format was landed after discussion with webviz developers on suitable format

closes #860 
related #782 