### PR TITLE
FIX: Re-add 'timeseries' index without duplication

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dev = [
     "pandas-stubs",
     "pyarrow-stubs",
     "pydocstyle",
+    "PyQt5-sip<12.16.0; python_version == '3.8'",
     "pytest-cov",
     "pytest-mock",
     "pytest-runner",

--- a/src/fmu/dataio/_definitions.py
+++ b/src/fmu/dataio/_definitions.py
@@ -72,6 +72,7 @@ class ExportFolder(str, Enum):
 STANDARD_TABLE_INDEX_COLUMNS: Final[dict[str, list[str]]] = {
     "volumes": ["ZONE", "REGION", "FACIES", "LICENCE"],
     "rft": ["measured_depth", "well", "time"],
+    "timeseries": ["DATE"],
     "simulationtimeseries": ["DATE"],
     "wellpicks": ["WELL", "HORIZON"],
 }

--- a/src/fmu/dataio/providers/objectdata/_tables.py
+++ b/src/fmu/dataio/providers/objectdata/_tables.py
@@ -44,7 +44,7 @@ def _derive_index(table_index: list[str] | None, columns: list[str]) -> list[str
         logger.debug("Finding index to include")
         for context, standard_cols in STANDARD_TABLE_INDEX_COLUMNS.items():
             for valid_col in standard_cols:
-                if valid_col in columns:
+                if valid_col in columns and valid_col not in index:
                     index.append(valid_col)
             if index:
                 logger.info("Context is %s ", context)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -650,6 +650,18 @@ def fixture_edataobj3(globalconfig1):
     )
 
 
+@pytest.fixture
+def export_data_obj_timeseries(globalconfig1):
+    """Combined globalconfig and settings to instance, for internal testing"""
+
+    return ExportData(
+        config=globalconfig1,
+        name="some timeseries",
+        content="timeseries",
+        tagname="",
+    )
+
+
 @pytest.fixture(name="mock_summary")
 def fixture_summary():
     """Return summary mock data

--- a/tests/test_units/test_table.py
+++ b/tests/test_units/test_table.py
@@ -153,6 +153,17 @@ def test_set_table_index_not_in_table(
     assert k_err.value.args[0] == "banana is not in table"
 
 
+def test_table_index_timeseries(export_data_obj_timeseries, drogon_summary):
+    """Test setting of table_index in an arbitrary timeseries.
+
+    Args:
+        edataobj3 (dict): metadata
+        drogon_summary (pd.Dataframe): dataframe with summary data from sumo
+    """
+    objdata = objectdata_provider_factory(drogon_summary, export_data_obj_timeseries)
+    assert objdata.table_index == ["DATE"], "Incorrect table index "
+
+
 def test_table_index_real_summary(edataobj3, drogon_summary):
     """Test setting of table_index in real summary file
 


### PR DESCRIPTION
#901 suggests a better and more structured approach to handle table indexes later. The current implementation of giving standard table index columns does not actually seem strictly tied to the content type and could add duplicated columns if it saw a match.

It could also possibly be handled from within the ObjectDataProvider.