### PR TITLE
ENH: Add standard table index column for `relperm`

### DIFF
--- a/src/fmu/dataio/_definitions.py
+++ b/src/fmu/dataio/_definitions.py
@@ -69,4 +69,5 @@ STANDARD_TABLE_INDEX_COLUMNS: Final[dict[str, list[str]]] = {
     "timeseries": ["DATE"],
     "simulationtimeseries": ["DATE"],
     "wellpicks": ["WELL", "HORIZON"],
+    "relperm": ["SATNUM"],
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -725,6 +725,12 @@ def fixture_summary():
     return pd.DataFrame({"alf": ["A", "B", "C"], "DATE": [1, 2, 3]})
 
 
+@pytest.fixture(name="mock_relperm")
+def fixture_relperm():
+    """Return relperm mock data"""
+    return pd.DataFrame({"alf": ["A", "B", "C"], "SATNUM": [1, 2, 3]})
+
+
 @pytest.fixture(name="drogon_summary")
 def fixture_drogon_sum(rootpath):
     """Return pyarrow table

--- a/tests/test_units/test_table.py
+++ b/tests/test_units/test_table.py
@@ -64,6 +64,15 @@ def test_inplace_volume_index(mock_volumes, globalconfig2, monkeypatch, tmp_path
     assert_correct_table_index(path, answer)
 
 
+def test_relperm_index(mock_relperm, globalconfig2, monkeypatch, tmp_path):
+    """Test that the table index is set correct for relperm data"""
+    monkeypatch.chdir(tmp_path)
+    answer = ["SATNUM"]
+    exd = ExportData(config=globalconfig2, content="relperm", name="baretull")
+    path = exd.export(mock_relperm)
+    assert_correct_table_index(path, answer)
+
+
 def test_derive_summary_index_pandas(
     mock_summary, globalconfig2, monkeypatch, tmp_path
 ):


### PR DESCRIPTION
PR to add `SATNUM` as standard table index column for tables of content `relperm`
Closes #931 

number 1000 🍾 🎊 🎉 