### PR TITLE
ENH: Add parquet as valid points/polygons format.

### DIFF
--- a/src/fmu/dataio/_definitions.py
+++ b/src/fmu/dataio/_definitions.py
@@ -36,6 +36,7 @@ class ValidFormats(Enum):
         "csv": ".csv",  # columns will be X Y Z, ID
         "csv|xtgeo": ".csv",  # use default xtgeo columns: X_UTME, ... POLY_ID
         "irap_ascii": ".pol",
+        "parquet": ".parquet",
     }
 
     points = {
@@ -43,6 +44,7 @@ class ValidFormats(Enum):
         "csv": ".csv",  # columns will be X Y Z
         "csv|xtgeo": ".csv",  # use default xtgeo columns: X_UTME, Y_UTMN, Z_TVDSS
         "irap_ascii": ".poi",
+        "parquet": ".parquet",
     }
 
     dictionary = {

--- a/src/fmu/dataio/providers/objectdata/_xtgeo.py
+++ b/src/fmu/dataio/providers/objectdata/_xtgeo.py
@@ -6,6 +6,8 @@ from textwrap import dedent
 from typing import TYPE_CHECKING, Final
 
 import numpy as np
+import pyarrow as pa
+import pyarrow.parquet as pq
 
 from fmu.dataio._definitions import ExportFolder, ValidFormats
 from fmu.dataio._logging import null_logger
@@ -189,11 +191,14 @@ class PolygonsDataProvider(ObjectDataProvider):
     def export_to_file(self, file: Path | BytesIO) -> None:
         """Export the object to file or memory buffer"""
 
-        if self.fmt == FileFormat.csv_xtgeo:
+        if self.fmt == FileFormat.parquet:
+            table = pa.Table.from_pandas(self.obj_dataframe)
+            pq.write_table(table, where=pa.output_stream(file))
+
+        elif self.fmt == FileFormat.csv_xtgeo:
             self.obj_dataframe.to_csv(file, index=False)
 
         elif self.fmt == FileFormat.csv:
-            # rename from xtgeo names to standard
             self.obj_dataframe.rename(
                 columns={
                     self.obj.xname: "X",
@@ -270,11 +275,14 @@ class PointsDataProvider(ObjectDataProvider):
     def export_to_file(self, file: Path | BytesIO) -> None:
         """Export the object to file or memory buffer"""
 
-        if self.fmt == FileFormat.csv_xtgeo:
+        if self.fmt == FileFormat.parquet:
+            table = pa.Table.from_pandas(self.obj_dataframe)
+            pq.write_table(table, where=pa.output_stream(file))
+
+        elif self.fmt == FileFormat.csv_xtgeo:
             self.obj_dataframe.to_csv(file, index=False)
 
         elif self.fmt == FileFormat.csv:
-            # rename from xtgeo names to standard
             self.obj_dataframe.rename(
                 columns={
                     self.obj.xname: "X",


### PR DESCRIPTION
Resolves #1074

Added support for exporting points/polygons as tables on `parquet` format. Necessary for #763 and since we are moving towards `parquet` as standard export format for tables. 

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=<packagename> --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
