### PR TITLE
MAINT: Update schema after pydantic update

### DIFF
--- a/schema/definitions/0.8.0/schema/fmu_results.json
+++ b/schema/definitions/0.8.0/schema/fmu_results.json
@@ -447,9 +447,6 @@
         },
         "class": {
           "const": "case",
-          "enum": [
-            "case"
-          ],
           "title": "metadata_class",
           "type": "string"
         },
@@ -461,9 +458,6 @@
         },
         "source": {
           "const": "fmu",
-          "enum": [
-            "fmu"
-          ],
           "title": "Source",
           "type": "string"
         },
@@ -472,9 +466,6 @@
         },
         "version": {
           "const": "0.8.0",
-          "enum": [
-            "0.8.0"
-          ],
           "title": "Version",
           "type": "string"
         }
@@ -684,9 +675,6 @@
         },
         "content": {
           "const": "depth",
-          "enum": [
-            "depth"
-          ],
           "title": "Content",
           "type": "string"
         },
@@ -918,9 +906,6 @@
         },
         "vertical_domain": {
           "const": "depth",
-          "enum": [
-            "depth"
-          ],
           "title": "Vertical Domain",
           "type": "string"
         }
@@ -1274,9 +1259,6 @@
         },
         "content": {
           "const": "facies_thickness",
-          "enum": [
-            "facies_thickness"
-          ],
           "title": "Content",
           "type": "string"
         },
@@ -1579,9 +1561,6 @@
         },
         "content": {
           "const": "fault_lines",
-          "enum": [
-            "fault_lines"
-          ],
           "title": "Content",
           "type": "string"
         },
@@ -1884,9 +1863,6 @@
         },
         "content": {
           "const": "fault_properties",
-          "enum": [
-            "fault_properties"
-          ],
           "title": "Content",
           "type": "string"
         },
@@ -2283,9 +2259,6 @@
         },
         "content": {
           "const": "field_outline",
-          "enum": [
-            "field_outline"
-          ],
           "title": "Content",
           "type": "string"
         },
@@ -2606,9 +2579,6 @@
         },
         "content": {
           "const": "field_region",
-          "enum": [
-            "field_region"
-          ],
           "title": "Content",
           "type": "string"
         },
@@ -3020,9 +2990,6 @@
         },
         "content": {
           "const": "fluid_contact",
-          "enum": [
-            "fluid_contact"
-          ],
           "title": "Content",
           "type": "string"
         },
@@ -3385,9 +3352,6 @@
         "stage": {
           "const": "iteration",
           "default": "iteration",
-          "enum": [
-            "iteration"
-          ],
           "title": "Stage",
           "type": "string"
         }
@@ -3403,9 +3367,6 @@
         },
         "class": {
           "const": "iteration",
-          "enum": [
-            "iteration"
-          ],
           "title": "metadata_class",
           "type": "string"
         },
@@ -3417,9 +3378,6 @@
         },
         "source": {
           "const": "fmu",
-          "enum": [
-            "fmu"
-          ],
           "title": "Source",
           "type": "string"
         },
@@ -3428,9 +3386,6 @@
         },
         "version": {
           "const": "0.8.0",
-          "enum": [
-            "0.8.0"
-          ],
           "title": "Version",
           "type": "string"
         }
@@ -3493,9 +3448,6 @@
         },
         "content": {
           "const": "khproduct",
-          "enum": [
-            "khproduct"
-          ],
           "title": "Content",
           "type": "string"
         },
@@ -3838,9 +3790,6 @@
         },
         "content": {
           "const": "lift_curves",
-          "enum": [
-            "lift_curves"
-          ],
           "title": "Content",
           "type": "string"
         },
@@ -4196,9 +4145,6 @@
         },
         "content": {
           "const": "named_area",
-          "enum": [
-            "named_area"
-          ],
           "title": "Content",
           "type": "string"
         },
@@ -4493,9 +4439,6 @@
         },
         "source": {
           "const": "fmu",
-          "enum": [
-            "fmu"
-          ],
           "title": "Source",
           "type": "string"
         },
@@ -4504,9 +4447,6 @@
         },
         "version": {
           "const": "0.8.0",
-          "enum": [
-            "0.8.0"
-          ],
           "title": "Version",
           "type": "string"
         }
@@ -4621,9 +4561,6 @@
         },
         "content": {
           "const": "pvt",
-          "enum": [
-            "pvt"
-          ],
           "title": "Content",
           "type": "string"
         },
@@ -4947,9 +4884,6 @@
         },
         "content": {
           "const": "parameters",
-          "enum": [
-            "parameters"
-          ],
           "title": "Content",
           "type": "string"
         },
@@ -5252,9 +5186,6 @@
         },
         "content": {
           "const": "pinchout",
-          "enum": [
-            "pinchout"
-          ],
           "title": "Content",
           "type": "string"
         },
