### PR TITLE
ENH: Add product to exported metadata for inplace_volumes

### DIFF
--- a/src/fmu/dataio/_metadata.py
+++ b/src/fmu/dataio/_metadata.py
@@ -13,6 +13,7 @@ from ._definitions import SOURCE, FmuResultsSchema
 from ._logging import null_logger
 from ._model import fields, schema
 from ._model.global_configuration import GlobalConfiguration
+from ._model.product import Product
 from .exceptions import InvalidMetadataError
 from .providers._filedata import FileDataProvider
 from .providers.objectdata._provider import objectdata_provider_factory
@@ -73,6 +74,7 @@ def generate_export_metadata(
     obj: types.Inferrable,
     dataio: ExportData,
     fmudata: FmuProvider | None = None,
+    product: Product | None = None,
 ) -> schema.InternalObjectMetadata:
     """
     Main function to generate the full metadata
@@ -101,7 +103,7 @@ def generate_export_metadata(
 
     """
 
-    objdata = objectdata_provider_factory(obj, dataio)
+    objdata = objectdata_provider_factory(obj, dataio, product)
 
     return schema.InternalObjectMetadata(
         schema_=TypeAdapter(AnyHttpUrl).validate_strings(FmuResultsSchema.url()),  # type: ignore[call-arg]

--- a/src/fmu/dataio/export/rms/inplace_volumes.py
+++ b/src/fmu/dataio/export/rms/inplace_volumes.py
@@ -11,7 +11,8 @@ import pyarrow as pa
 
 import fmu.dataio as dio
 from fmu.dataio._logging import null_logger
-from fmu.dataio._model.enums import Classification
+from fmu.dataio._model import product
+from fmu.dataio._model.enums import Classification, ProductName
 from fmu.dataio._products.inplace_volumes import InplaceVolumesResult
 from fmu.dataio.export import _enums
 from fmu.dataio.export._decorators import experimental
@@ -69,6 +70,11 @@ class _ExportVolumetricsRMS:
         self._volume_table_name = self._read_volume_table_name_from_job()
         self._dataframe = self._get_table_with_volumes()
         _logger.debug("Process data... DONE")
+
+    @property
+    def _product(self) -> product.InplaceVolumesProduct:
+        """Product type for the exported data."""
+        return product.InplaceVolumesProduct(name=ProductName.inplace_volumes)
 
     @property
     def _classification(self) -> Classification:
@@ -317,7 +323,12 @@ class _ExportVolumetricsRMS:
         )
 
         volume_table = pa.Table.from_pandas(self._dataframe)
