### PR TITLE
TST: Fix failing test in komodo

### DIFF
--- a/tests/test_schema/test_schemas_up_to_date.py
+++ b/tests/test_schema/test_schemas_up_to_date.py
@@ -86,6 +86,9 @@ def test_schema_url_changes_with_komodo_bleeding_env_var(
     assert json["$id"].startswith(FmuSchemas.PROD_URL)
     assert json["$schema"] == "https://json-schema.org/draft/2020-12/schema"
 
+    # needed to prevent tests failing if inside an actual komodo environment
+    monkeypatch.delenv("KOMODO_RELEASE", raising=False)
+
     monkeypatch.setenv(env_var, env_var_value)
     json = schema.dump()
     assert schema.url().startswith(FmuSchemas.DEV_URL)


### PR DESCRIPTION
Fixed test to not fail if komodo release env already exists, meaning if you are in komodo env

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=<packagename> --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [ ] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [ ] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [ ] Checked the boxes in this checklist ✅
