### PR TITLE
ENH: Add 'simulationtimeseries' content type

### DIFF
--- a/schema/definitions/0.8.0/schema/fmu_results.json
+++ b/schema/definitions/0.8.0/schema/fmu_results.json
@@ -181,6 +181,9 @@
           "$ref": "#/$defs/SeismicData"
         },
         {
+          "$ref": "#/$defs/SimulationTimeSeriesData"
+        },
+        {
           "$ref": "#/$defs/SubcropData"
         },
         {
@@ -7305,6 +7308,311 @@
         "seismic"
       ],
       "title": "SeismicData",
+      "type": "object"
+    },
+    "SimulationTimeSeriesData": {
+      "description": "The ``data`` block contains information about the data contained in this object.\nThis class contains metadata for simulation time series. This is a time series\nresult derived from some simulator like OPM Flow.",
+      "properties": {
+        "alias": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Alias"
+        },
+        "base": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "bbox": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BoundingBox3D"
+            },
+            {
+              "$ref": "#/$defs/BoundingBox2D"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Bbox"
+        },
+        "content": {
+          "const": "simulationtimeseries",
+          "enum": [
+            "simulationtimeseries"
+          ],
+          "title": "Content",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
+        "format": {
+          "examples": [
+            "irap_binary"
+          ],
+          "title": "Format",
+          "type": "string"
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "grid_model": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GridModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "is_observation": {
+          "title": "Is Observation",
+          "type": "boolean"
+        },
+        "is_prediction": {
+          "title": "Is Prediction",
+          "type": "boolean"
+        },
+        "layout": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layout"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "regular",
+            "cornerpoint"
+          ]
+        },
+        "name": {
+          "examples": [
+            "VIKING GP. Top"
+          ],
+          "title": "Name",
+          "type": "string"
+        },
+        "offset": {
+          "default": 0.0,
+          "title": "Offset",
+          "type": "number"
+        },
+        "spec": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CPGridPropertySpecification"
+            },
+            {
+              "$ref": "#/$defs/CPGridSpecification"
+            },
+            {
+              "$ref": "#/$defs/FaultRoomSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/PointSpecification"
+            },
+            {
+              "$ref": "#/$defs/CubeSpecification"
+            },
+            {
+              "$ref": "#/$defs/PolygonsSpecification"
+            },
+            {
+              "$ref": "#/$defs/SurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TableSpecification"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Spec"
+        },
+        "stratigraphic": {
+          "title": "Stratigraphic",
+          "type": "boolean"
+        },
+        "stratigraphic_alias": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Stratigraphic Alias"
+        },
+        "table_index": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            [
+              "ZONE",
+              "REGION"
+            ]
+          ],
+          "title": "Table Index"
+        },
+        "tagname": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "ds_extract_geogrid",
+            "ds_post_strucmod"
+          ],
+          "title": "Tagname"
+        },
+        "time": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Time"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "top": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "undef_is_zero": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Undef Is Zero"
+        },
+        "unit": {
+          "default": "",
+          "examples": [
+            "m"
+          ],
+          "title": "Unit",
+          "type": "string"
+        },
+        "vertical_domain": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalDomain"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "depth",
+            "time"
+          ]
+        }
+      },
+      "required": [
+        "content",
+        "name",
+        "stratigraphic",
+        "format",
+        "is_observation",
+        "is_prediction"
+      ],
+      "title": "SimulationTimeSeriesData",
       "type": "object"
     },
     "Smda": {

--- a/src/fmu/dataio/_definitions.py
+++ b/src/fmu/dataio/_definitions.py
@@ -72,6 +72,6 @@ class ExportFolder(str, Enum):
 STANDARD_TABLE_INDEX_COLUMNS: Final[dict[str, list[str]]] = {
     "volumes": ["ZONE", "REGION", "FACIES", "LICENCE"],
     "rft": ["measured_depth", "well", "time"],
-    "timeseries": ["DATE"],  # summary
+    "simulationtimeseries": ["DATE"],
     "wellpicks": ["WELL", "HORIZON"],
 }

--- a/src/fmu/dataio/_model/data.py
+++ b/src/fmu/dataio/_model/data.py
@@ -524,6 +524,17 @@ class SeismicData(Data):
     """A block describing seismic data. See :class:`Seismic`."""
 
 
+class SimulationTimeSeriesData(Data):
+    """
+    The ``data`` block contains information about the data contained in this object.
+    This class contains metadata for simulation time series. This is a time series
+    result derived from some simulator like OPM Flow.
+    """
+
+    content: Literal[enums.Content.simulationtimeseries]
+    """The type of content these data represent."""
+
+
 class SubcropData(Data):
     """
     The ``data`` block contains information about the data contained in this object.
@@ -650,6 +661,7 @@ class AnyData(RootModel):
             RelpermData,
             RFTData,
             SeismicData,
+            SimulationTimeSeriesData,
             SubcropData,
             ThicknessData,
             TimeData,

--- a/src/fmu/dataio/_model/enums.py
+++ b/src/fmu/dataio/_model/enums.py
@@ -40,6 +40,7 @@ class Content(str, Enum):
     relperm = "relperm"
     rft = "rft"
     seismic = "seismic"
+    simulationtimeseries = "simulationtimeseries"
     subcrop = "subcrop"
     thickness = "thickness"
     time = "time"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -641,12 +641,11 @@ def fixture_aggr_surfs_mean(fmurun_w_casemetadata, rmsglobalconfig, regsurf):
 @pytest.fixture(name="edataobj3")
 def fixture_edataobj3(globalconfig1):
     """Combined globalconfig and settings to instance, for internal testing"""
-    # logger.debug("Establish edataobj1")
 
     return ExportData(
         config=globalconfig1,
         name="summary",
-        content="timeseries",
+        content="simulationtimeseries",
         tagname="",
     )
 

--- a/tests/test_units/test_contents.py
+++ b/tests/test_units/test_contents.py
@@ -241,6 +241,17 @@ def test_content_seismic(polygons, globalconfig2):
     # tested various other places
 
 
+def test_content_simulationtimeseries(dataframe, globalconfig2):
+    """Test export of the simulationtimeseries content."""
+    meta = ExportData(
+        config=globalconfig2,
+        name="MyName",
+        content="simulationtimeseries",
+    ).generate_metadata(dataframe)
+
+    assert meta["data"]["content"] == "simulationtimeseries"
+
+
 def test_content_subcrop(polygons, globalconfig2):
     """Test export of the subcrop content."""
     meta = ExportData(

--- a/tests/test_units/test_table.py
+++ b/tests/test_units/test_table.py
@@ -75,7 +75,9 @@ def test_derive_summary_index_pandas(
     """
     monkeypatch.chdir(tmp_path)
     answer = ["DATE"]
-    exd = ExportData(config=globalconfig2, content="timeseries", name="baretull")
+    exd = ExportData(
+        config=globalconfig2, content="simulationtimeseries", name="baretull"
+    )
     path = exd.export(mock_summary)
     assert_correct_table_index(path, answer)
 
@@ -93,7 +95,9 @@ def test_derive_summary_index_pyarrow(
 
     monkeypatch.chdir(tmp_path)
     answer = ["DATE"]
-    exd = ExportData(config=globalconfig2, content="timeseries", name="baretull")
+    exd = ExportData(
+        config=globalconfig2, content="simulationtimeseries", name="baretull"
+    )
     path = exd.export(Table.from_pandas(mock_summary))
     assert_correct_table_index(path, answer)
 


### PR DESCRIPTION
Resolves #689 

Rationale for new content type: 'simulationtimeseries' is more of a super-type of 'timeseries' than a subtype since it can contain multiple timeseries vectors. 