### PR TITLE
FIX: Use content to find correct standard table_index for tables

### DIFF
--- a/docs/src/dataio_3_migration.rst
+++ b/docs/src/dataio_3_migration.rst
@@ -82,6 +82,11 @@ Additionally
  - ``fmu_context='case_symlink_realization'`` is no longer a valid argument value for ``fmu_context``.  
    If necessary to create symlinks from data stored at case level to the individual realizations, 
    use the ``SYMLINK`` forward model provided by ERT instead.
+ - The process for setting the ``table_index`` in metadata when not provided by the user has changed.
+   Previously, a ``table_index`` was automatically assigned from a set of commonly known index columns,
+   now the table_index will remain empty. An exception exists for tables associated with content types
+   that have a predefined standard index; then the ``table_index`` will be set to the intersection of
+   the table's columns and the standard.
 
 
 Changes to class variables 
@@ -226,7 +231,7 @@ Using the ``ExportData`` class for re-exporting preprocessed data is deprecated.
 as input argument, and redundant arguments are no longer accepted.
 
 
-Exaple using ``ExportData`` to re-export preprocessed data:
+Example using ``ExportData`` to re-export preprocessed data:
 
 .. code-block:: python
 
@@ -245,7 +250,7 @@ Exaple using ``ExportData`` to re-export preprocessed data:
     exd.export(preprocessed_seismic_cube)
 
 
-Exaple using ``ExportPreprocessedData`` to re-export preprocessed data:
+Example using ``ExportPreprocessedData`` to re-export preprocessed data:
 
 .. code-block:: python
 

--- a/tests/test_export_rms/test_export_rms_volumetrics.py
+++ b/tests/test_export_rms/test_export_rms_volumetrics.py
@@ -106,7 +106,7 @@ def test_rms_volumetrics_export_class_table_index(voltable_standard, exportvolum
 
     # should fail if missing table index
     exportvolumetrics._dataframe = voltable_standard.drop(columns="ZONE")
-    with pytest.raises(KeyError, match="ZONE is not in table"):
+    with pytest.raises(KeyError, match="are not present"):
         exportvolumetrics._export_volume_table()
 
 


### PR DESCRIPTION
PR to start using the `content` to find the correct standard `table_index` columns for a table if it is defined in the `STANDARD_TABLE_INDEX_COLUMNS`.

Previous functionality has been to compare the columns in the table against all commonly known index columns (independent of content), and set the table_index based on matches found.

- This functionality is kept for contents that don't yet have standard table_index columns defined, but is deprecated with a message telling the user to set the table_index as input to prevent `data.table_index` being empty in the future. 

Closes #915 