### PR TITLE
CI: Only build docs, dont deploy

### DIFF
--- a/.github/workflows/fmudataio-documention.yml
+++ b/.github/workflows/fmudataio-documention.yml
@@ -1,5 +1,4 @@
-# build and test some end points
-name: Build and deploy docs for fmu-dataio
+name: Test building docs for fmu-dataio
 
 on:
   pull_request:
@@ -24,29 +23,8 @@ jobs:
           pip install -U pip
           pip install .[docs]
 
-      - name: Generate examples
+      - name: Generate updated examples
         run: sh examples/update_examples.sh
 
-      - name: Build documentation
+      - name: Build documentation with sphinx
         run: sphinx-build -b html docs/src build/docs/html -j auto
-
-      - name: Update GitHub pages
-        if: github.repository_owner == 'equinor' && github.ref == 'refs/heads/main'
-        run: |
-          cp -R ./build/docs/html ../html
-          git config --local user.email "fmu-dataio-github-action"
-          git config --local user.name "fmu-dataio-github-action"
-          git fetch origin gh-pages
-          git checkout --track origin/gh-pages
-          git clean -f -f -d -x  # Double -f is intentional.
-          git rm -r *
-          cp -R ../html/* .
-          touch .nojekyll  # If not, github pages ignores _* directories.
-          git add .
-          echo "Ready for commit"
-          if git diff-index --quiet HEAD; then
-            echo "No changes in documentation. Skip documentation deploy."
-          else
-            git commit -m "Update Github Pages"
-            git push "https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" gh-pages
-          fi

--- a/docs/src/examples.rst
+++ b/docs/src/examples.rst
@@ -17,7 +17,7 @@ This is a snippet of the ``global_variables.yml`` file which holds the static me
 
 .. toggle::
 
-   .. literalinclude:: ../../examples/example_exports/fmuconfig/output/global_variables.yml
+   .. literalinclude:: ../../examples/fmuconfig/output/global_variables.yml
       :language: yaml
 
 |
@@ -88,7 +88,7 @@ Exporting volume tables RMS or file
 
 Below is an example of exporting volume tables from csv-files, 
 while an example of a simple export of RMS volumetrics can be found 
-`here <https://fmu-dataio.readthedocs.io/en/latest/standard_results/initial_inplace_volumes.html>`.
+`here <./standard_results/initial_inplace_volumes.html>`__.
 
 Python script
 ~~~~~~~~~~~~~


### PR DESCRIPTION
Resolves #1080 

Update github workflow `fmudataio-documentation.yml` to only build doc and dont deploy:

Readthedocs automatically builds and updates the docs on updates on main, so the `fmudataio-documentation.yml` is now only used for testing that the docs are building with Sphinx. The changes in this PR are made to reflect this and remove outdated code.

## Checklist

- [X] Tests added (if not, comment why): No tests for CI
- [X] Test coverage equal or up from main (run pytest with `--cov=<packagename> --cov-report term-missing`)
- [X] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [X] Docstrings are correct and updated
- [X] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [X] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅
