### PR TITLE
MAINT: Add extra required info for standard_table_index

### DIFF
--- a/src/fmu/dataio/providers/objectdata/_tables.py
+++ b/src/fmu/dataio/providers/objectdata/_tables.py
@@ -42,8 +42,8 @@ def _derive_index(table_index: list[str] | None, columns: list[str]) -> list[str
 
     if table_index is None:
         logger.debug("Finding index to include")
-        for context, standard_cols in STANDARD_TABLE_INDEX_COLUMNS.items():
-            for valid_col in standard_cols:
+        for context, standard_table_index in STANDARD_TABLE_INDEX_COLUMNS.items():
+            for valid_col in standard_table_index.columns:
                 if valid_col in columns and valid_col not in index:
                     index.append(valid_col)
             if index:


### PR DESCRIPTION
PR to add a way to separate which index columns are required and not. 
On the road to improving data standards we would like to give the users information when they are not following the standards, this enables giving the warning only for columns marked as required. 
Closes #1011 
Towards #915
