### PR TITLE
FIX: Require a valid config for standard_result exports

### DIFF
--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -865,6 +865,11 @@ class ExportData:
     def _export_with_product(self, obj: types.Inferrable, product: Product) -> str:
         """Export the object with product information in the metadata."""
 
+        if not isinstance(self.config, GlobalConfiguration):
+            raise ValidationError(
+                "When exporting standard_results it is required to have a valid config."
+            )
+
         fmudata = self._get_fmu_provider() if self._fmurun else None
 
         metadata = generate_export_metadata(

--- a/tests/test_export_rms/test_export_rms_volumetrics.py
+++ b/tests/test_export_rms/test_export_rms_volumetrics.py
@@ -466,6 +466,23 @@ def test_validate_table_against_pydantic_model_before_export(
 
 
 @inside_rms
+def test_rms_volumetrics_export_config_invalid(
+    mock_project_variable,
+    exportvolumetrics,
+):
+    """Test that an exception is raised if the config is invalid."""
+
+    from fmu.dataio.export.rms.inplace_volumes import export_inplace_volumes
+
+    with mock.patch(  # noqa
+        "fmu.dataio.export.rms.inplace_volumes.load_global_config",
+        return_value={},
+    ):
+        with pytest.raises(ValueError, match="valid config"):
+            export_inplace_volumes(mock_project_variable, "Geogrid", "geogrid_volume")
+
+
+@inside_rms
 def test_rms_volumetrics_export_config_missing(
     mock_project_variable,
     mocked_rmsapi_modules,


### PR DESCRIPTION
Add requirement that the config should be valid when exporting `standard_results` to prevent generating invalid metadata.
Closes #1023
