### PR TITLE
FIX: Open metadata with utf-8 encoding

### DIFF
--- a/src/fmu/dataio/_utils.py
+++ b/src/fmu/dataio/_utils.py
@@ -130,7 +130,7 @@ def export_file(
             serialized_json = json.dumps(obj)
 
         if isinstance(file, Path):
-            with open(file, "w") as stream:
+            with open(file, "w", encoding="utf-8") as stream:
                 stream.write(serialized_json)
         else:
             file.write(serialized_json.encode("utf-8"))
@@ -220,7 +220,7 @@ def read_parameters_txt(pfile: Path | str) -> types.Parameters:
 
     res: types.Parameters = {}
 
-    with open(pfile) as f:
+    with open(pfile, encoding="utf-8") as f:
         for line in f:
             line_parts = shlex.split(line)
             if len(line_parts) == 2:
@@ -346,7 +346,7 @@ def read_metadata_from_file(filename: str | Path) -> dict:
     metafilepath = Path(metafile)
     if not metafilepath.exists():
         raise OSError(f"Cannot find requested metafile: {metafile}")
-    with open(metafilepath) as stream:
+    with open(metafilepath, encoding="utf-8") as stream:
         return yaml.safe_load(stream)
 
 


### PR DESCRIPTION
Resolves #978 

When calling 'open' without specifying the encoding Python will use `locale.getencoding()` for Python 3.11+ and
`locale.getpreferredencoding(False)` (with or without the `False`) for Python 3.8 to determine which encoding to open the file with.

RMS sets this to ANSI_X3.4-1968 (a weird way of saying ascii). This can cause opening the file to fail when non-ascii characters are present within it.