### PR TITLE
MAINT: Add FileFormat enum to schema

### DIFF
--- a/examples/0.8.0/summary_table.yml
+++ b/examples/0.8.0/summary_table.yml
@@ -42,15 +42,15 @@ fmu:
         VALYSAR_PERMH_CHANNEL: 1000
         VALYSAR_PERMH_CREVASSE: 100
 file:
-  relative_path: realization-0/iter-0/share/results/tables/drogon--summary.arrow
-  absolute_path: /scratch/fmu/dbs/drogon_ahm-2023-10-03/realization-0/iter-0/share/results/tables/drogon--summary.arrow
+  relative_path: realization-0/iter-0/share/results/tables/drogon--summary.parquet
+  absolute_path: /scratch/fmu/dbs/drogon_ahm-2023-10-03/realization-0/iter-0/share/results/tables/drogon--summary.parquet
   checksum_md5: c1da337b642fb594246c275a9bd597da
 data:
   name: DROGON
   stratigraphic: false
   content: timeseries
   tagname: summary
-  format: arrow
+  format: parquet
   layout: table
   unit: ""
   vertical_domain: depth

--- a/schemas/0.9.0/fmu_results.json
+++ b/schemas/0.9.0/fmu_results.json
@@ -735,11 +735,10 @@
           ]
         },
         "format": {
+          "$ref": "#/$defs/FileFormat",
           "examples": [
             "irap_binary"
-          ],
-          "title": "Format",
-          "type": "string"
+          ]
         },
         "geometry": {
           "anyOf": [
@@ -1298,11 +1297,10 @@
           ]
         },
         "format": {
+          "$ref": "#/$defs/FileFormat",
           "examples": [
             "irap_binary"
-          ],
-          "title": "Format",
-          "type": "string"
+          ]
         },
         "geometry": {
           "anyOf": [
@@ -1596,11 +1594,10 @@
           ]
         },
         "format": {
+          "$ref": "#/$defs/FileFormat",
           "examples": [
             "irap_binary"
-          ],
-          "title": "Format",
-          "type": "string"
+          ]
         },
         "geometry": {
           "anyOf": [
@@ -1894,11 +1891,10 @@
           ]
         },
         "format": {
+          "$ref": "#/$defs/FileFormat",
           "examples": [
             "irap_binary"
-          ],
-          "title": "Format",
-          "type": "string"
+          ]
         },
         "geometry": {
           "anyOf": [
@@ -2289,11 +2285,10 @@
           "$ref": "#/$defs/FieldOutline"
         },
         "format": {
+          "$ref": "#/$defs/FileFormat",
           "examples": [
             "irap_binary"
-          ],
-          "title": "Format",
-          "type": "string"
+          ]
         },
         "geometry": {
           "anyOf": [
@@ -2605,11 +2600,10 @@
           "$ref": "#/$defs/FieldRegion"
         },
         "format": {
+          "$ref": "#/$defs/FileFormat",
           "examples": [
             "irap_binary"
-          ],
-          "title": "Format",
-          "type": "string"
+          ]
         },
         "geometry": {
           "anyOf": [
@@ -2876,6 +2870,22 @@
       "title": "File",
       "type": "object"
     },
+    "FileFormat": {
+      "description": "The format of a given data object.",
+      "enum": [
+        "parquet",
+        "json",
+        "csv",
+        "csv|xtgeo",
+        "irap_ascii",
+        "irap_binary",
+        "roff",
+        "segy",
+        "openvds"
+      ],
+      "title": "FileFormat",
+      "type": "string"
+    },
     "FileSchema": {
       "description": "The schema identifying the format of a standard result.",
       "properties": {
@@ -3004,11 +3014,10 @@
           "$ref": "#/$defs/FluidContact"
         },
         "format": {
+          "$ref": "#/$defs/FileFormat",
           "examples": [
             "irap_binary"
-          ],
-          "title": "Format",
-          "type": "string"
+          ]
         },
         "geometry": {
           "anyOf": [
@@ -3488,11 +3497,10 @@
           ]
         },
         "format": {
+          "$ref": "#/$defs/FileFormat",
           "examples": [
             "irap_binary"
-          ],
-          "title": "Format",
-          "type": "string"
+          ]
         },
         "geometry": {
           "anyOf": [
@@ -3826,11 +3834,10 @@
           ]
         },
         "format": {
+          "$ref": "#/$defs/FileFormat",
           "examples": [
             "irap_binary"
-          ],
-          "title": "Format",
-          "type": "string"
+          ]
         },
         "geometry": {
           "anyOf": [
@@ -4177,11 +4184,10 @@
           ]
         },
         "format": {
+          "$ref": "#/$defs/FileFormat",
           "examples": [
             "irap_binary"
-          ],
-          "title": "Format",
-          "type": "string"
+          ]
         },
         "geometry": {
           "anyOf": [
@@ -4594,11 +4600,10 @@
           ]
         },
         "format": {
+          "$ref": "#/$defs/FileFormat",
           "examples": [
             "irap_binary"
-          ],
-          "title": "Format",
-          "type": "string"
+          ]
         },
         "geometry": {
           "anyOf": [
@@ -4892,11 +4897,10 @@
           ]
         },
         "format": {
+          "$ref": "#/$defs/FileFormat",
           "examples": [
             "irap_binary"
-          ],
-          "title": "Format",
-          "type": "string"
+          ]
         },
         "geometry": {
           "anyOf": [
@@ -5190,11 +5194,10 @@
           ]
         },
         "format": {
+          "$ref": "#/$defs/FileFormat",
           "examples": [
             "irap_binary"
-          ],
-          "title": "Format",
-          "type": "string"
+          ]
         },
         "geometry": {
           "anyOf": [
@@ -5537,11 +5540,10 @@
           ]
         },
         "format": {
+          "$ref": "#/$defs/FileFormat",
           "examples": [
             "irap_binary"
-          ],
-          "title": "Format",
-          "type": "string"
+          ]
         },
         "geometry": {
           "anyOf": [
@@ -5835,11 +5837,10 @@
           ]
         },
         "format": {
+          "$ref": "#/$defs/FileFormat",
           "examples": [
             "irap_binary"
-          ],
-          "title": "Format",
-          "type": "string"
+          ]
         },
         "geometry": {
           "anyOf": [
@@ -6238,11 +6239,10 @@
           ]
         },
         "format": {
+          "$ref": "#/$defs/FileFormat",
           "examples": [
             "irap_binary"
-          ],
-          "title": "Format",
-          "type": "string"
+          ]
         },
         "geometry": {
           "anyOf": [
@@ -6536,11 +6536,10 @@
           ]
         },
         "format": {
+          "$ref": "#/$defs/FileFormat",
           "examples": [
             "irap_binary"
-          ],
-          "title": "Format",
-          "type": "string"
+          ]
         },
         "geometry": {
           "anyOf": [
@@ -6922,11 +6921,10 @@
           ]
         },
         "format": {
+          "$ref": "#/$defs/FileFormat",
           "examples": [
             "irap_binary"
-          ],
-          "title": "Format",
-          "type": "string"
+          ]
         },
         "geometry": {
           "anyOf": [
@@ -7224,11 +7222,10 @@
           ]
         },
         "format": {
+          "$ref": "#/$defs/FileFormat",
           "examples": [
             "irap_binary"
-          ],
-          "title": "Format",
-          "type": "string"
+          ]
         },
         "geometry": {
           "anyOf": [
@@ -7661,11 +7658,10 @@
           ]
         },
         "format": {
+          "$ref": "#/$defs/FileFormat",
           "examples": [
             "irap_binary"
-          ],
-          "title": "Format",
-          "type": "string"
+          ]
         },
         "geometry": {
           "anyOf": [
@@ -8109,11 +8105,10 @@
           ]
         },
         "format": {
+          "$ref": "#/$defs/FileFormat",
           "examples": [
             "irap_binary"
-          ],
-          "title": "Format",
-          "type": "string"
+          ]
         },
         "geometry": {
           "anyOf": [
@@ -8431,11 +8426,10 @@
           ]
         },
         "format": {
+          "$ref": "#/$defs/FileFormat",
           "examples": [
             "irap_binary"
-          ],
-          "title": "Format",
-          "type": "string"
+          ]
         },
         "geometry": {
           "anyOf": [
@@ -8720,11 +8714,10 @@
           ]
         },
         "format": {
+          "$ref": "#/$defs/FileFormat",
           "examples": [
             "irap_binary"
-          ],
-          "title": "Format",
-          "type": "string"
+          ]
         },
         "geometry": {
           "anyOf": [
@@ -9107,11 +9100,10 @@
           ]
         },
         "format": {
+          "$ref": "#/$defs/FileFormat",
           "examples": [
             "irap_binary"
-          ],
-          "title": "Format",
-          "type": "string"
+          ]
         },
         "geometry": {
           "anyOf": [
@@ -9423,11 +9415,10 @@
           ]
         },
         "format": {
+          "$ref": "#/$defs/FileFormat",
           "examples": [
             "irap_binary"
-          ],
-          "title": "Format",
-          "type": "string"
+          ]
         },
         "geometry": {
           "anyOf": [
@@ -9743,11 +9734,10 @@
           ]
         },
         "format": {
+          "$ref": "#/$defs/FileFormat",
           "examples": [
             "irap_binary"
-          ],
-          "title": "Format",
-          "type": "string"
+          ]
         },
         "geometry": {
           "anyOf": [
@@ -10041,11 +10031,10 @@
           ]
         },
         "format": {
+          "$ref": "#/$defs/FileFormat",
           "examples": [
             "irap_binary"
-          ],
-          "title": "Format",
-          "type": "string"
+          ]
         },
         "geometry": {
           "anyOf": [

--- a/src/fmu/dataio/_models/fmu_results/data.py
+++ b/src/fmu/dataio/_models/fmu_results/data.py
@@ -241,7 +241,7 @@ class Data(BaseModel):
     object is coordinate-based. See :class:`BoundingBox3D` and
     :class:`BoundingBox2D`."""
 
-    format: str = Field(examples=["irap_binary"])
+    format: enums.FileFormat = Field(examples=["irap_binary"])
     """A reference to a known file format."""
 
     grid_model: Optional[GridModel] = Field(default=None)

--- a/src/fmu/dataio/_models/fmu_results/enums.py
+++ b/src/fmu/dataio/_models/fmu_results/enums.py
@@ -152,3 +152,17 @@ class FluidContactType(str, Enum):
 
     owc = "owc"
     """Oil-water contact."""
+
+
+class FileFormat(str, Enum):
+    """The format of a given data object."""
+
+    parquet = "parquet"
+    json = "json"
+    csv = "csv"
+    csv_xtgeo = "csv|xtgeo"
+    irap_ascii = "irap_ascii"
+    irap_binary = "irap_binary"
+    roff = "roff"
+    segy = "segy"
+    openvds = "openvds"

--- a/src/fmu/dataio/providers/objectdata/_base.py
+++ b/src/fmu/dataio/providers/objectdata/_base.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
         BoundingBox3D,
         Geometry,
     )
-    from fmu.dataio._models.fmu_results.enums import FMUClass, Layout
+    from fmu.dataio._models.fmu_results.enums import FileFormat, FMUClass, Layout
     from fmu.dataio._models.fmu_results.specification import AnySpecification
     from fmu.dataio.dataio import ExportData
     from fmu.dataio.types import Inferrable
@@ -132,7 +132,7 @@ class ObjectDataProvider(Provider):
 
     @property
     @abstractmethod
-    def fmt(self) -> str:
+    def fmt(self) -> FileFormat:
         raise NotImplementedError
 
     @property

--- a/src/fmu/dataio/providers/objectdata/_faultroom.py
+++ b/src/fmu/dataio/providers/objectdata/_faultroom.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Final
 from fmu.dataio._definitions import ExportFolder, ValidFormats
 from fmu.dataio._logging import null_logger
 from fmu.dataio._models.fmu_results.data import BoundingBox3D
-from fmu.dataio._models.fmu_results.enums import FMUClass, Layout
+from fmu.dataio._models.fmu_results.enums import FileFormat, FMUClass, Layout
 from fmu.dataio._models.fmu_results.global_configuration import (
     GlobalConfiguration,
 )
@@ -37,11 +37,11 @@ class FaultRoomSurfaceProvider(ObjectDataProvider):
 
     @property
     def extension(self) -> str:
-        return self._validate_get_ext(self.fmt, ValidFormats.dictionary)
+        return self._validate_get_ext(self.fmt.value, ValidFormats.dictionary)
 
     @property
-    def fmt(self) -> str:
-        return self.dataio.dict_fformat
+    def fmt(self) -> FileFormat:
+        return FileFormat(self.dataio.dict_fformat)
 
     @property
     def layout(self) -> Layout:

--- a/src/fmu/dataio/providers/objectdata/_provider.py
+++ b/src/fmu/dataio/providers/objectdata/_provider.py
@@ -95,7 +95,7 @@ import xtgeo
 
 from fmu.dataio._definitions import ExportFolder, ValidFormats
 from fmu.dataio._logging import null_logger
-from fmu.dataio._models.fmu_results.enums import FMUClass, Layout
+from fmu.dataio._models.fmu_results.enums import FileFormat, FMUClass, Layout
 from fmu.dataio._models.fmu_results.standard_result import StandardResult
 from fmu.dataio.readers import FaultRoomSurface
 
@@ -192,11 +192,11 @@ class DictionaryDataProvider(ObjectDataProvider):
 
     @property
     def extension(self) -> str:
-        return self._validate_get_ext(self.fmt, ValidFormats.dictionary)
+        return self._validate_get_ext(self.fmt.value, ValidFormats.dictionary)
 
     @property
-    def fmt(self) -> str:
-        return self.dataio.dict_fformat
+    def fmt(self) -> FileFormat:
+        return FileFormat(self.dataio.dict_fformat)
 
     @property
     def layout(self) -> Layout:

--- a/src/fmu/dataio/providers/objectdata/_tables.py
+++ b/src/fmu/dataio/providers/objectdata/_tables.py
@@ -10,7 +10,7 @@ from fmu.dataio._definitions import (
     ValidFormats,
 )
 from fmu.dataio._logging import null_logger
-from fmu.dataio._models.fmu_results.enums import Content, FMUClass, Layout
+from fmu.dataio._models.fmu_results.enums import Content, FileFormat, FMUClass, Layout
 from fmu.dataio._models.fmu_results.specification import TableSpecification
 
 from ._base import (
@@ -144,11 +144,11 @@ class DataFrameDataProvider(ObjectDataProvider):
 
     @property
     def extension(self) -> str:
-        return self._validate_get_ext(self.fmt, ValidFormats.table)
+        return self._validate_get_ext(self.fmt.value, ValidFormats.table)
 
     @property
-    def fmt(self) -> str:
-        return self.dataio.table_fformat
+    def fmt(self) -> FileFormat:
+        return FileFormat(self.dataio.table_fformat)
 
     @property
     def layout(self) -> Layout:
@@ -195,11 +195,11 @@ class ArrowTableDataProvider(ObjectDataProvider):
 
     @property
     def extension(self) -> str:
-        return self._validate_get_ext(self.fmt, ValidFormats.table)
+        return self._validate_get_ext(self.fmt.value, ValidFormats.table)
 
     @property
-    def fmt(self) -> str:
-        return self.dataio.arrow_fformat
+    def fmt(self) -> FileFormat:
+        return FileFormat(self.dataio.arrow_fformat)
 
     @property
     def layout(self) -> Layout:

--- a/src/fmu/dataio/providers/objectdata/_xtgeo.py
+++ b/src/fmu/dataio/providers/objectdata/_xtgeo.py
@@ -10,7 +10,7 @@ import numpy as np
 from fmu.dataio._definitions import ExportFolder, ValidFormats
 from fmu.dataio._logging import null_logger
 from fmu.dataio._models.fmu_results.data import BoundingBox2D, BoundingBox3D, Geometry
-from fmu.dataio._models.fmu_results.enums import FMUClass, Layout
+from fmu.dataio._models.fmu_results.enums import FileFormat, FMUClass, Layout
 from fmu.dataio._models.fmu_results.specification import (
     CPGridPropertySpecification,
     CPGridSpecification,
@@ -60,11 +60,11 @@ class RegularSurfaceDataProvider(ObjectDataProvider):
 
     @property
     def extension(self) -> str:
-        return self._validate_get_ext(self.fmt, ValidFormats.surface)
+        return self._validate_get_ext(self.fmt.value, ValidFormats.surface)
 
     @property
-    def fmt(self) -> str:
-        return self.dataio.surface_fformat
+    def fmt(self) -> FileFormat:
+        return FileFormat(self.dataio.surface_fformat)
 
     @property
     def layout(self) -> Layout:
@@ -134,11 +134,11 @@ class PolygonsDataProvider(ObjectDataProvider):
 
     @property
     def extension(self) -> str:
-        return self._validate_get_ext(self.fmt, ValidFormats.polygons)
+        return self._validate_get_ext(self.fmt.value, ValidFormats.polygons)
 
     @property
-    def fmt(self) -> str:
-        return self.dataio.polygons_fformat
+    def fmt(self) -> FileFormat:
+        return FileFormat(self.dataio.polygons_fformat)
 
     @property
     def layout(self) -> Layout:
@@ -190,11 +190,11 @@ class PointsDataProvider(ObjectDataProvider):
 
     @property
     def extension(self) -> str:
-        return self._validate_get_ext(self.fmt, ValidFormats.points)
+        return self._validate_get_ext(self.fmt.value, ValidFormats.points)
 
     @property
-    def fmt(self) -> str:
-        return self.dataio.points_fformat
+    def fmt(self) -> FileFormat:
+        return FileFormat(self.dataio.points_fformat)
 
     @property
     def layout(self) -> Layout:
@@ -251,11 +251,11 @@ class CubeDataProvider(ObjectDataProvider):
 
     @property
     def extension(self) -> str:
-        return self._validate_get_ext(self.fmt, ValidFormats.cube)
+        return self._validate_get_ext(self.fmt.value, ValidFormats.cube)
 
     @property
-    def fmt(self) -> str:
-        return self.dataio.cube_fformat
+    def fmt(self) -> FileFormat:
+        return FileFormat(self.dataio.cube_fformat)
 
     @property
     def layout(self) -> Layout:
@@ -334,11 +334,11 @@ class CPGridDataProvider(ObjectDataProvider):
 
     @property
     def extension(self) -> str:
-        return self._validate_get_ext(self.fmt, ValidFormats.grid)
+        return self._validate_get_ext(self.fmt.value, ValidFormats.grid)
 
     @property
-    def fmt(self) -> str:
-        return self.dataio.grid_fformat
+    def fmt(self) -> FileFormat:
+        return FileFormat(self.dataio.grid_fformat)
 
     @property
     def layout(self) -> Layout:
@@ -419,11 +419,11 @@ class CPGridPropertyDataProvider(ObjectDataProvider):
 
     @property
     def extension(self) -> str:
-        return self._validate_get_ext(self.fmt, ValidFormats.grid)
+        return self._validate_get_ext(self.fmt.value, ValidFormats.grid)
 
     @property
-    def fmt(self) -> str:
-        return self.dataio.grid_fformat
+    def fmt(self) -> FileFormat:
+        return FileFormat(self.dataio.grid_fformat)
 
     @property
     def layout(self) -> Layout:


### PR DESCRIPTION
Towards #911 

Added a `FileFormat` enum to strengthen the validation of the `data.format` field.
The enum values are a combination of supported export formats from `fmu-dataio` and formats found in the `fmu-sumo-uploader` and `fmu-sumo-aggregation-service`.

Existing tests should be sufficient.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=<packagename> --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
