### PR TITLE
MAINT: Refactor 'schema'/'internal' classes 

### DIFF
--- a/schemas/0.8.0/fmu_results.json
+++ b/schemas/0.8.0/fmu_results.json
@@ -476,10 +476,7 @@
           "$ref": "#/$defs/Masterdata"
         },
         "source": {
-          "const": "fmu",
-          "enum": [
-            "fmu"
-          ],
+          "default": "fmu",
           "title": "Source",
           "type": "string"
         },
@@ -487,10 +484,7 @@
           "$ref": "#/$defs/Tracklog"
         },
         "version": {
-          "const": "0.8.0",
-          "enum": [
-            "0.8.0"
-          ],
+          "default": "0.8.0",
           "title": "Version",
           "type": "string"
         }
@@ -499,8 +493,6 @@
         "class",
         "masterdata",
         "tracklog",
-        "source",
-        "version",
         "fmu",
         "access"
       ],
@@ -3555,10 +3547,7 @@
           "$ref": "#/$defs/Masterdata"
         },
         "source": {
-          "const": "fmu",
-          "enum": [
-            "fmu"
-          ],
+          "default": "fmu",
           "title": "Source",
           "type": "string"
         },
@@ -3566,10 +3555,7 @@
           "$ref": "#/$defs/Tracklog"
         },
         "version": {
-          "const": "0.8.0",
-          "enum": [
-            "0.8.0"
-          ],
+          "default": "0.8.0",
           "title": "Version",
           "type": "string"
         }
@@ -3578,8 +3564,6 @@
         "class",
         "masterdata",
         "tracklog",
-        "source",
-        "version",
         "fmu",
         "access"
       ],
@@ -4664,10 +4648,7 @@
           "$ref": "#/$defs/Masterdata"
         },
         "source": {
-          "const": "fmu",
-          "enum": [
-            "fmu"
-          ],
+          "default": "fmu",
           "title": "Source",
           "type": "string"
         },
@@ -4675,10 +4656,7 @@
           "$ref": "#/$defs/Tracklog"
         },
         "version": {
-          "const": "0.8.0",
-          "enum": [
-            "0.8.0"
-          ],
+          "default": "0.8.0",
           "title": "Version",
           "type": "string"
         }
@@ -4687,8 +4665,6 @@
         "class",
         "masterdata",
         "tracklog",
-        "source",
-        "version",
         "fmu",
         "access",
         "data",
@@ -6496,10 +6472,7 @@
           "$ref": "#/$defs/Masterdata"
         },
         "source": {
-          "const": "fmu",
-          "enum": [
-            "fmu"
-          ],
+          "default": "fmu",
           "title": "Source",
           "type": "string"
         },
@@ -6507,10 +6480,7 @@
           "$ref": "#/$defs/Tracklog"
         },
         "version": {
-          "const": "0.8.0",
-          "enum": [
-            "0.8.0"
-          ],
+          "default": "0.8.0",
           "title": "Version",
           "type": "string"
         }
@@ -6519,8 +6489,6 @@
         "class",
         "masterdata",
         "tracklog",
-        "source",
-        "version",
         "fmu",
         "access"
       ],

--- a/src/fmu/dataio/_model/root.py
+++ b/src/fmu/dataio/_model/root.py
@@ -13,7 +13,7 @@ from pydantic import (
 from pydantic.json_schema import GenerateJsonSchema
 from typing_extensions import Annotated
 
-from fmu.dataio._definitions import FmuSchemas, SchemaBase
+from fmu.dataio._definitions import SOURCE, FmuSchemas, SchemaBase
 
 from .data import AnyData
 from .enums import FMUClass
@@ -38,6 +38,102 @@ if TYPE_CHECKING:
 T = TypeVar("T", Dict, List, object)
 
 
+class FmuResultsSchema(SchemaBase):
+    """The main metadata export describing the results."""
+
+    VERSION: str = "0.8.0"
+    FILENAME: str = "fmu_results.json"
+    PATH: Path = FmuSchemas.PATH / VERSION / FILENAME
+
+    class FmuResultsGenerateJsonSchema(GenerateJsonSchema):
+        contractual: Final[list[str]] = [
+            "access",
+            "class",
+            "data.alias",
+            "data.bbox",
+            "data.content",
+            "data.format",
+            "data.geometry",
+            "data.grid_model",
+            "data.is_observation",
+            "data.is_prediction",
+            "data.name",
+            "data.offset",
+            "data.product.name",
+            "data.seismic.attribute",
+            "data.spec.columns",
+            "data.stratigraphic",
+            "data.stratigraphic_alias",
+            "data.tagname",
+            "data.time",
+            "data.vertical_domain",
+            "file.checksum_md5",
+            "file.relative_path",
+            "file.size_bytes",
+            "fmu.aggregation.operation",
+            "fmu.aggregation.realization_ids",
+            "fmu.case",
+            "fmu.context.stage",
+            "fmu.iteration.name",
+            "fmu.iteration.uuid",
+            "fmu.model",
+            "fmu.realization.id",
+            "fmu.realization.is_reference",
+            "fmu.realization.name",
+            "fmu.realization.uuid",
+            "fmu.workflow",
+            "masterdata",
+            "source",
+            "tracklog.datetime",
+            "tracklog.event",
+            "tracklog.user.id",
+            "version",
+        ]
+
+        def _remove_format_path(self, obj: T) -> T:
+            """
+            Removes entries with key "format" and value "path" from dictionaries. This
+            adjustment is necessary because JSON Schema does not recognize the "format":
+            "path", while OpenAPI does. This function is used in contexts where OpenAPI
+            specifications are not applicable.
+            """
+
+            if isinstance(obj, dict):
+                return {
+                    k: self._remove_format_path(v)
+                    for k, v in obj.items()
+                    if not (k == "format" and v == "path")
+                }
+
+            if isinstance(obj, list):
+                return [self._remove_format_path(element) for element in obj]
+
+            return obj
+
+        def generate(
+            self,
+            schema: Mapping[str, Any],
+            mode: Literal["validation", "serialization"] = "validation",
+        ) -> dict[str, Any]:
+            json_schema = super().generate(schema, mode=mode)
+            json_schema["$schema"] = self.schema_dialect
+            json_schema["$id"] = FmuResultsSchema.url()
+            json_schema["$contractual"] = self.contractual
+
+            # sumo-core's validator does not recognize these.
+            del json_schema["discriminator"]["mapping"]
+            del json_schema["$defs"]["AnyData"]["discriminator"]["mapping"]
+            del json_schema["$defs"]["AnyProduct"]["discriminator"]["mapping"]
+
+            return self._remove_format_path(json_schema)
+
+    @staticmethod
+    def dump() -> dict[str, Any]:
+        return Root.model_json_schema(
+            schema_generator=FmuResultsSchema.FmuResultsGenerateJsonSchema
+        )
+
+
 class MetadataBase(BaseModel):
     """Base model for all root metadata models generated."""
 
@@ -52,10 +148,10 @@ class MetadataBase(BaseModel):
     """The ``tracklog`` block contains a record of events recorded on these data.
     See :class:`Tracklog`."""
 
-    source: Literal["fmu"]
+    source: str = SOURCE
     """The source of this data. Defaults to 'fmu'."""
 
-    version: Literal["0.8.0"]
+    version: str = Field(default=FmuResultsSchema.VERSION)
     """The version of the schema that generated this data."""
 
 
@@ -197,99 +293,3 @@ class Root(
             }
         )
         return json_schema
