### PR TITLE
CI: Pin Sphinx==8.1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dev = [
     "types-PyYAML",
 ]
 docs = [
-    "Sphinx",
+    "Sphinx==8.1.3",
     "autoapi",
     "autodoc-pydantic>=2.0.0",
     "furo",


### PR DESCRIPTION
PR to pin Sphinx==8.1.3
New version of sphinx released yesterday causes CI to fail #1017 
Not sure why yet, will make an issue to unpin it once we do.
