### PR TITLE
MAINT: Link export functions to each objdata provider

### DIFF
--- a/src/fmu/dataio/aggregation.py
+++ b/src/fmu/dataio/aggregation.py
@@ -267,20 +267,11 @@ class AggregatedData:
 
         objdata = objectdata_provider_factory(obj=obj, dataio=etemp)
 
-        try:
-            checksum_md5 = _utils.compute_md5(objdata.export_to_file)
-        except Exception as e:
-            logger.debug(
-                f"Exception {e} occured when trying to compute md5 from memory stream "
-                f"for an object of type {type(obj)}. Will use tempfile instead."
-            )
-            checksum_md5 = _utils.compute_md5_using_temp_file(objdata.export_to_file)
-
         template["tracklog"] = [fields.Tracklog.initialize()[0]]
         template["file"] = {
             "relative_path": str(relpath),
             "absolute_path": str(abspath) if abspath else None,
-            "checksum_md5": checksum_md5,
+            "checksum_md5": _utils.compute_md5_from_objdata(objdata),
         }
 
         # data section

--- a/src/fmu/dataio/aggregation.py
+++ b/src/fmu/dataio/aggregation.py
@@ -268,13 +268,13 @@ class AggregatedData:
         objdata = objectdata_provider_factory(obj=obj, dataio=etemp)
 
         try:
-            checksum_md5 = _utils.compute_md5(obj, objdata.extension)
+            checksum_md5 = _utils.compute_md5(objdata.export_to_file)
         except Exception as e:
             logger.debug(
                 f"Exception {e} occured when trying to compute md5 from memory stream "
                 f"for an object of type {type(obj)}. Will use tempfile instead."
             )