@@ -5604,9 +5535,6 @@
         },
         "content": {
           "const": "property",
-          "enum": [
-            "property"
-          ],
           "title": "Content",
           "type": "string"
         },
@@ -5909,9 +5837,6 @@
         },
         "content": {
           "const": "rft",
-          "enum": [
-            "rft"
-          ],
           "title": "Content",
           "type": "string"
         },
@@ -6238,9 +6163,6 @@
         "stage": {
           "const": "realization",
           "default": "realization",
-          "enum": [
-            "realization"
-          ],
           "title": "Stage",
           "type": "string"
         }
@@ -6256,9 +6178,6 @@
         },
         "class": {
           "const": "realization",
-          "enum": [
-            "realization"
-          ],
           "title": "metadata_class",
           "type": "string"
         },
@@ -6270,9 +6189,6 @@
         },
         "source": {
           "const": "fmu",
-          "enum": [
-            "fmu"
-          ],
           "title": "Source",
           "type": "string"
         },
@@ -6281,9 +6197,6 @@
         },
         "version": {
           "const": "0.8.0",
-          "enum": [
-            "0.8.0"
-          ],
           "title": "Version",
           "type": "string"
         }
@@ -6346,9 +6259,6 @@
         },
         "content": {
           "const": "regions",
-          "enum": [
-            "regions"
-          ],
           "title": "Content",
           "type": "string"
         },
@@ -6651,9 +6561,6 @@
         },
         "content": {
           "const": "relperm",
-          "enum": [
-            "relperm"
-          ],
           "title": "Content",
           "type": "string"
         },
@@ -7044,9 +6951,6 @@
         },
         "content": {
           "const": "seismic",
-          "enum": [
-            "seismic"
-          ],
           "title": "Content",
           "type": "string"
         },
@@ -7466,9 +7370,6 @@
         },
         "content": {
           "const": "subcrop",
-          "enum": [
-            "subcrop"
-          ],
           "title": "Content",
           "type": "string"
         },
@@ -7928,9 +7829,6 @@
         },
         "content": {
           "const": "thickness",
-          "enum": [
-            "thickness"
-          ],
           "title": "Content",
           "type": "string"
         },
@@ -8262,9 +8160,6 @@
         },
         "content": {
           "const": "time",
-          "enum": [
-            "time"
-          ],
           "title": "Content",
           "type": "string"
         },
@@ -8496,9 +8391,6 @@
         },
         "vertical_domain": {
           "const": "time",
-          "enum": [
-            "time"
-          ],
           "title": "Vertical Domain",
           "type": "string"
         }
@@ -8561,9 +8453,6 @@
         },
         "content": {
           "const": "timeseries",
-          "enum": [
-            "timeseries"
-          ],
           "title": "Content",
           "type": "string"
         },
@@ -8960,9 +8849,6 @@
         },
         "content": {
           "const": "transmissibilities",
-          "enum": [
-            "transmissibilities"
-          ],
           "title": "Content",
           "type": "string"
         },
@@ -9283,9 +9169,6 @@
         },
         "content": {
           "const": "velocity",
-          "enum": [
-            "velocity"
-          ],
           "title": "Content",
           "type": "string"
         },
@@ -9610,9 +9493,6 @@
         },
         "content": {
           "const": "volumes",
-          "enum": [
-            "volumes"
-          ],
           "title": "Content",
           "type": "string"
         },
@@ -9915,9 +9795,6 @@
         },
         "content": {
           "const": "wellpicks",
-          "enum": [
-            "wellpicks"
-          ],
           "title": "Content",
           "type": "string"
         },

--- a/src/fmu/dataio/_model/global_configuration.py
+++ b/src/fmu/dataio/_model/global_configuration.py
@@ -85,7 +85,7 @@ class StratigraphyElement(BaseModel):
 
     name: str
     stratigraphic: bool = Field(default=False)
-    alias: Optional[List[str]] = Field(default_factory=list)
+    alias: Optional[List[str]] = Field(default=None)
     stratigraphic_alias: Optional[List[str]] = Field(default=None)
     offset: float = Field(default=0.0, allow_inf_nan=False)
     top: Optional[data.Layer] = Field(default=None)

--- a/src/fmu/dataio/_model/global_configuration.py
+++ b/src/fmu/dataio/_model/global_configuration.py
@@ -85,7 +85,7 @@ class StratigraphyElement(BaseModel):
 
     name: str
     stratigraphic: bool = Field(default=False)
-    alias: Optional[List[str]] = Field(default=None)
+    alias: Optional[List[str]] = Field(default_factory=list)
     stratigraphic_alias: Optional[List[str]] = Field(default=None)
     offset: float = Field(default=0.0, allow_inf_nan=False)
     top: Optional[data.Layer] = Field(default=None)


### PR DESCRIPTION
Updated pydantic json schema for fmu-datio 

Pydantic had a new release 2.10.0 that changed the json schema generation for enums. Because of this the fmu-datio schema was no longer up to date. 

Schema has now been updated with these new changes to be up to date.

