### PR TITLE
ENH: Stricter validation for specification fields

### DIFF
--- a/schemas/0.9.0/fmu_results.json
+++ b/schemas/0.9.0/fmu_results.json
@@ -324,14 +324,17 @@
       "description": "Specifies relevant values describing a corner point grid property object.",
       "properties": {
         "ncol": {
+          "minimum": 0,
           "title": "Ncol",
           "type": "integer"
         },
         "nlay": {
+          "minimum": 0,
           "title": "Nlay",
           "type": "integer"
         },
         "nrow": {
+          "minimum": 0,
           "title": "Nrow",
           "type": "integer"
         }
@@ -348,14 +351,17 @@
       "description": "Specifies relevant values describing a corner point grid object.",
       "properties": {
         "ncol": {
+          "minimum": 0,
           "title": "Ncol",
           "type": "integer"
         },
         "nlay": {
+          "minimum": 0,
           "title": "Nlay",
           "type": "integer"
         },
         "nrow": {
+          "minimum": 0,
           "title": "Nrow",
           "type": "integer"
         },
@@ -585,14 +591,17 @@
       "description": "Specifies relevant values describing a cube object, i.e. a seismic cube.",
       "properties": {
         "ncol": {
+          "minimum": 0,
           "title": "Ncol",
           "type": "integer"
         },
         "nlay": {
+          "minimum": 0,
           "title": "Nlay",
           "type": "integer"
         },
         "nrow": {
+          "minimum": 0,
           "title": "Nrow",
           "type": "integer"
         },
@@ -605,6 +614,7 @@
           "type": "number"
         },
         "xinc": {
+          "minimum": 0.0,
           "title": "Xinc",
           "type": "number"
         },
@@ -616,6 +626,7 @@
           "$ref": "#/$defs/AxisOrientation"
         },
         "yinc": {
+          "minimum": 0.0,
           "title": "Yinc",
           "type": "number"
         },
@@ -627,6 +638,7 @@
           "$ref": "#/$defs/AxisOrientation"
         },
         "zinc": {
+          "minimum": 0.0,
           "title": "Zinc",
           "type": "number"
         },
@@ -5692,6 +5704,7 @@
             1,
             9999
           ],
+          "minimum": 0,
           "title": "Size",
           "type": "integer"
         }
@@ -5706,6 +5719,7 @@
       "description": "Specifies relevant values describing a polygon object.",
       "properties": {
         "npolys": {
+          "minimum": 0,
           "title": "Npolys",
           "type": "integer"
         }
@@ -8267,10 +8281,12 @@
       "description": "Specifies relevant values describing a regular surface object.",
       "properties": {
         "ncol": {
+          "minimum": 0,
           "title": "Ncol",
           "type": "integer"
         },
         "nrow": {
+          "minimum": 0,
           "title": "Nrow",
           "type": "integer"
         },
@@ -8283,6 +8299,7 @@
           "type": "number"
         },
         "xinc": {
+          "minimum": 0.0,
           "title": "Xinc",
           "type": "number"
         },
@@ -8294,6 +8311,7 @@
           "$ref": "#/$defs/AxisOrientation"
         },
         "yinc": {
+          "minimum": 0.0,
           "title": "Yinc",
           "type": "number"
         },
@@ -8373,48 +8391,37 @@
           "type": "array"
         },
         "num_columns": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
           "examples": [
             1,
             9999
           ],
-          "title": "Num Columns"
+          "minimum": 0,
+          "title": "Num Columns",
+          "type": "integer"
         },
         "num_rows": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
           "examples": [
             1,
             9999
           ],
-          "title": "Num Rows"
+          "minimum": 0,
+          "title": "Num Rows",
+          "type": "integer"
         },
         "size": {
           "examples": [
             1,
             9999
           ],
+          "minimum": 0,
           "title": "Size",
           "type": "integer"
         }
       },
       "required": [
         "columns",
+        "num_columns",
+        "num_rows",
         "size"
       ],
       "title": "TableSpecification",

