### PR TITLE
CI: Run most actions with Python 3.11

### DIFF
--- a/.github/workflows/fmudataio-publish-pypi.yml
+++ b/.github/workflows/fmudataio-publish-pypi.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.10
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install pypa/build
         run: python -m pip install build twine

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install dev-env.
         run: |

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.10"]
+        python-version: ["3.8", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Resolves #898 

We are moving to Python 3.11 being our current version. May as well do that here too.