### PR TITLE
ENH: Add inplace volumes result and schema

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dev = [
     "coverage>=4.1",
     "ert",
     "hypothesis",
+    "jsonschema",
     "mypy",
     "pandas-stubs",
     "pyarrow-stubs",

--- a/src/fmu/dataio/_products/inplace_volumes.py
+++ b/src/fmu/dataio/_products/inplace_volumes.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Final, List, Literal, Optional
+
+from pydantic import BaseModel, Field, RootModel
+from pydantic.json_schema import GenerateJsonSchema
+
+if TYPE_CHECKING:
+    from typing import Any, Mapping
+
+# These are to be used when creating the 'product' key in metadata.
+VERSION: Final[str] = "0.1.0"
+SCHEMA: Final[str] = (
+    "https://main-fmu-schemas-prod.radix.equinor.com/schemas"
+    f"/file_formats/volumes/{VERSION}/inplace_volumes.json"
+)
+
+
+class InplaceVolumesResultRow(BaseModel):
+    """Represents a row in a static inplace volumes export.
+
+    These fields are the current agreed upon standard result. Changes to this model
+    should increase the version number in a way that corresponds to the schema
+    versioning specification (i.e. they are a patch, minor, or major change)."""
+
+    FLUID: Literal["oil", "gas", "water"]
+    ZONE: str
+    REGION: Optional[str] = Field(default=None)
+    FACIES: Optional[str] = Field(default=None)
+    LICENSE: Optional[str] = Field(default=None)
+
+    BULK: float = Field(ge=0.0)
+    NET: Optional[float] = Field(default=None, ge=0.0)
+    PORV: float = Field(ge=0.0)
+    HCPV: Optional[float] = Field(default=None, ge=0.0)
+    STOIIP: Optional[float] = Field(default=None, ge=0.0)
+    GIIP: Optional[float] = Field(default=None, ge=0.0)
+    ASSOCIATEDGAS: Optional[float] = Field(default=None, ge=0.0)
+    ASSOCIATEDOIL: Optional[float] = Field(default=None, ge=0.0)
+
+
+class InplaceVolumesResult(RootModel):
+    """Represents the resultant static inplace volumes csv file, which is naturally a
+    list of rows.
+
+    Consumers who retrieve this csv file must reading it into a json-dictionary
+    equivalent format to validate it against the schema."""
+
+    root: List[InplaceVolumesResultRow]
+
+
+class InplaceVolumesJsonSchema(GenerateJsonSchema):
+    """Implements a schema generator so that some additional fields may be added."""
+
+    def generate(
+        self,
+        schema: Mapping[str, Any],
+        mode: Literal["validation", "serialization"] = "validation",
+    ) -> dict[str, Any]:
+        json_schema = super().generate(schema, mode=mode)
+        json_schema["$schema"] = self.schema_dialect
+        json_schema["$id"] = SCHEMA
+        json_schema["version"] = VERSION
+
+        return json_schema
+
+
+def dump() -> dict[str, Any]:
+    return InplaceVolumesResult.model_json_schema(
+        schema_generator=InplaceVolumesJsonSchema
+    )


### PR DESCRIPTION
Resolves #877 

This will need refinement and discussion, but here is something to discuss.

- Suggests a module interface from `_products`
  - When FMU products are exported they can import the VERSION and SCHEMA to use:
  - ```yml
     data:
       product:
         type: ...
         # All schema-able products have this; not every product is schema-able (e.g. roff files)
         file_schema:
           version: {fmu.dataio._products.inplace_volumes.VERSION}  # Or schema_version? Not needed?
           url: {fmu.dataio._products.inplace_volumes.SCHEMA} 
    ```
  - This should give consumers approximately what they need for data consistency guarantees
- The bad: most things are optional. Currently a valid product can look like:
  - `ZONE,REGION,BULK_TOTAL,PORV_TOTAL`
  - This isn't very useful -- it is a poor data contract to make (and the last two may need to be optional too?)
- This doesn't yet set-up the deployment of the schema, a way to generate them etc
  - We should have a discussion about how products and their versions are organized, relative to each-other and generally in the URL
  - This means the `update_schema` script in `tools/` needs to be extended
  - The script that installs the schema files on the Radix app will need to be updated too

Will take documentation separately since things in here are likely to shift a bit.