### PR TITLE
ENH: Add simplified export for structure_depth_fault_lines

### DIFF
--- a/docs/src/standard_results/initial_inplace_volumes.md
+++ b/docs/src/standard_results/initial_inplace_volumes.md
@@ -68,7 +68,7 @@ However, when these columns are present, their type is validated.
 
 ## Standard result schema
 
-This standard results is made available with a validation schema that can be
+This standard result is made available with a validation schema that can be
 used by consumers. A reference to the URL where this schema is located is
 present within the `data.standard_result` key in its associated object metadata.
 

--- a/docs/src/standard_results/structure_depth_fault_lines.md
+++ b/docs/src/standard_results/structure_depth_fault_lines.md
@@ -1,0 +1,80 @@
+# Structure depth fault lines
+
+This exports the modelled structural depth fault lines from within RMS.
+These fault lines are polygons that represent the intersection of a modelled
+stratigraphic horizon surface with the modelled fault surfaces.
+
+:::{note} 
+It is only possible to export **one single set** of depth fault lines per
+model workflow, i.e. one fault line polygon object per stratigraphic horizon.
+:::
+
+:::{table} Current
+:widths: auto
+:align: left
+
+| Field | Value |
+| --- | --- |
+| Version | **{{ StructureDepthFaultLinesSchema.VERSION }}** |
+| Output | `share/results/polygons/structure_depth_fault_lines/surfacename.parquet` |
+:::
+
+## Requirements
+
+- RMS
+- depth fault line polygons stored in a horizon folder within RMS
+
+The fault line polygons must be located within a horizon folder in RMS and be in domain `depth`.
+This export function will automatically export all non-empty polygon objects from the provided folder.
+
+
+:::{important}
+These polygons should be extracted from the final depth horizon model using the `Extract Fault Lines`
+job in RMS. This will ensure that all fault polygons are closed and that the fault name is added as an attribute.
+:::
+
+## Usage
+
+```{eval-rst}
+.. autofunction:: fmu.dataio.export.rms.structure_depth_fault_lines.export_structure_depth_fault_lines
+```
+
+## Result
+
+Given a stratigraphic horizon name `TopVolantis` the result file will be
+`share/results/polygons/structure_depth_fault_lines/topvolantis.parquet`.
+
+This is a tabular file on `.parquet` format. It contains
+the following columns with types validated as indicated.
+
+```{eval-rst}
+.. autopydantic_model:: fmu.dataio._models.standard_result.structure_depth_fault_lines.StructureDepthFaultLinesResultRow
+   :members:
+   :inherited-members: BaseModel
+   :model-show-config-summary: False
+   :model-show-json: False
+   :model-show-validator-members: False
+   :model-show-validator-summary: False
+   :field-list-validators: False
+```
+
+
+## Standard result schema
+
+This standard result is made available with a validation schema that can be
+used by consumers. A reference to the URL where this schema is located is
+present within the `data.standard_result` key in its associated object metadata.
+
+| Field | Value |
+| --- | --- |
+| Version | {{ StructureDepthFaultLinesSchema.VERSION }} |
+| Filename | {{ StructureDepthFaultLinesSchema.FILENAME }} |
+| Path | {{ StructureDepthFaultLinesSchema.PATH }} |
+| Prod URL | {{ '[{}]({}) 🔒'.format(StructureDepthFaultLinesSchema.prod_url(), StructureDepthFaultLinesSchema.prod_url()) }}
+| Dev URL | {{ '[{}]({}) 🔒'.format(StructureDepthFaultLinesSchema.dev_url(), StructureDepthFaultLinesSchema.dev_url()) }}
+
+### JSON schema
+
+The current JSON schema is embedded here.
+
+{{ StructureDepthFaultLinesSchema.literalinclude }}

--- a/docs/src/standard_results/structure_depth_surfaces.md
+++ b/docs/src/standard_results/structure_depth_surfaces.md
@@ -5,8 +5,10 @@ These surfaces typically represent the final surface set generated during a stru
 modelling workflow (after well conditioning), and frequently serve as the framework for
 constructing the grid.
 
-Note, it is only possible to export **one single set** of depth surface predictions per 
+:::{note} 
+It is only possible to export **one single set** of depth surface predictions per 
 model workflow.
