### PR TITLE
Replace import ert.config with ert

### DIFF
--- a/src/fmu/dataio/scripts/copy_preprocessed.py
+++ b/src/fmu/dataio/scripts/copy_preprocessed.py
@@ -19,7 +19,7 @@ from ert.plugins.plugin_manager import hook_implementation
 from fmu.dataio import ExportPreprocessedData
 
 try:
-    from ert.config import ErtScript
+    from ert import ErtScript
 except ImportError:
     from res.job_queue import ErtScript
 

--- a/src/fmu/dataio/scripts/create_case_metadata.py
+++ b/src/fmu/dataio/scripts/create_case_metadata.py
@@ -21,7 +21,7 @@ from ert.plugins.plugin_manager import hook_implementation
 from fmu.dataio import CreateCaseMetadata
 
 try:
-    from ert.config import ErtScript
+    from ert import ErtScript
 except ImportError:
     from res.job_queue import ErtScript
 


### PR DESCRIPTION
Imports `ErtScript` according to documentation.
Ref.
https://fmu-docs.equinor.com/docs/ert/getting_started/howto/plugin_system.html#ert.plugins.hook_specifications.jobs.legacy_ertscript_workflow

Resolves problem in bleeding:
https://github.com/equinor/komodo-releases/actions/runs/13761587305/job/38480279067

```
    try:
        from ert.config import ErtScript
    except ImportError:
>       from res.job_queue import ErtScript
E       ModuleNotFoundError: No module named 'res'
```

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=<packagename> --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [ ] Checked the boxes in this checklist ✅
