### PR TITLE
DEP: Deprecate non-parquet points/polygon exports

### DIFF
--- a/src/fmu/dataio/providers/objectdata/_xtgeo.py
+++ b/src/fmu/dataio/providers/objectdata/_xtgeo.py
@@ -194,8 +194,15 @@ class PolygonsDataProvider(ObjectDataProvider):
         if self.fmt == FileFormat.parquet:
             table = pa.Table.from_pandas(self.obj_dataframe)
             pq.write_table(table, where=pa.output_stream(file))
+            return
 
-        elif self.fmt == FileFormat.csv_xtgeo:
+        warnings.warn(
+            "In the future polygons will be exported as tables on "
+            "parquet format, using xtgeo naming standards as column names: "
+            "X_UTME, Y_UTMN, Z_TVDSS, POLY_ID.",
+            FutureWarning,
+        )
+        if self.fmt == FileFormat.csv_xtgeo:
             self.obj_dataframe.to_csv(file, index=False)
 
         elif self.fmt == FileFormat.csv:
@@ -278,8 +285,15 @@ class PointsDataProvider(ObjectDataProvider):
         if self.fmt == FileFormat.parquet:
             table = pa.Table.from_pandas(self.obj_dataframe)
             pq.write_table(table, where=pa.output_stream(file))
+            return
 
-        elif self.fmt == FileFormat.csv_xtgeo:
+        warnings.warn(
+            "In the future points will be exported as tables on "
+            "parquet format, using xtgeo naming standards as column names: "
+            "X_UTME, Y_UTMN, Z_TVDSS.",
+            FutureWarning,
+        )
+        if self.fmt == FileFormat.csv_xtgeo:
             self.obj_dataframe.to_csv(file, index=False)
 
         elif self.fmt == FileFormat.csv:

--- a/tests/test_units/test_ert_context.py
+++ b/tests/test_units/test_ert_context.py
@@ -139,7 +139,6 @@ def test_polys_export_file_set_name(fmurun_w_casemetadata, rmsglobalconfig, poly
     edata = dataio.ExportData(
         config=rmsglobalconfig, content="depth", name="TopVolantis"
     )
-
     output = edata.export(polygons)
     logger.info("Output is %s", output)
 
@@ -167,7 +166,8 @@ def test_polys_export_file_use_xtgeo_names(
     )
 
     edata.polygons_fformat = "csv|xtgeo"  # override
-    output = edata.export(polygons)
+    with pytest.warns(FutureWarning, match="parquet format"):
+        output = edata.export(polygons)
 
     thefile = pd.read_csv(output)
     assert set(thefile.columns) == {"X_UTME", "Y_UTMN", "Z_TVDSS", "POLY_ID"}
@@ -217,7 +217,8 @@ def test_polys_export_file_as_irap_ascii(
     )
 
     edata.polygons_fformat = "irap_ascii"  # override
-    output = Path(edata.export(polygons))
+    with pytest.warns(FutureWarning, match="parquet format"):
+        output = Path(edata.export(polygons))
 
     assert output.exists()
     assert output == (
@@ -266,8 +267,8 @@ def test_points_export_file_set_name_xtgeoheaders(
         config=rmsglobalconfig, content="depth", name="TopVolantiz"
     )
     edata.points_fformat = "csv|xtgeo"  # override
-
-    output = edata.export(points)
+    with pytest.warns(FutureWarning, match="parquet format"):
+        output = edata.export(points)
     logger.info("Output is %s", output)
 
     assert str(output) == str(
@@ -299,7 +300,8 @@ def test_points_export_file_as_irap_ascii(
     )
 
     edata.points_fformat = "irap_ascii"  # override
-    output = Path(edata.export(points))
+    with pytest.warns(FutureWarning, match="parquet format"):
+        output = Path(edata.export(points))
 
     assert output.exists()
     assert output == (


### PR DESCRIPTION
Resolves #1070

PR to start adding a deprecation notice whenever points/polygons are exported on a format other than `parquet.`

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=<packagename> --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
