### PR TITLE
MAINT: Move exceptions from _definitions to exceptions file

### DIFF
--- a/src/fmu/dataio/_definitions.py
+++ b/src/fmu/dataio/_definitions.py
@@ -6,14 +6,6 @@ from enum import Enum
 from typing import Final
 
 
-class ValidationError(ValueError, KeyError):
-    """Raise error while validating."""
-
-
-class ConfigurationError(ValueError):
-    pass
-
-
 class ValidFormats(Enum):
     surface = {
         "irap_binary": ".gri",

--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -27,7 +27,6 @@ if TYPE_CHECKING:
 
 from fmu.dataio.aggregation import AggregatedData
 
-from ._definitions import ValidationError
 from ._logging import null_logger
 from ._metadata import generate_export_metadata
 from ._models.fmu_results import enums, global_configuration
@@ -42,6 +41,7 @@ from ._utils import (
     some_config_from_env,
 )
 from .case import CreateCaseMetadata
+from .exceptions import ValidationError
 from .preprocessed import ExportPreprocessedData
 from .providers._filedata import FileDataProvider
 from .providers._fmu import FmuProvider, get_fmu_context_from_environment

--- a/src/fmu/dataio/exceptions.py
+++ b/src/fmu/dataio/exceptions.py
@@ -3,3 +3,11 @@ from __future__ import annotations
 
 class InvalidMetadataError(Exception):
     """Raised when valid metadata cannot be generated or returned."""
+
+
+class ValidationError(ValueError, KeyError):
+    """Raise error while validating."""
+
+
+class ConfigurationError(ValueError):
+    pass

--- a/src/fmu/dataio/providers/objectdata/_base.py
+++ b/src/fmu/dataio/providers/objectdata/_base.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Final
 
-from fmu.dataio._definitions import ConfigurationError, ValidFormats
+from fmu.dataio._definitions import ValidFormats
 from fmu.dataio._logging import null_logger
 from fmu.dataio._models.fmu_results.data import AnyData, Time, Timestamp
 from fmu.dataio._models.fmu_results.enums import Content
@@ -16,6 +16,7 @@ from fmu.dataio._models.fmu_results.global_configuration import (
 )
 from fmu.dataio._models.fmu_results.product import Product
 from fmu.dataio._utils import generate_description
+from fmu.dataio.exceptions import ConfigurationError
 from fmu.dataio.providers._base import Provider
 from fmu.dataio.providers.objectdata._export_models import AllowedContent, UnsetData
 

--- a/tests/test_units/test_objectdataprovider_class.py
+++ b/tests/test_units/test_objectdataprovider_class.py
@@ -7,8 +7,9 @@ import pytest
 import yaml
 
 from fmu import dataio
-from fmu.dataio._definitions import ConfigurationError, ValidFormats
+from fmu.dataio._definitions import ValidFormats
 from fmu.dataio._models.fmu_results.specification import FaultRoomSurfaceSpecification
+from fmu.dataio.exceptions import ConfigurationError
 from fmu.dataio.providers.objectdata._faultroom import FaultRoomSurfaceProvider
 from fmu.dataio.providers.objectdata._provider import (
     objectdata_provider_factory,


### PR DESCRIPTION
Small PR to move custom exceptions defined in `fmu.dataio._definitions` to the already existing `fmu.dataio.exceptions`