--- a/src/fmu/dataio/_models/fmu_results/specification.py
+++ b/src/fmu/dataio/_models/fmu_results/specification.py
@@ -10,17 +10,17 @@ from . import enums
 class RowColumn(BaseModel):
     """Specifies the number of rows and columns in a regular surface object."""
 
-    nrow: int
+    nrow: int = Field(ge=0)
     """The number of rows."""
 
-    ncol: int
+    ncol: int = Field(ge=0)
     """The number of columns."""
 
 
 class RowColumnLayer(RowColumn):
     """Specifies the number of rows, columns, and layers in grid object."""
 
-    nlay: int
+    nlay: int = Field(ge=0)
     """The number of layers."""
 
 
@@ -33,10 +33,10 @@ class SurfaceSpecification(RowColumn):
     undef: float = Field(allow_inf_nan=False)
     """Value representing undefined data."""
 
-    xinc: float = Field(allow_inf_nan=False)
+    xinc: float = Field(ge=0, allow_inf_nan=False)
     """Increment along the x-axis."""
 
-    yinc: float = Field(allow_inf_nan=False)
+    yinc: float = Field(ge=0, allow_inf_nan=False)
     """Increment along the y-axis."""
 
     xori: float = Field(allow_inf_nan=False)
@@ -55,7 +55,7 @@ class PointSpecification(BaseModel):
     attributes: Optional[List[str]] = Field(default=None)
     """List of columns present in a table."""
 
-    size: int = Field(examples=[1, 9999])
+    size: int = Field(ge=0, examples=[1, 9999])
     """Size of data object."""
 
 
@@ -65,13 +65,13 @@ class TableSpecification(BaseModel):
     columns: List[str]
     """List of columns present in a table."""
 
-    num_columns: Optional[int] = Field(default=None, examples=[1, 9999])
+    num_columns: int = Field(ge=0, examples=[1, 9999])
     """The number of columns in a table."""
 
-    num_rows: Optional[int] = Field(default=None, examples=[1, 9999])
+    num_rows: int = Field(ge=0, examples=[1, 9999])
     """The number of rows in a table.."""
 
-    size: int = Field(examples=[1, 9999])
+    size: int = Field(ge=0, examples=[1, 9999])
     """The total size of the table, i.e. `rows x cols`."""
 
 
@@ -124,7 +124,7 @@ class CPGridPropertySpecification(RowColumnLayer):
 class PolygonsSpecification(BaseModel):
     """Specifies relevant values describing a polygon object."""
 
-    npolys: int
+    npolys: int = Field(ge=0)
     """The number of individual polygons in the data object."""
 
 
@@ -153,16 +153,16 @@ class FaultRoomSurfaceSpecification(BaseModel):
 class CubeSpecification(SurfaceSpecification):
     """Specifies relevant values describing a cube object, i.e. a seismic cube."""
 
-    nlay: int
+    nlay: int = Field(ge=0)
     """The number of layers."""
 
-    xinc: float = Field(allow_inf_nan=False)
+    xinc: float = Field(ge=0, allow_inf_nan=False)
     """Increment along the x-axis."""
 
-    yinc: float = Field(allow_inf_nan=False)
+    yinc: float = Field(ge=0, allow_inf_nan=False)
     """Increment along the y-axis."""
 
-    zinc: float = Field(allow_inf_nan=False)
+    zinc: float = Field(ge=0, allow_inf_nan=False)
     """Increment along the z-axis."""
 
     xori: float = Field(allow_inf_nan=False)


### PR DESCRIPTION
Adresses #911

Added stricter validation to specification model fields where applicable for schema `0.9.0` 

- Ensuring relevant fields are greater or equal to 0  
- removing `num_columns` and `num_rows` as optional for TableSpecification, it is always set.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=<packagename> --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
