### PR TITLE
FIX: Revert Dockerfile chown

### DIFF
--- a/.github/workflows/ci-fmudataio.yml
+++ b/.github/workflows/ci-fmudataio.yml
@@ -1,4 +1,4 @@
-name: Build and test fmu-dataio
+name: Test
 
 on:
   pull_request:
@@ -7,8 +7,8 @@ on:
     - cron: "0 0 * * *"
 
 jobs:
-  build_pywheels:
-    name: PY ${{ matrix.python-version }} on ${{ matrix.os }}
+  run_tests:
+    name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -43,3 +43,12 @@ jobs:
 
       - name: Full test
         run: pytest -v
+
+  docker_build:
+    name: Build Docker image
+    runs-on: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Test Docker image can build
+        run: docker build .

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apk update && apk upgrade && apk add jq
 # See https://radix.equinor.com/docs/topic-docker/#running-as-non-root
 RUN addgroup -S -g 1001 radix-non-root-group
 RUN adduser -S -u 1001 -G radix-non-root-group radix-non-root-user
-RUN chown -R 1001:1001 schemas
+RUN chown -R 1001:1001 .
 
 COPY tools/modify-schema-files.sh /docker-entrypoint.d/50-modify-schema-files.sh
 COPY nginx.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
This reverts the docker `chown` back to the workdir without specifying the schemas dir directly, which was incorrect to do. It also adds a CI job to check that it builds.