### PR TITLE
FIX: Fix standard table index for volumes

### DIFF
--- a/src/fmu/dataio/_definitions.py
+++ b/src/fmu/dataio/_definitions.py
@@ -64,7 +64,7 @@ class ExportFolder(str, Enum):
 
 
 STANDARD_TABLE_INDEX_COLUMNS: Final[dict[str, list[str]]] = {
-    "volumes": ["ZONE", "REGION", "FACIES", "LICENCE"],
+    "volumes": ["ZONE", "REGION", "FACIES", "LICENSE", "FLUID"],
     "rft": ["measured_depth", "well", "time"],
     "timeseries": ["DATE"],
     "simulationtimeseries": ["DATE"],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -747,7 +747,8 @@ def fixture_mock_volumes():
     return pd.DataFrame(
         {
             "ZONE": ["B", "A", "C"],
-            "LICENCE": ["L3", "L2", "L1"],
+            "LICENSE": ["L3", "L2", "L1"],
+            "FLUID": ["oil", "gas", "water"],
             "nums": [1, 2, 3],
             "OTHER": ["q", "a", "f"],
         }

--- a/tests/test_units/test_table.py
+++ b/tests/test_units/test_table.py
@@ -58,7 +58,7 @@ def test_inplace_volume_index(mock_volumes, globalconfig2, monkeypatch, tmp_path
         globalconfig2 (dict): one global variables dict
     """
     monkeypatch.chdir(tmp_path)
-    answer = ["ZONE", "LICENCE"]
+    answer = ["ZONE", "LICENSE", "FLUID"]
     exd = ExportData(config=globalconfig2, content="volumes", name="baretull")
     path = exd.export(mock_volumes)
     assert_correct_table_index(path, answer)


### PR DESCRIPTION
Added `FLUID` as standard table index column, and fixed typo in `LICENSE` for tables of content `volumes`.
Closes #918 
Closes #917 