### PR TITLE
ENH: Faultroom export - add mapping of juxt.pos. to SMDA names (#724)

### DIFF
--- a/src/fmu/dataio/providers/objectdata/_utils.py
+++ b/src/fmu/dataio/providers/objectdata/_utils.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import warnings
+
+from fmu.dataio._model.global_configuration import Stratigraphy
+
+
+class Utils:
+    @staticmethod
+    def get_stratigraphic_name(stratigraphy: Stratigraphy, name: str) -> str:
+        """
+        Get the name of a stratigraphic element from the stratigraphy.
+        name: name of stratigraphic element
+        """
+        if name in stratigraphy:
+            return stratigraphy[name].name
+
+        warnings.warn(
+            f"Stratigraphic element '{name}' not found in the stratigraphic column "
+            "in global config"
+        )
+        return ""

--- a/tests/test_units/test_checksum_md5.py
+++ b/tests/test_units/test_checksum_md5.py
@@ -180,7 +180,7 @@ def test_checksum_md5_for_dictionary(monkeypatch, tmp_path, globalconfig1):
     assert meta["file"]["checksum_md5"] == md5sum(export_path)
 
 
-def test_checksum_md5_for_faultroom(monkeypatch, tmp_path, globalconfig1, rootpath):
+def test_checksum_md5_for_faultroom(monkeypatch, tmp_path, globalconfig2, rootpath):
     """
     Test that the MD5 hash in the metadata is equal to one computed for
     the exported file for a FaultRoomSurface
@@ -194,7 +194,7 @@ def test_checksum_md5_for_faultroom(monkeypatch, tmp_path, globalconfig1, rootpa
 
     export_path = Path(
         ExportData(
-            config=globalconfig1,
+            config=globalconfig2,
             content="depth",
             name="myname",
         ).export(fault_room_surface)

--- a/tests/test_units/test_objectdataprovider_class.py
+++ b/tests/test_units/test_objectdataprovider_class.py
@@ -8,6 +8,8 @@ import yaml
 
 import fmu.dataio as dataio
 from fmu.dataio._definitions import ConfigurationError, ValidFormats
+from fmu.dataio._model.specification import FaultRoomSurfaceSpecification
+from fmu.dataio.providers.objectdata._faultroom import FaultRoomSurfaceProvider
 from fmu.dataio.providers.objectdata._provider import (
     objectdata_provider_factory,
 )
@@ -23,7 +25,7 @@ from ..utils import inside_rms
 
 def test_objectdata_regularsurface_derive_named_stratigraphy(regsurf, edataobj1):
     """Get name and some stratigaphic keys for a valid RegularSurface object ."""
-    # mimic the stripped parts of configuations for testing here
+    # mimic the stripped parts of configurations for testing here
     objdata = objectdata_provider_factory(regsurf, edataobj1)
 
     res = objdata._get_stratigraphy_element()
@@ -35,7 +37,7 @@ def test_objectdata_regularsurface_derive_named_stratigraphy(regsurf, edataobj1)
 
 def test_objectdata_regularsurface_get_stratigraphy_element_differ(regsurf, edataobj2):
     """Get name and some stratigaphic keys for a valid RegularSurface object ."""
-    # mimic the stripped parts of configuations for testing here
+    # mimic the stripped parts of configurations for testing here
     objdata = objectdata_provider_factory(regsurf, edataobj2)
 
     res = objdata._get_stratigraphy_element()
@@ -43,6 +45,24 @@ def test_objectdata_regularsurface_get_stratigraphy_element_differ(regsurf, edat
     assert res.name == "VOLANTIS GP. Top"
     assert "TopVolantis" in res.alias
     assert res.stratigraphic is True
+
+
+def test_objectdata_faultroom_fault_juxtaposition_get_stratigraphy_differ(
+    faultroom_object, edataobj2
+):
+    """
+    Fault juxtaposition is a list of formations on the footwall and hangingwall sides.
+    Ensure that each name is converted to the names given in the stratigraphic column
+    in the global config.
+    """
+    objdata = objectdata_provider_factory(faultroom_object, edataobj2)
+    assert isinstance(objdata, FaultRoomSurfaceProvider)
+
+    frss = objdata.get_spec()
+    assert isinstance(frss, FaultRoomSurfaceSpecification)
+
+    assert frss.juxtaposition_fw == ["Valysar Fm.", "Therys Fm.", "Volon Fm."]
+    assert frss.juxtaposition_hw == ["Valysar Fm.", "Therys Fm.", "Volon Fm."]
 
 
 def test_objectdata_regularsurface_validate_extension(regsurf, edataobj1):

--- a/tests/test_units/test_providers_utils_class.py
+++ b/tests/test_units/test_providers_utils_class.py
@@ -1,0 +1,22 @@
+import pytest
+
+from fmu.dataio.providers.objectdata._utils import Utils
+
+
+def test_stratigraphy(edataobj2):
+    """Test the stratigraphy."""
+
+    strat = edataobj2.config.stratigraphy
+
+    ###### Test get stratigraphic name ######
+
+    # Correct name
+    assert Utils.get_stratigraphic_name(strat, "Valysar") == "Valysar Fm."
+
+    # Incorrect name
+    with pytest.warns(UserWarning, match="not found in the stratigraphic column"):
+        assert Utils.get_stratigraphic_name(strat, "Ile") == ""
+
+    # Empty name
+    with pytest.warns(UserWarning, match="not found in the stratigraphic column"):
+        assert Utils.get_stratigraphic_name(strat, "") == ""


### PR DESCRIPTION
Resolves #724, and sorts the mapped names according to the given stratigraphic column.

Discussion on Slack: https://equinor.slack.com/archives/C06E3UTGTEV/p1719922723901579