+:::
 
 :::{table} Current
 :widths: auto

--- a/schemas/file_formats/0.1.0/inplace_volumes.json
+++ b/schemas/file_formats/0.1.0/inplace_volumes.json
@@ -143,7 +143,7 @@
   },
   "$id": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/file_formats/0.1.0/inplace_volumes.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "description": "Represents the resultant static inplace volumes csv file, which is naturally a\nlist of rows.\n\nConsumers who retrieve this csv file must reading it into a json-dictionary\nequivalent format to validate it against the schema.",
+  "description": "Represents the resultant static inplace volumes parquet file, which is naturally\na list of rows.\n\nConsumers who retrieve this parquet file must read it into a json-dictionary\nequivalent format to validate it against the schema.",
   "items": {
     "$ref": "#/$defs/InplaceVolumesResultRow"
   },

--- a/src/fmu/dataio/_models/standard_results/inplace_volumes.py
+++ b/src/fmu/dataio/_models/standard_results/inplace_volumes.py
@@ -64,10 +64,10 @@ class InplaceVolumesResultRow(BaseModel):
 
 
 class InplaceVolumesResult(RootModel):
-    """Represents the resultant static inplace volumes csv file, which is naturally a
-    list of rows.
+    """Represents the resultant static inplace volumes parquet file, which is naturally
+    a list of rows.
 
-    Consumers who retrieve this csv file must reading it into a json-dictionary
+    Consumers who retrieve this parquet file must read it into a json-dictionary
     equivalent format to validate it against the schema."""
 
     root: List[InplaceVolumesResultRow]
@@ -76,7 +76,7 @@ class InplaceVolumesResult(RootModel):
 class InplaceVolumesSchema(SchemaBase):
     """This class represents the schema that is used to validate the inplace volumes
     table being exported. This means that the version, schema filename, and schema