-        absolute_export_path = edata.export(volume_table)
+
+        # export the volume table with product info in the metadata
+        absolute_export_path = edata._export_with_product(
+            volume_table,
+            product=self._product,
+        )
 
         _logger.debug("Volume result to: %s", absolute_export_path)
         return ExportResult(

--- a/src/fmu/dataio/providers/objectdata/_base.py
+++ b/src/fmu/dataio/providers/objectdata/_base.py
@@ -8,16 +8,13 @@ from typing import TYPE_CHECKING, Any, Final
 
 from fmu.dataio._definitions import ConfigurationError, ValidFormats
 from fmu.dataio._logging import null_logger
-from fmu.dataio._model.data import (
-    AnyData,
-    Time,
-    Timestamp,
-)
+from fmu.dataio._model.data import AnyData, Time, Timestamp
 from fmu.dataio._model.enums import Content
 from fmu.dataio._model.global_configuration import (
     GlobalConfiguration,
     StratigraphyElement,
 )
+from fmu.dataio._model.product import Product
 from fmu.dataio._model.schema import AllowedContent, InternalUnsetData
 from fmu.dataio._utils import generate_description
 from fmu.dataio.providers._base import Provider
@@ -51,6 +48,7 @@ class ObjectDataProvider(Provider):
     # input fields
     obj: Inferrable
     dataio: ExportData
+    product: Product | None = None
 
     # result properties; the most important is metadata which IS the 'data' part in
     # the resulting metadata. But other variables needed later are also given
@@ -83,7 +81,7 @@ class ObjectDataProvider(Provider):
             metadata[usecontent] = getattr(
                 content_model.content_incl_specific, usecontent, None
             )
-        metadata["product"] = None
+        metadata["product"] = self.product
         metadata["tagname"] = self.dataio.tagname
         metadata["format"] = self.fmt
         metadata["layout"] = self.layout

--- a/src/fmu/dataio/providers/objectdata/_provider.py
+++ b/src/fmu/dataio/providers/objectdata/_provider.py
@@ -96,6 +96,7 @@ import xtgeo
 from fmu.dataio._definitions import ExportFolder, ValidFormats
 from fmu.dataio._logging import null_logger
 from fmu.dataio._model.enums import FMUClass, Layout
+from fmu.dataio._model.product import Product
 from fmu.dataio.readers import FaultRoomSurface
 
 from ._base import (
@@ -120,7 +121,9 @@ logger: Final = null_logger(__name__)
 
 
 def objectdata_provider_factory(
-    obj: Inferrable, dataio: ExportData
+    obj: Inferrable,
+    dataio: ExportData,
+    product: Product | None = None,
 ) -> ObjectDataProvider:
     """Factory function that generates metadata for a particular data object. This
     function will return an instance of an object-independent (i.e., typeable) class
@@ -134,25 +137,25 @@ def objectdata_provider_factory(
         metadata for.
     """
     if isinstance(obj, xtgeo.RegularSurface):
-        return RegularSurfaceDataProvider(obj=obj, dataio=dataio)
+        return RegularSurfaceDataProvider(obj=obj, dataio=dataio, product=product)
     if isinstance(obj, xtgeo.Polygons):
-        return PolygonsDataProvider(obj=obj, dataio=dataio)
+        return PolygonsDataProvider(obj=obj, dataio=dataio, product=product)
     if isinstance(obj, xtgeo.Points):
-        return PointsDataProvider(obj=obj, dataio=dataio)
+        return PointsDataProvider(obj=obj, dataio=dataio, product=product)
     if isinstance(obj, xtgeo.Cube):
-        return CubeDataProvider(obj=obj, dataio=dataio)
+        return CubeDataProvider(obj=obj, dataio=dataio, product=product)
     if isinstance(obj, xtgeo.Grid):
-        return CPGridDataProvider(obj=obj, dataio=dataio)
+        return CPGridDataProvider(obj=obj, dataio=dataio, product=product)
     if isinstance(obj, xtgeo.GridProperty):
-        return CPGridPropertyDataProvider(obj=obj, dataio=dataio)
+        return CPGridPropertyDataProvider(obj=obj, dataio=dataio, product=product)
     if isinstance(obj, pd.DataFrame):
-        return DataFrameDataProvider(obj=obj, dataio=dataio)
+        return DataFrameDataProvider(obj=obj, dataio=dataio, product=product)
     if isinstance(obj, FaultRoomSurface):
-        return FaultRoomSurfaceProvider(obj=obj, dataio=dataio)
+        return FaultRoomSurfaceProvider(obj=obj, dataio=dataio, product=product)
     if isinstance(obj, dict):
-        return DictionaryDataProvider(obj=obj, dataio=dataio)
+        return DictionaryDataProvider(obj=obj, dataio=dataio, product=product)
     if isinstance(obj, pa.Table):
-        return ArrowTableDataProvider(obj=obj, dataio=dataio)
+        return ArrowTableDataProvider(obj=obj, dataio=dataio, product=product)
 
     raise NotImplementedError(f"This data type is not currently supported: {type(obj)}")
 

--- a/tests/test_export_rms/test_export_rms_volumetrics.py
+++ b/tests/test_export_rms/test_export_rms_volumetrics.py
@@ -12,7 +12,10 @@ from pydantic import ValidationError
 
 from fmu import dataio
 from fmu.dataio._logging import null_logger
+from fmu.dataio._model.enums import ProductName
 from fmu.dataio._products.inplace_volumes import (
+    SCHEMA,
+    VERSION,
     InplaceVolumesResult,
     InplaceVolumesResultRow,
     dump,
@@ -582,3 +585,15 @@ def test_that_required_columns_one_to_one_in_enums_and_schema() -> None:
         if field_info.is_required():
             schema_required_fields.append(field_name)
     assert set(_enums.InplaceVolumes.required_columns()) == set(schema_required_fields)
+
+
+def test_product_in_metadata(exportvolumetrics):
+    """Test that the product is set correctly in the metadata"""
+
+    out = exportvolumetrics._export_volume_table()
+    metadata = dataio.read_metadata(out.items[0].absolute_path)
+
+    assert "product" in metadata["data"]
+    assert metadata["data"]["product"]["name"] == ProductName.inplace_volumes
+    assert metadata["data"]["product"]["file_schema"]["version"] == VERSION
+    assert metadata["data"]["product"]["file_schema"]["url"] == SCHEMA

--- a/tests/test_units/test_dataio.py
+++ b/tests/test_units/test_dataio.py
@@ -1135,6 +1135,13 @@ def test_alias_as_none(globalconfig2, regsurf):
     assert meta["data"]["alias"] == [name]
 
 
+def test_product_not_present_in_generated_metadata(globalconfig1, regsurf):
+    """Test that data.product is not set for regular exports through ExportData"""
+
+    meta = ExportData(config=globalconfig1, content="depth").generate_metadata(regsurf)
+    assert "product" not in meta["data"]
+
+
 def test_ert_experiment_id_present_in_generated_metadata(
     fmurun_w_casemetadata, monkeypatch, globalconfig1, regsurf
 ):


### PR DESCRIPTION
Final PR to start adding `data.product` to the metadata for `inplace_volumes.`

Added separate private export function in `ExportData` to be used for export of data that qualifies as products. Using this export function will add product information to the exported metadata.