### PR TITLE
MAINT: Add warning if content_metadata is not required

### DIFF
--- a/src/fmu/dataio/providers/objectdata/_base.py
+++ b/src/fmu/dataio/providers/objectdata/_base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from abc import abstractmethod
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -182,6 +183,13 @@ class ObjectDataProvider(Provider):
                         f"{list(content_metadata_model.model_fields)}. "
                     )
                 return content_metadata_model.model_validate(content_metadata)
+
+            if content_metadata:
+                warnings.warn(
+                    f"Content '{content.value}' does not require 'content_metadata', "
+                    "ignoring input."
+                )
+
         return None
 
     @staticmethod

--- a/tests/test_units/test_dataio.py
+++ b/tests/test_units/test_dataio.py
@@ -600,6 +600,16 @@ def test_content_deprecated_seismic_offset(regsurf, globalconfig2):
     }
 
 
+def test_content_metdata_ignored(globalconfig1, regsurf):
+    """Test that warning is given when content does not require content_metadata"""
+    with pytest.warns(UserWarning, match="ignoring input"):
+        ExportData(
+            config=globalconfig1,
+            content="depth",
+            content_metadata={"extra": "invalid"},
+        ).generate_metadata(regsurf)
+
+
 @pytest.mark.filterwarnings("ignore: Number of maps nodes are 0")
 def test_surfaces_with_non_finite_values(
     globalconfig1, regsurf_masked_only, regsurf_nan_only, regsurf


### PR DESCRIPTION
Add warning to inform user if `content_metadata` is not required as input.
Closes #1025 