### PR TITLE
ENH: Add stricter validation to version fields

### DIFF
--- a/schemas/0.8.0/fmu_results.json
+++ b/schemas/0.8.0/fmu_results.json
@@ -491,6 +491,7 @@
         },
         "version": {
           "default": "0.8.0",
+          "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)",
           "title": "Version",
           "type": "string"
         }
@@ -3035,6 +3036,7 @@
           "type": "string"
         },
         "version": {
+          "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)",
           "title": "Version",
           "type": "string"
         }
@@ -3568,6 +3570,7 @@
         },
         "version": {
           "default": "0.8.0",
+          "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)",
           "title": "Version",
           "type": "string"
         }
@@ -4675,6 +4678,7 @@
         },
         "version": {
           "default": "0.8.0",
+          "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)",
           "title": "Version",
           "type": "string"
         }
@@ -6505,6 +6509,7 @@
         },
         "version": {
           "default": "0.8.0",
+          "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)",
           "title": "Version",
           "type": "string"
         }

--- a/src/fmu/dataio/_models/fmu_results/fmu_results.py
+++ b/src/fmu/dataio/_models/fmu_results/fmu_results.py
@@ -18,6 +18,7 @@ from fmu.dataio._models._schema_base import (
     GenerateJsonSchemaBase,
     SchemaBase,
 )
+from fmu.dataio.types import VersionStr
 
 from .data import AnyData
 from .enums import FMUClass
@@ -43,7 +44,7 @@ if TYPE_CHECKING:
 class FmuResultsSchema(SchemaBase):
     """The main metadata export describing the results."""
 
-    VERSION: str = "0.8.0"
+    VERSION: VersionStr = "0.8.0"
     FILENAME: str = "fmu_results.json"
     PATH: Path = FmuSchemas.PATH / VERSION / FILENAME
 
@@ -129,7 +130,7 @@ class MetadataBase(BaseModel):
     source: str = Field(default=FmuResultsSchema.SOURCE)
     """The source of this data. Defaults to 'fmu'."""
 
-    version: str = Field(default=FmuResultsSchema.VERSION)
+    version: VersionStr = Field(default=FmuResultsSchema.VERSION)
     """The version of the schema that generated this data."""
 
     schema_: AnyHttpUrl = Field(

--- a/src/fmu/dataio/_models/fmu_results/product.py
+++ b/src/fmu/dataio/_models/fmu_results/product.py
@@ -11,6 +11,7 @@ from pydantic import (
 from typing_extensions import Annotated
 
 from fmu.dataio._models.products import InplaceVolumesSchema
+from fmu.dataio.types import VersionStr
 
 from . import enums
 
@@ -18,7 +19,7 @@ from . import enums
 class FileSchema(BaseModel):
     """The schema identifying the format of a product."""
 
-    version: str
+    version: VersionStr
     """The version of the product schema."""
 
     url: AnyHttpUrl

--- a/src/fmu/dataio/_models/products/inplace_volumes.py
+++ b/src/fmu/dataio/_models/products/inplace_volumes.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field, RootModel
 
 from fmu.dataio._models._schema_base import FmuSchemas, SchemaBase
 from fmu.dataio.export._enums import InplaceVolumes
+from fmu.dataio.types import VersionStr
 
 if TYPE_CHECKING:
     from typing import Any
@@ -78,7 +79,7 @@ class InplaceVolumesSchema(SchemaBase):
     locaiton corresponds directly with the values and their validation constraints,
     documented above."""
 
-    VERSION: str = "0.1.0"
+    VERSION: VersionStr = "0.1.0"
     """The version of this schema."""
 
     FILENAME: str = "inplace_volumes.json"

--- a/src/fmu/dataio/types.py
+++ b/src/fmu/dataio/types.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Literal, MutableMapping, Union
 
+from pydantic import Field
 from typing_extensions import Annotated, TypeAlias
 
 if TYPE_CHECKING:
@@ -50,6 +51,10 @@ if TYPE_CHECKING:
         ],
         "Collection of 'inferrable' objects with metadata deduction capabilities",
     ]
+
+VersionStr: TypeAlias = Annotated[
+    str, Field(pattern=r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)")
+]
 
 Parameters: TypeAlias = Annotated[
     MutableMapping[str, Union[str, float, int, None, "Parameters"]],

--- a/tests/test_schema/test_custom_field_validation_types.py
+++ b/tests/test_schema/test_custom_field_validation_types.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from fmu.dataio._models import FmuResults
+
+
+def test_version_string_type(metadata_examples: dict[str, Any]) -> None:
+    """Tests fmu.dataio.types.VerionStr"""
+    example = deepcopy(metadata_examples["surface_depth.yml"])
+    example["version"] = "1.2.a"
+    with pytest.raises(ValidationError, match="String should match pattern"):
+        FmuResults.model_validate(example)
+    example["version"] = "1.2"
+    with pytest.raises(ValidationError, match="String should match pattern"):
+        FmuResults.model_validate(example)

--- a/tests/test_schema/test_schemabase.py
+++ b/tests/test_schema/test_schemabase.py
@@ -28,6 +28,29 @@ def test_schemabase_validates_class_vars() -> None:
             PATH: Path = FmuSchemas.PATH / "test"
 
 
+def test_schemabase_validates_verion_string_form() -> None:
+    with pytest.raises(TypeError, match="Invalid VERSION format for 'MajorMinor'"):
+
+        class MajorMinor(SchemaBase):
+            VERSION = "12.3"
+            FILENAME: str = "fmu_results.json"
+            PATH: Path = FmuSchemas.PATH / "test"
+
+    with pytest.raises(TypeError, match="Invalid VERSION format for 'Alphanumeric'"):
+
+        class Alphanumeric(SchemaBase):
+            VERSION = "1.3.a"
+            FILENAME: str = "fmu_results.json"
+            PATH: Path = FmuSchemas.PATH / "test"
+
+    with pytest.raises(TypeError, match="Invalid VERSION format for 'LeadingZero'"):
+
+        class LeadingZero(SchemaBase):
+            VERSION = "01.3.0"
+            FILENAME: str = "fmu_results.json"
+            PATH: Path = FmuSchemas.PATH / "test"
+
+
 def test_schemabase_requires_path_starting_with_fmuschemas_path() -> None:
     """Tests that SchemaBase catches if a subclass's PATH does not fall into the main
     schemas directory."""


### PR DESCRIPTION
Contributes to #911 

Note this skips _some_ version fields that may not be in a strict SemVer form. This is specifically checking that schema versions are of the right form.