-
-
-class FmuResultsSchema(SchemaBase):
-    """The main metadata export describing the results."""
-
-    VERSION: str = "0.8.0"
-    FILENAME: str = "fmu_results.json"
-    PATH: Path = FmuSchemas.PATH / VERSION / FILENAME
-
-    class FmuResultsGenerateJsonSchema(GenerateJsonSchema):
-        contractual: Final[list[str]] = [
-            "access",
-            "class",
-            "data.alias",
-            "data.bbox",
-            "data.content",
-            "data.format",
-            "data.geometry",
-            "data.grid_model",
-            "data.is_observation",
-            "data.is_prediction",
-            "data.name",
-            "data.offset",
-            "data.product.name",
-            "data.seismic.attribute",
-            "data.spec.columns",
-            "data.stratigraphic",
-            "data.stratigraphic_alias",
-            "data.tagname",
-            "data.time",
-            "data.vertical_domain",
-            "file.checksum_md5",
-            "file.relative_path",
-            "file.size_bytes",
-            "fmu.aggregation.operation",
-            "fmu.aggregation.realization_ids",
-            "fmu.case",
-            "fmu.context.stage",
-            "fmu.iteration.name",
-            "fmu.iteration.uuid",
-            "fmu.model",
-            "fmu.realization.id",
-            "fmu.realization.is_reference",
-            "fmu.realization.name",
-            "fmu.realization.uuid",
-            "fmu.workflow",
-            "masterdata",
-            "source",
-            "tracklog.datetime",
-            "tracklog.event",
-            "tracklog.user.id",
-            "version",
-        ]
-
-        def _remove_format_path(self, obj: T) -> T:
-            """
-            Removes entries with key "format" and value "path" from dictionaries. This
-            adjustment is necessary because JSON Schema does not recognize the "format":
-            "path", while OpenAPI does. This function is used in contexts where OpenAPI
-            specifications are not applicable.
-            """
-
-            if isinstance(obj, dict):
-                return {
-                    k: self._remove_format_path(v)
-                    for k, v in obj.items()
-                    if not (k == "format" and v == "path")
-                }
-
-            if isinstance(obj, list):
-                return [self._remove_format_path(element) for element in obj]
-
-            return obj
-
-        def generate(
-            self,
-            schema: Mapping[str, Any],
-            mode: Literal["validation", "serialization"] = "validation",
-        ) -> dict[str, Any]:
-            json_schema = super().generate(schema, mode=mode)
-            json_schema["$schema"] = self.schema_dialect
-            json_schema["$id"] = FmuResultsSchema.url()
-            json_schema["$contractual"] = self.contractual
-
-            # sumo-core's validator does not recognize these.
-            del json_schema["discriminator"]["mapping"]
-            del json_schema["$defs"]["AnyData"]["discriminator"]["mapping"]
-            del json_schema["$defs"]["AnyProduct"]["discriminator"]["mapping"]
-
-            return self._remove_format_path(json_schema)
-
-    @staticmethod
-    def dump() -> dict[str, Any]:
-        return Root.model_json_schema(
-            schema_generator=FmuResultsSchema.FmuResultsGenerateJsonSchema
-        )

--- a/src/fmu/dataio/aggregation.py
+++ b/src/fmu/dataio/aggregation.py
@@ -12,7 +12,7 @@ from fmu.dataio._model import fields
 
 from . import _utils, dataio, types
 from ._logging import null_logger
-from ._model import schema
+from ._metadata import ObjectMetadataExport
 from ._model.enums import FMUContext
 from .exceptions import InvalidMetadataError
 from .providers.objectdata._provider import objectdata_provider_factory
@@ -65,7 +65,7 @@ class AggregatedData:
     tagname: str = ""
     verbosity: str = "DEPRECATED"  # keep for while
 
-    _metadata: schema.InternalObjectMetadata = field(init=False)
+    _metadata: ObjectMetadataExport = field(init=False)
     _metafile: Path = field(default_factory=Path, init=False)
 
     def __post_init__(self) -> None:
@@ -292,7 +292,7 @@ class AggregatedData:
             template["data"]["bbox"] = bbox
 
         try:
