### PR TITLE
FIX: Use dev schema in Komodo bleeding

### DIFF
--- a/src/fmu/dataio/_models/_schema_base.py
+++ b/src/fmu/dataio/_models/_schema_base.py
@@ -163,9 +163,14 @@ class SchemaBase(ABC):
 
     @classmethod
     def url(cls) -> str:
-        """Returns the URL this file will reside at, based upon class variables set here
-        and in FmuSchemas."""
-        if os.environ.get("DEV_SCHEMA", False):
+        """Returns the URL the schema resides at.
+
+        Schema URLs are composed from class variables set by children derived from this
+        base class. If we're in a development environment, or Komodo bleeding, return
+        the dev schema URL."""
+        if os.environ.get("DEV_SCHEMA", False) or "bleeding" in os.environ.get(
+            "KOMODO_RELEASE", os.environ.get("KOMODO_RELEASE_BACKUP", "")
+        ):
             return cls.dev_url()
         return cls.prod_url()
 


### PR DESCRIPTION
Resolves #1053 

This checks if `bleeding` exists in `KOMODO_RELEASE` or `KOMODO_RELEASE_BACKUP` (set when Komodo is disabled for RMS). If it is, produce metadata that points to the dev schemas.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=<packagename> --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