-    locaiton corresponds directly with the values and their validation constraints,
+    location corresponds directly with the values and their validation constraints,
     documented above."""
 
     VERSION: VersionStr = "0.1.0"

--- a/src/fmu/dataio/export/rms/__init__.py
+++ b/src/fmu/dataio/export/rms/__init__.py
@@ -1,7 +1,9 @@
 from .inplace_volumes import export_inplace_volumes, export_rms_volumetrics
+from .structure_depth_fault_lines import export_structure_depth_fault_lines
 from .structure_depth_surfaces import export_structure_depth_surfaces
 
 __all__ = [
+    "export_structure_depth_fault_lines",
     "export_structure_depth_surfaces",
     "export_inplace_volumes",
     "export_rms_volumetrics",

--- a/src/fmu/dataio/export/rms/structure_depth_fault_lines.py
+++ b/src/fmu/dataio/export/rms/structure_depth_fault_lines.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Final
+
+import fmu.dataio as dio
+from fmu.dataio._logging import null_logger
+from fmu.dataio._models.fmu_results.enums import (
+    Classification,
+    Content,
+    StandardResultName,
+)
+from fmu.dataio._models.fmu_results.standard_result import (
+    StructureDepthFaultLinesStandardResult,
+)
+from fmu.dataio.exceptions import ValidationError
+from fmu.dataio.export._decorators import experimental
+from fmu.dataio.export._export_result import ExportResult, ExportResultItem
+from fmu.dataio.export.rms._utils import (
+    get_polygons_in_folder,
+    get_rms_project_units,
+    load_global_config,
+)
+
+if TYPE_CHECKING:
+    import xtgeo
+
+_logger: Final = null_logger(__name__)
+
+
+class _ExportStructureDepthFaultLines:
+    def __init__(
+        self,
+        project: Any,
+        horizon_folder: str,
+    ) -> None:
+        _logger.debug("Process data, establish state prior to export.")
+        self._horizon_folder = horizon_folder
+        self._config = load_global_config()
+        self._fault_lines = get_polygons_in_folder(project, horizon_folder)
+        self._unit = "m" if get_rms_project_units(project) == "metric" else "ft"
+
+        _logger.debug("Process data... DONE")
+
+    @property
+    def _standard_result(self) -> StructureDepthFaultLinesStandardResult:
+        """Standard result type for the exported data."""
+        return StructureDepthFaultLinesStandardResult(
+            name=StandardResultName.structure_depth_fault_lines
+        )
+
+    @property
+    def _classification(self) -> Classification:
+        """Get default classification."""
+        return Classification.internal
+
+    @property
+    def _subfolder(self) -> str:
+        """Subfolder for exporting the data to."""
+        return StandardResultName.structure_depth_fault_lines.value
+
+    def _export_fault_line(self, pol: xtgeo.Polygons) -> ExportResultItem:
+        edata = dio.ExportData(
+            config=self._config,
+            content=Content.fault_lines.value,
+            unit=self._unit,
+            vertical_domain="depth",
+            domain_reference="msl",
+            subfolder=self._subfolder,
+            is_prediction=True,
+            name=pol.name,
+            classification=self._classification,
+            rep_include=True,
+        )
+
+        edata.polygons_fformat = "parquet"  # type: ignore
+
+        absolute_export_path = edata._export_with_standard_result(
+            pol, standard_result=self._standard_result
+        )
+        _logger.debug("Fault_lines exported to: %s", absolute_export_path)
+
+        return ExportResultItem(
+            absolute_path=Path(absolute_export_path),
+        )
+
+    def _export_fault_lines(self) -> ExportResult:
+        """Export the fault lines for each stratigraphic horizon."""
+        return ExportResult(
+            items=[self._export_fault_line(pol) for pol in self._fault_lines]
+        )
+
+    def _raise_on_open_polygons(self, pol: xtgeo.Polygons) -> None:
+        """
+        Check that all fault line polygons within the polygon set are closed. In a
+        closed polygon the first and last row of the dataframe are equal i.e. equal
+        coordinates. If an open polygon is found an error is given.
+        """
+        open_polygons = []
+        for polid, poldf in pol.get_dataframe(copy=False).groupby("POLY_ID"):
+            if not poldf.iloc[0].equals(poldf.iloc[-1]):
+                open_polygons.append(polid)
+
+        # TODO provide fault names when NAME attribute is possible to
+        # fetch with xtgeo.
+        if open_polygons:
+            raise ValidationError(
+                "All fault line polygons must be closed. Found "
+                f"{len(open_polygons)} open ones for horizon {pol.name}. "
+                f"Ensure that the horizon folder {self._horizon_folder} "
+                "actually contains fault lines."
+            )
+
+    def _validate_data(self) -> None:
+        """Data validations before export."""
+        # TODO: check that the fault lines have a stratigraphy entry.
+
+        for pol in self._fault_lines:
+            self._raise_on_open_polygons(pol)
+
+    def export(self) -> ExportResult:
+        """Export the fault lines as a standard_result."""
+        self._validate_data()
+        return self._export_fault_lines()
+
+
+@experimental
+def export_structure_depth_fault_lines(
+    project: Any,
+    horizon_folder: str,
+) -> ExportResult:
+    """Simplified interface when exporting fault lines from RMS.
+
+    Args:
+        project: The 'magic' project variable in RMS.
+        horizon_folder: Name of horizon folder in RMS.
+    Note:
+        This function is experimental and may change in future versions.
+
+    Examples:
+        Example usage in an RMS script::
+
+            from fmu.dataio.export.rms import export_structure_depth_fault_lines
+
+            export_results = export_structure_depth_fault_lines(
+                project, "DL_faultlines"
+            )
+
+            for result in export_results.items:
+                print(f"Output fault line polygons to {result.absolute_path}")
+
+    """
+
+    return _ExportStructureDepthFaultLines(project, horizon_folder).export()

--- a/src/fmu/dataio/export/rms/structure_depth_surfaces.py
+++ b/src/fmu/dataio/export/rms/structure_depth_surfaces.py
@@ -36,7 +36,7 @@ class _ExportStructureDepthSurfaces:
 
     @property
     def _standard_result(self) -> standard_result.StructureDepthSurfaceStandardResult:
-        """Product type for the exported data."""
+        """Standard result type for the exported data."""
         return standard_result.StructureDepthSurfaceStandardResult(
             name=StandardResultName.structure_depth_surface
         )

--- a/tests/test_export_rms/conftest.py
+++ b/tests/test_export_rms/conftest.py
@@ -242,3 +242,19 @@ def xtgeo_surfaces(regsurf):
     regsurf_base.values += 200
 
     yield [regsurf_top, regsurf_mid, regsurf_base]
+
+
+@pytest.fixture
+def xtgeo_fault_lines(polygons):
+    top = polygons.copy()
+    top.name = "TopVolantis"
+
+    mid = polygons.copy()
+    mid.name = "TopTherys"
+    mid.get_dataframe(copy=False)[mid.zname] += 100
+
+    base = polygons.copy()
+    base.name = "TopVolon"
+    base.get_dataframe(copy=False)[base.zname] += 200
+
+    yield [top, mid, base]

--- a/tests/test_export_rms/test_export_structure_depth_fault_lines.py
+++ b/tests/test_export_rms/test_export_structure_depth_fault_lines.py
@@ -1,0 +1,161 @@
+"""Test the dataio running RMS spesici utility function for volumetrics"""
+
+from pathlib import Path
+from unittest import mock
+
+import jsonschema
+import numpy as np
+import pyarrow.parquet as pq
+import pytest
+
+from fmu import dataio
+from fmu.dataio._logging import null_logger
+from fmu.dataio._models.fmu_results.enums import StandardResultName
+from fmu.dataio._models.standard_results.structure_depth_fault_lines import (
+    StructureDepthFaultLinesResult,
+    StructureDepthFaultLinesSchema,
+)
+from tests.utils import inside_rms
+
+logger = null_logger(__name__)
+
+
+@pytest.fixture
+def mock_export_class(
+    mock_project_variable,
+    monkeypatch,
+    rmssetup_with_fmuconfig,
+    xtgeo_fault_lines,
+):
+    # needed to find the global config at correct place
+    monkeypatch.chdir(rmssetup_with_fmuconfig)
+
+    from fmu.dataio.export.rms.structure_depth_fault_lines import (
+        _ExportStructureDepthFaultLines,
+    )
+
+    with mock.patch(
+        "fmu.dataio.export.rms.structure_depth_fault_lines.get_polygons_in_folder",
+        return_value=xtgeo_fault_lines,
+    ):
+        yield _ExportStructureDepthFaultLines(mock_project_variable, "geogrid_vol")
+
+
+@inside_rms
+def test_files_exported_with_metadata(mock_export_class, rmssetup_with_fmuconfig):
+    """Test that the standard_result is set correctly in the metadata"""
+
+    mock_export_class.export()
+
+    export_folder = (
+        rmssetup_with_fmuconfig
+        / "../../share/results/polygons/structure_depth_fault_lines"
+    )
+    assert export_folder.exists()
+
+    assert (export_folder / "topvolantis.parquet").exists()
+    assert (export_folder / "toptherys.parquet").exists()
+    assert (export_folder / "topvolon.parquet").exists()
+
+    assert (export_folder / ".topvolantis.parquet.yml").exists()
+    assert (export_folder / ".toptherys.parquet.yml").exists()
+    assert (export_folder / ".topvolon.parquet.yml").exists()
+
+
+@inside_rms
+def test_standard_result_in_metadata(mock_export_class):
+    """Test that the standard_result is set correctly in the metadata"""
+
+    out = mock_export_class.export()
+    metadata = dataio.read_metadata(out.items[0].absolute_path)
+
+    assert "standard_result" in metadata["data"]
+    assert (
+        metadata["data"]["standard_result"]["name"]
+        == StandardResultName.structure_depth_fault_lines
+    )
+    assert (
+        metadata["data"]["standard_result"]["file_schema"]["version"]
+        == StructureDepthFaultLinesSchema.VERSION
+    )
+    assert (
+        metadata["data"]["standard_result"]["file_schema"]["url"]
+        == StructureDepthFaultLinesSchema.url()
+    )
+
+
+@inside_rms
+def test_public_export_function(mock_project_variable, mock_export_class):
+    """Test that the export function works"""
+
+    from fmu.dataio.export.rms import export_structure_depth_fault_lines
+
+    out = export_structure_depth_fault_lines(mock_project_variable, "DS_extract")
+
+    assert len(out.items) == 3
+
+    metadata = dataio.read_metadata(out.items[0].absolute_path)
+
+    assert "fault_lines" in metadata["data"]["content"]
+    assert metadata["access"]["classification"] == "internal"
+    assert (
+        metadata["data"]["standard_result"]["name"]
+        == StandardResultName.structure_depth_fault_lines
+    )
+    assert metadata["data"]["format"] == "parquet"
+
+
+@inside_rms
+def test_config_missing(mock_project_variable, rmssetup_with_fmuconfig, monkeypatch):
+    """Test that an exception is raised if the config is missing."""
+
+    from fmu.dataio.export.rms import export_structure_depth_fault_lines
+    from fmu.dataio.export.rms._utils import CONFIG_PATH
+
+    monkeypatch.chdir(rmssetup_with_fmuconfig)
+
+    config_path_modified = Path("wrong.yml")
+
+    CONFIG_PATH.rename(config_path_modified)
+
+    with pytest.raises(FileNotFoundError, match="Could not detect"):
+        export_structure_depth_fault_lines(mock_project_variable, "DS_extract")
+
+    # restore the global config file for later tests
+    config_path_modified.rename(CONFIG_PATH)
+
+
+@inside_rms
+def test_payload_validates_against_model(
+    mock_export_class,
+):
+    """Tests that the volume table exported is validated against the payload result
+    model."""
+
+    out = mock_export_class._export_fault_lines()
+    df = (
+        pq.read_table(out.items[0].absolute_path)
+        .to_pandas()
+        .replace(np.nan, None)
+        .to_dict(orient="records")
+    )
+    StructureDepthFaultLinesResult.model_validate(df)  # Throws if invalid
+
+
+@inside_rms
+def test_payload_validates_against_schema(
+    mock_export_class,
+):
+    """Tests that the volume table exported is validated against the payload result
+    schema."""
+
+    out = mock_export_class._export_fault_lines()
+    df = (
+        pq.read_table(out.items[0].absolute_path)
+        .to_pandas()
+        .replace(np.nan, None)
+        .to_dict(orient="records")
+    )
+    jsonschema.validate(
+        instance=df, schema=StructureDepthFaultLinesSchema.dump()
+    )  # Throws if invalid

--- a/tests/test_export_rms/test_utils.py
+++ b/tests/test_export_rms/test_utils.py
@@ -43,3 +43,40 @@ def test_get_horizons_in_folder_folder_not_exist(mock_project_variable):
 
     with pytest.raises(ValueError, match="not exist inside RMS"):
         get_horizons_in_folder(mock_project_variable, horizon_folder)
+
+
+def test_get_horizons_in_folder_all_empty(mock_project_variable):
+    from fmu.dataio.export.rms._utils import get_horizons_in_folder
+
+    horizon_folder = "DS_final"
+
+    horizon1 = mock.MagicMock()
+    horizon1[horizon_folder].is_empty.return_value = True
+
+    mock_project_variable.horizons.__iter__.return_value = [horizon1]
+
+    with pytest.raises(RuntimeError, match="only empty items"):
+        get_horizons_in_folder(mock_project_variable, horizon_folder)
+
+
+def test_get_polygons_in_folder_folder_not_exist(mock_project_variable):
+    from fmu.dataio.export.rms._utils import get_polygons_in_folder
+
+    horizon_folder = "non_existent_folder"
+
+    with pytest.raises(ValueError, match="not exist inside RMS"):
+        get_polygons_in_folder(mock_project_variable, horizon_folder)
+
+
+def test_get_polygons_in_folder_all_empty(mock_project_variable):
+    from fmu.dataio.export.rms._utils import get_polygons_in_folder
+
+    horizon_folder = "DS_final"
+
+    horizon1 = mock.MagicMock()
+    horizon1[horizon_folder].is_empty.return_value = True
+
+    mock_project_variable.horizons.__iter__.return_value = [horizon1]
+
+    with pytest.raises(RuntimeError, match="only empty items"):
+        get_polygons_in_folder(mock_project_variable, horizon_folder)


### PR DESCRIPTION
Resolves #763 

PR to add a simple export function for exporting the standard result `structure_depth_fault_lines` from within RMS. Including documentation for how to use the export function. 

Validations include checking that the polygons are closed. I will make a separate PR to include a check that the stratigraphic horizon exists in the `stratigraphy` block in the config, this needs to be added for the existing simple export of the standard result `structure_depth_surfaces` also.

Note the standard result schemas was added in #1083.


## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=<packagename> --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
