### PR TITLE
BLD: Pin pydantic to < 2.10 as ERT have done

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,8 @@ dependencies = [
     "fmu-config>=1.1.0",
     "numpy",
     "pandas",
-    "pyarrow",
-    "pydantic",
+    "pyarrow", 
+    "pydantic < 2.10",
     "PyYAML",
     "xtgeo>=2.16",
 ]


### PR DESCRIPTION
Pydantic version 2.10 was released november 20th. 

This lead to issues for ERT for which they had to pin the Pydantic version < 2.10.

To not be in conflict with this, we also pin the `pydantic` version in `fmu-dataio` < `2.10`.

Once https://github.com/equinor/ert/issues/9292 has bee resolved, we should also unpin `fmu-dataio`. This will be followed up through https://github.com/equinor/fmu-dataio/issues/874