-            checksum_md5 = _utils.compute_md5_using_temp_file(obj, objdata.extension)
+            checksum_md5 = _utils.compute_md5_using_temp_file(objdata.export_to_file)
 
         template["tracklog"] = [fields.Tracklog.initialize()[0]]
         template["file"] = {

--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -34,8 +34,8 @@ from ._models.fmu_results.global_configuration import GlobalConfiguration
 from ._models.fmu_results.standard_result import StandardResult
 from ._utils import (
     detect_inside_rms,  # dataio_examples,
-    export_file,
     export_metadata_file,
+    export_object_to_file,
     prettyprint_dict,
     read_metadata_from_file,
     some_config_from_env,
@@ -859,7 +859,7 @@ class ExportData:
         ).get_metadata()
 
         assert filemeta.absolute_path is not None  # for mypy
-        export_file(obj, file=filemeta.absolute_path, fmt=objdata.fmt)
+        export_object_to_file(filemeta.absolute_path, objdata.export_to_file)
         return str(filemeta.absolute_path)
 
     def _export_with_standard_result(
@@ -873,6 +873,7 @@ class ExportData:
             )
 
         fmudata = self._get_fmu_provider() if self._fmurun else None
+        objdata = objectdata_provider_factory(obj, self)
 
         metadata = generate_export_metadata(
             obj=obj, dataio=self, fmudata=fmudata, standard_result=standard_result
@@ -881,7 +882,7 @@ class ExportData:
         outfile = Path(metadata["file"]["absolute_path"])
         metafile = outfile.parent / f".{outfile.name}.yml"
 
-        export_file(obj, outfile, fmt=metadata["data"].get("format", ""))
+        export_object_to_file(outfile, objdata.export_to_file)
         logger.info("Actual file is:   %s", outfile)
 
         export_metadata_file(metafile, metadata)
@@ -1001,7 +1002,8 @@ class ExportData:
         outfile = Path(metadata["file"]["absolute_path"])
         metafile = outfile.parent / f".{outfile.name}.yml"
 
-        export_file(obj, outfile, fmt=metadata["data"].get("format", ""))
+        objdata = objectdata_provider_factory(obj, self)
+        export_object_to_file(outfile, objdata.export_to_file)
         logger.info("Actual file is:   %s", outfile)
 
         export_metadata_file(metafile, metadata)

--- a/src/fmu/dataio/providers/_filedata.py
+++ b/src/fmu/dataio/providers/_filedata.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Final
 
 from fmu.dataio._logging import null_logger
 from fmu.dataio._models.fmu_results import enums, fields
-from fmu.dataio._utils import compute_md5, compute_md5_using_temp_file
+from fmu.dataio._utils import compute_md5_from_objdata
 
 from ._base import Provider
 
@@ -85,7 +85,7 @@ class FileDataProvider(Provider):
         return fields.File(
             absolute_path=absolute_path.resolve(),
             relative_path=relative_path,
-            checksum_md5=self._compute_md5(),
+            checksum_md5=compute_md5_from_objdata(self.objdata),
         )
 
     def _get_share_folders(self) -> Path:
@@ -103,17 +103,6 @@ class FileDataProvider(Provider):
 
         logger.info("Export share folders are %s", sharefolder)
         return sharefolder
-
-    def _compute_md5(self) -> str:
-        """Compute an MD5 sum using a temporary file."""
-        try:
-            return compute_md5(self.objdata.export_to_file)
-        except Exception as e:
-            logger.debug(
-                f"Exception {e} occured when trying to compute md5 from memory stream "
-                f"for an object of type {type(self.obj)}. Will use tempfile instead."
-            )
-            return compute_md5_using_temp_file(self.objdata.export_to_file)
 
     def _add_filename_to_path(self, path: Path) -> Path:
         stem = self._get_filestem()

--- a/src/fmu/dataio/providers/_filedata.py
+++ b/src/fmu/dataio/providers/_filedata.py
@@ -107,19 +107,13 @@ class FileDataProvider(Provider):
     def _compute_md5(self) -> str:
         """Compute an MD5 sum using a temporary file."""
         try:
-            return compute_md5(
-                obj=self.obj,
-                file_suffix=self.objdata.extension,
-                fmt=self.objdata.fmt,
-            )
+            return compute_md5(self.objdata.export_to_file)
         except Exception as e:
             logger.debug(
                 f"Exception {e} occured when trying to compute md5 from memory stream "
                 f"for an object of type {type(self.obj)}. Will use tempfile instead."
             )
-            return compute_md5_using_temp_file(
-                self.obj, self.objdata.extension, fmt=self.objdata.fmt
-            )
+            return compute_md5_using_temp_file(self.objdata.export_to_file)
 
     def _add_filename_to_path(self, path: Path) -> Path:
         stem = self._get_filestem()

--- a/src/fmu/dataio/providers/objectdata/_base.py
+++ b/src/fmu/dataio/providers/objectdata/_base.py
@@ -4,6 +4,8 @@ import warnings
 from abc import abstractmethod
 from dataclasses import dataclass, field
 from datetime import datetime
+from pathlib import Path
+from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING, Any, Final
 
 from fmu.dataio._definitions import ValidFormats
@@ -15,7 +17,7 @@ from fmu.dataio._models.fmu_results.global_configuration import (
     StratigraphyElement,
 )
 from fmu.dataio._models.fmu_results.standard_result import StandardResult
-from fmu.dataio._utils import generate_description
+from fmu.dataio._utils import generate_description, md5sum
 from fmu.dataio.exceptions import ConfigurationError
 from fmu.dataio.providers._base import Provider
 from fmu.dataio.providers.objectdata._export_models import (
@@ -163,6 +165,20 @@ class ObjectDataProvider(Provider):
     @abstractmethod
     def get_spec(self) -> AnySpecification | None:
         raise NotImplementedError
+
+    def compute_md5(self) -> str:
+        """Compute an MD5 sum"""
+        memory_stream = BytesIO()
+        self.export_to_file(memory_stream)
+        return md5sum(memory_stream)
+
+    def compute_md5_using_temp_file(self) -> str:
+        """Compute an MD5 sum using a temporary file."""
+        with NamedTemporaryFile(buffering=0, suffix=".tmp") as tf:
+            logger.info("Compute MD5 sum for tmp file")
+            tempfile = Path(tf.name)
+            self.export_to_file(tempfile)
+            return md5sum(tempfile)
 
     def get_metadata(self) -> AnyData | UnsetData:
         assert self._metadata is not None

--- a/src/fmu/dataio/providers/objectdata/_base.py
+++ b/src/fmu/dataio/providers/objectdata/_base.py
@@ -26,6 +26,9 @@ from fmu.dataio.providers.objectdata._export_models import (
 )
 
 if TYPE_CHECKING:
+    from io import BytesIO
+    from pathlib import Path
+
     from pydantic import BaseModel
 
     from fmu.dataio._models.fmu_results.data import (
@@ -143,6 +146,10 @@ class ObjectDataProvider(Provider):
     @property
     @abstractmethod
     def table_index(self) -> list[str] | None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def export_to_file(self, file: Path | BytesIO) -> None:
         raise NotImplementedError
 
     @abstractmethod

--- a/src/fmu/dataio/providers/objectdata/_faultroom.py
+++ b/src/fmu/dataio/providers/objectdata/_faultroom.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Final
 
 from fmu.dataio._definitions import ExportFolder, ValidFormats
@@ -18,6 +20,8 @@ from ._base import (
 )
 
 if TYPE_CHECKING:
+    from io import BytesIO
+
     from fmu.dataio.readers import FaultRoomSurface
 
 logger: Final = null_logger(__name__)
@@ -97,3 +101,14 @@ class FaultRoomSurfaceProvider(ObjectDataProvider):
             properties=self.obj.properties,
             name=self.obj.name,
         )
+
+    def export_to_file(self, file: Path | BytesIO) -> None:
+        """Export the object to file or memory buffer"""
+
+        serialized_json = json.dumps(self.obj.storage, indent=4)
+
+        if isinstance(file, Path):
+            with open(file, "w", encoding="utf-8") as stream:
+                stream.write(serialized_json)
+        else:
+            file.write(serialized_json.encode("utf-8"))

--- a/src/fmu/dataio/providers/objectdata/_provider.py
+++ b/src/fmu/dataio/providers/objectdata/_provider.py
@@ -86,7 +86,9 @@ data:
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Final
 
 import pandas as pd
@@ -114,6 +116,9 @@ from ._xtgeo import (
 )
 
 if TYPE_CHECKING:
+    from io import BytesIO
+    from pathlib import Path
+
     from fmu.dataio.dataio import ExportData
     from fmu.dataio.types import Inferrable
 
@@ -214,3 +219,14 @@ class DictionaryDataProvider(ObjectDataProvider):
 
     def get_spec(self) -> None:
         """Derive data.spec for dict."""
+
+    def export_to_file(self, file: Path | BytesIO) -> None:
+        """Export the object to file or memory buffer"""
+
+        serialized_json = json.dumps(self.obj)
+
+        if isinstance(file, Path):
+            with open(file, "w", encoding="utf-8") as stream:
+                stream.write(serialized_json)
+        else:
+            file.write(serialized_json.encode("utf-8"))

--- a/tests/test_units/test_ert_context.py
+++ b/tests/test_units/test_ert_context.py
@@ -149,6 +149,52 @@ def test_polys_export_file_set_name(fmurun_w_casemetadata, rmsglobalconfig, poly
         ).resolve()
     )
 
+    thefile = pd.read_csv(output)
+    assert set(thefile.columns) == {"X", "Y", "Z", "ID"}
+
+
+def test_polys_export_file_use_xtgeo_names(
+    fmurun_w_casemetadata, rmsglobalconfig, polygons
+):
+    """Export the polygon to file with correct metadata and name."""
+
+    logger.info("Active folder is %s", fmurun_w_casemetadata)
+    os.chdir(fmurun_w_casemetadata)
+
+    edata = dataio.ExportData(
+        config=rmsglobalconfig, content="depth", name="TopVolantis"
+    )
+
+    edata.polygons_fformat = "csv|xtgeo"  # override
+    output = edata.export(polygons)
+
+    thefile = pd.read_csv(output)
+    assert set(thefile.columns) == {"X_UTME", "Y_UTMN", "Z_TVDSS", "POLY_ID"}
+
+    edata.polygons_fformat = "csv"  # reset
+
+
+def test_polys_export_file_as_irap_ascii(
+    fmurun_w_casemetadata, rmsglobalconfig, polygons
+):
+    """Export the polygon to file with correct metadata and name."""
+
+    logger.info("Active folder is %s", fmurun_w_casemetadata)
+    os.chdir(fmurun_w_casemetadata)
+
+    edata = dataio.ExportData(
+        config=rmsglobalconfig, content="depth", name="TopVolantis"
+    )
+
+    edata.polygons_fformat = "irap_ascii"  # override
+    output = Path(edata.export(polygons))
+
+    assert output.exists()
+    assert output == (
+        edata._rootpath / "realization-0/iter-0/share/results/polygons/topvolantis.pol"
+    )
+    edata.polygons_fformat = "csv"  # reset
+
 
 def test_points_export_file_set_name(fmurun_w_casemetadata, rmsglobalconfig, points):
     """Export the points to file with correct metadata and name."""
@@ -170,10 +216,11 @@ def test_points_export_file_set_name(fmurun_w_casemetadata, rmsglobalconfig, poi
         ).resolve()
     )
 
-    thefile = pd.read_csv(
-        edata._rootpath / "realization-0/iter-0/share/results/points/topvolantis.csv"
-    )
-    assert thefile.columns[0] == "X"
+    thefile = pd.read_csv(output)
+    assert set(thefile.columns) == {"X", "Y", "Z", "WellName"}
+
+    meta = dataio.read_metadata(output)
+    assert meta["data"]["spec"]["attributes"] == ["WellName"]
 
 
 def test_points_export_file_set_name_xtgeoheaders(
@@ -200,12 +247,35 @@ def test_points_export_file_set_name_xtgeoheaders(
         ).resolve()
     )
 
-    thefile = pd.read_csv(
-        edata._rootpath / "realization-0/iter-0/share/results/points/topvolantiz.csv"
-    )
-    assert thefile.columns[0] == "X_UTME"
+    thefile = pd.read_csv(output)
+    assert set(thefile.columns) == {"X_UTME", "Y_UTMN", "Z_TVDSS", "WellName"}
+
+    meta = dataio.read_metadata(output)
+    assert meta["data"]["spec"]["attributes"] == ["WellName"]
 
     dataio.ExportData.points_fformat = "csv"
+
+
+def test_points_export_file_as_irap_ascii(
+    fmurun_w_casemetadata, rmsglobalconfig, points
+):
+    """Export the polygon to file with correct metadata and name."""
+
+    logger.info("Active folder is %s", fmurun_w_casemetadata)
+    os.chdir(fmurun_w_casemetadata)
+
+    edata = dataio.ExportData(
+        config=rmsglobalconfig, content="depth", name="TopVolantis"
+    )
+
+    edata.points_fformat = "irap_ascii"  # override
+    output = Path(edata.export(points))
+
+    assert output.exists()
+    assert output == (
+        edata._rootpath / "realization-0/iter-0/share/results/points/topvolantis.poi"
+    )
+    edata.points_fformat = "csv"  # reset
 
 
 # ======================================================================================


### PR DESCRIPTION
Resolves #1057 

Added a new abstract method `export_to_file` to the `ObjectDataProvider` for exporting the object to file or memory buffer. This method was implemented for each `ObjectDataProvider` subclass by copying the relevant export function from the `_utils.export_file` function.

I was hoping to remove the  `_utils.export_file` function alltogether but it is still needed for the `AggregatedData` class since we can't easily create an `ObjectDataProvider` here as an instance of `ExportData` is needed as argument into the constructor.

Not much tests added, there are quite some tests already on exporting various data types on different format. 

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=<packagename> --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
