### PR TITLE
MAINT: Drop separate FLUID_COLUMN variable

### DIFF
--- a/src/fmu/dataio/export/_enums.py
+++ b/src/fmu/dataio/export/_enums.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Final
 
 
 class InplaceVolumes:
@@ -22,9 +21,6 @@ class InplaceVolumes:
         REGION = "REGION"
         FACIES = "FACIES"
         LICENSE = "LICENSE"
-
-    FLUID_COLUMN: Final = TableIndexColumns.FLUID
-    """The column name and value used to indicate the index value for fluid type."""
 
     class VolumetricColumns(str, Enum):
         """The value columns for an inplace volumes table."""

--- a/src/fmu/dataio/export/rms/inplace_volumes.py
+++ b/src/fmu/dataio/export/rms/inplace_volumes.py
@@ -211,7 +211,7 @@ class _ExportVolumetricsRMS:
                 )
 
                 # add the fluid as column entry instead
-                fluid_table[_enums.InplaceVolumes.FLUID_COLUMN.value] = fluid
+                fluid_table[_TableIndexColumns.FLUID.value] = fluid
 
                 tables.append(fluid_table)
 
@@ -253,12 +253,8 @@ class _ExportVolumetricsRMS:
                     "Please update and rerun the volumetric job before export."
                 )
 
-        has_oil = (
-            "oil" in self._dataframe[_enums.InplaceVolumes.FLUID_COLUMN.value].values
-        )
-        has_gas = (
-            "gas" in self._dataframe[_enums.InplaceVolumes.FLUID_COLUMN.value].values
-        )
+        has_oil = "oil" in self._dataframe[_TableIndexColumns.FLUID.value].values
+        has_gas = "gas" in self._dataframe[_TableIndexColumns.FLUID.value].values
 
         # check that one of oil and gas fluids are present
         if not (has_oil or has_gas):

--- a/tests/test_export_rms/test_export_rms_volumetrics.py
+++ b/tests/test_export_rms/test_export_rms_volumetrics.py
@@ -150,12 +150,9 @@ def test_convert_table_from_legacy_to_standard_format(
     pd.testing.assert_frame_equal(voltable_standard, exported_table)
 
     # check that the fluid column exists and contains oil and gas
-    assert _enums.InplaceVolumes.FLUID_COLUMN in exported_table
-    assert set(exported_table[_enums.InplaceVolumes.FLUID_COLUMN].unique()) == {
-        "oil",
-        "gas",
-        "water",
-    }
+    fluid_col = _enums.InplaceVolumes.TableIndexColumns.FLUID.value
+    assert fluid_col in exported_table
+    assert set(exported_table[fluid_col].unique()) == {"oil", "gas", "water"}
 
     # check the column order
     assert list(exported_table.columns) == EXPECTED_COLUMN_ORDER


### PR DESCRIPTION
No need to treat the `FLUID_COLUMN` separate anymore after we got the enums in `InplaceVolumes` in place.