### PR TITLE
DEP: Deprecate content as dict input, split in two arguments

### DIFF
--- a/docs/src/dataio_3_migration.rst
+++ b/docs/src/dataio_3_migration.rst
@@ -20,7 +20,9 @@ but with replacements inplace.
    a dictionary form to provide a reference together with the ``vertical_domain`` is deprecated, use 
    the ``domain_reference`` argument instead.
  - ``workflow`` now only supports string input, example ``workflow='Structural modelling'``.
- - ``content`` was previously optional, it should now be explicitly provided.
+ - ``content`` was previously optional, it should now be explicitly provided as a valid content string.
+ - ``content`` no longer supports using a dictionary form to provide extra information together
+   with the ``content``, use the ``content_metadata`` argument instead.
  - ``content={'seismic': {'offset': '0-15'}}`` no longer works, use the key ``stacking_offset`` instead 
    of ``offset``.
 
@@ -32,6 +34,7 @@ Following are an example demonstrating several deprecated patterns:
     from fmu.dataio import ExportData
 
     ExportData(
+        content={'seismic': {'attribute': 'amplitude', 'calculation': 'mean'}}, # ⛔️ 
         fmu_context='preprocessed', # ⛔️ 
         access_ssdl={'access_level': 'asset', 'rep_include': True}, # ⛔️ 
         vertical_domain={'depth': 'msl'}, # ⛔️ 
@@ -45,7 +48,8 @@ Change to this instead 👇:
     from fmu.dataio import ExportData
 
     ExportData(
-        content='depth', # ✅ content must explicitly be provided
+        content='seismic', # ✅ content must explicitly be provided as a string
+        content_metadata={'attribute': 'amplitude', 'calculation': 'mean'}, # ✅
         preprocessed=True, # ✅
         classification='restricted', # ✅ note the use of 'restricted' instead of 'asset'
         rep_include=True, # ✅

--- a/tests/test_units/test_contents.py
+++ b/tests/test_units/test_contents.py
@@ -3,7 +3,9 @@
 import pytest
 from pydantic import ValidationError
 
+from fmu.dataio._models.fmu_results import enums
 from fmu.dataio.dataio import ExportData
+from fmu.dataio.providers.objectdata._export_models import content_requires_metadata
 
 # generic testing of functionality related to content is done elsewhere,
 # mainly in test_dataio.py.
@@ -83,7 +85,7 @@ def test_content_fluid_contact_case_insensitive(regsurf, globalconfig2):
 
 def test_content_fluid_contact_raises_on_invalid_contact(regsurf, globalconfig2):
     """Test export of the fluid_contact content."""
-    with pytest.raises(ValidationError, match="fluid_contact"):
+    with pytest.raises(ValidationError, match="FluidContact"):
         ExportData(
             config=globalconfig2,
             name="MyName",
@@ -333,3 +335,19 @@ def test_content_wellpicks(dataframe, globalconfig2):
     ).generate_metadata(dataframe)
 
     assert meta["data"]["content"] == "wellpicks"
+
+
+def test_content_requires_metadata():
+    """Test the content_requires_metadata function"""
+
+    # test contents that requires extra
+    assert content_requires_metadata(enums.Content.field_outline)
+    assert content_requires_metadata(enums.Content.field_region)
+    assert content_requires_metadata(enums.Content.fluid_contact)
+    assert content_requires_metadata(enums.Content.property)
+    assert content_requires_metadata(enums.Content.seismic)
+
+    # test some random contents that does not require extra
+    assert not content_requires_metadata(enums.Content.depth)
+    assert not content_requires_metadata(enums.Content.timeseries)
+    assert not content_requires_metadata(enums.Content.volumes)

--- a/tests/test_units/test_dataio.py
+++ b/tests/test_units/test_dataio.py
@@ -470,7 +470,7 @@ def test_content_invalid_dict(globalconfig1, regsurf):
     eobj = ExportData(
         config=globalconfig1, content={"seismic": "some_key", "extra": "some_value"}
     )
-    with pytest.raises(ValueError, match="Found more than one content item"):
+    with pytest.raises(ValueError):
         eobj.generate_metadata(regsurf)
 
 
@@ -483,7 +483,7 @@ def test_content_valid_string(regsurf, globalconfig2):
 
 def test_seismic_content_require_seismic_data(globalconfig2, regsurf):
     eobj = ExportData(config=globalconfig2, content="seismic")
-    with pytest.raises(pydantic.ValidationError, match="requires additional input"):
+    with pytest.raises(ValueError, match="requires additional input"):
         eobj.generate_metadata(regsurf)
 
 
@@ -522,7 +522,7 @@ def test_content_is_a_wrongly_formatted_dict(globalconfig2, regsurf):
         name="TopVolantis",
         content={"seismic": "myvalue"},
     )
-    with pytest.raises(ValueError, match="incorrectly formatted"):
+    with pytest.raises(ValueError):
         eobj.generate_metadata(regsurf)
 
 


### PR DESCRIPTION
PR to start deprecating `content` as a dictionary, and introduce a new `content_metadata` argument for the additional information. 

Closes #1012  
Closes #1005 