-            self._metadata = schema.InternalObjectMetadata.model_validate(template)
+            self._metadata = ObjectMetadataExport.model_validate(template)
         except ValidationError as err:
             raise InvalidMetadataError(
                 f"The existing metadata for the aggregated data is invalid. "

--- a/src/fmu/dataio/case.py
+++ b/src/fmu/dataio/case.py
@@ -13,7 +13,8 @@ from fmu.dataio._model import fields
 
 from . import _utils
 from ._logging import null_logger
-from ._model import global_configuration, schema
+from ._metadata import CaseMetadataExport
+from ._model import global_configuration
 from ._model.fields import Access, Case, Masterdata, Model, User
 
 logger: Final = null_logger(__name__)
@@ -115,7 +116,7 @@ class CreateCaseMetadata:  # pylint: disable=too-few-public-methods
             warnings.warn(exists_warning, UserWarning)
             return {}
 
-        self._metadata = schema.InternalCaseMetadata(
+        self._metadata = CaseMetadataExport(
             masterdata=Masterdata.model_validate(self.config["masterdata"]),
             access=Access.model_validate(self.config["access"]),
             fmu=fields.FMUBase(

--- a/src/fmu/dataio/preprocessed.py
+++ b/src/fmu/dataio/preprocessed.py
@@ -10,7 +10,8 @@ import yaml
 from pydantic import ValidationError
 
 from ._logging import null_logger
-from ._model import enums, schema
+from ._metadata import ObjectMetadataExport
+from ._model import enums
 from ._model.enums import FMUContext
 from ._model.fields import File
 from ._utils import export_metadata_file, md5sum
@@ -186,9 +187,7 @@ class ExportPreprocessedData:
         try:
             # TODO: Would like to use meta.Root.model_validate() here
             # but then the '$schema' field is dropped from the meta_existing
-            validated_metadata = schema.InternalObjectMetadata.model_validate(
-                meta_existing
-            )
+            validated_metadata = ObjectMetadataExport.model_validate(meta_existing)
             validated_metadata.tracklog.extend(enums.TrackLogEventType.merged)
             return validated_metadata.model_dump(
                 mode="json", exclude_none=True, by_alias=True

--- a/src/fmu/dataio/providers/_fmu.py
+++ b/src/fmu/dataio/providers/_fmu.py
@@ -41,7 +41,8 @@ import pydantic
 from fmu.config import utilities as ut
 from fmu.dataio import _utils
 from fmu.dataio._logging import null_logger
-from fmu.dataio._model import fields, schema
+from fmu.dataio._metadata import CaseMetadataExport
+from fmu.dataio._model import fields
 from fmu.dataio._model.enums import ErtSimulationMode, FMUContext
 from fmu.dataio.exceptions import InvalidMetadataError
 
@@ -280,7 +281,7 @@ class FmuProvider(Provider):
             return None
 
         try:
-            restart_metadata = schema.InternalCaseMetadata.model_validate(
+            restart_metadata = CaseMetadataExport.model_validate(
                 ut.yaml_load(restart_case_metafile)
             )
             return _utils.uuid_from_string(
@@ -300,12 +301,12 @@ class FmuProvider(Provider):
         real_uuid = _utils.uuid_from_string(f"{case_uuid}{iter_uuid}{self._real_id}")
         return iter_uuid, real_uuid
 
-    def _get_case_meta(self) -> schema.InternalCaseMetadata:
+    def _get_case_meta(self) -> CaseMetadataExport:
         """Parse and validate the CASE metadata."""
         logger.debug("Loading case metadata file and return pydantic case model")
         assert self._casepath is not None
         case_metafile = self._casepath / ERT_RELATIVE_CASE_METADATA_FILE
-        return schema.InternalCaseMetadata.model_validate(
+        return CaseMetadataExport.model_validate(
             ut.yaml_load(case_metafile, loader="standard")
         )
 

--- a/src/fmu/dataio/providers/objectdata/_base.py
+++ b/src/fmu/dataio/providers/objectdata/_base.py
@@ -15,9 +15,9 @@ from fmu.dataio._model.global_configuration import (
     StratigraphyElement,
 )
 from fmu.dataio._model.product import Product
-from fmu.dataio._model.schema import AllowedContent, InternalUnsetData
 from fmu.dataio._utils import generate_description
 from fmu.dataio.providers._base import Provider
+from fmu.dataio.providers.objectdata._export_models import AllowedContent, UnsetData
 
 if TYPE_CHECKING:
     from fmu.dataio._model.data import (
@@ -53,7 +53,7 @@ class ObjectDataProvider(Provider):
     # result properties; the most important is metadata which IS the 'data' part in
     # the resulting metadata. But other variables needed later are also given
     # as instance properties in addition (for simplicity in other classes/functions)
-    _metadata: AnyData | InternalUnsetData | None = field(default=None)
+    _metadata: AnyData | UnsetData | None = field(default=None)
     name: str = field(default="")
     time0: datetime | None = field(default=None)
     time1: datetime | None = field(default=None)
@@ -101,7 +101,7 @@ class ObjectDataProvider(Provider):
         metadata["description"] = generate_description(self.dataio.description)
 
         self._metadata = (
-            InternalUnsetData.model_validate(metadata)
+            UnsetData.model_validate(metadata)
             if metadata["content"] == "unset"
             else AnyData.model_validate(metadata)
         )
@@ -149,7 +149,7 @@ class ObjectDataProvider(Provider):
     def get_spec(self) -> AnySpecification | None:
         raise NotImplementedError
 
-    def get_metadata(self) -> AnyData | InternalUnsetData:
+    def get_metadata(self) -> AnyData | UnsetData:
         assert self._metadata is not None
         return self._metadata
 

--- a/tools/update-schema
+++ b/tools/update-schema
@@ -195,7 +195,7 @@ def write_schema(
                 f"{BOLD}{schema.FILENAME}{NC} version {BOLD}{schema.VERSION}{NC}: "
                 f"modifying '$id' url to 'prod':\n      {schema.url()}",
             )
-        else:
+        elif new_schema == existing_schema:
             print(
                 PASS,
                 f"{BOLD}{schema.FILENAME}{NC} version "


### PR DESCRIPTION
This restructures how these classes are formed and where they live. It was confusing to locate them with the model when they are really just tweaks to the model for us when exporting. This refactor tries to bring some clarity to that relationship.

It also changes some of the metadata classes to use their literal values as defaults which changed the schema.