### PR TITLE
DOC: Use dummy for uuids and tracklog props

### DIFF
--- a/.github/workflows/ci-fmudataio.yml
+++ b/.github/workflows/ci-fmudataio.yml
@@ -39,9 +39,15 @@ jobs:
           pip install \
             "fmu-sumo-uploader @ git+https://github.com/equinor/fmu-sumo-uploader.git@66a9f9b"
 
-        # fmu-sumo-uploader blocked by OpenVDS on Python 3.12
-      - name: Install fmu-sumo-uploader for Python 3.9+
-        if: matrix.python-version != '3.12' && matrix.python-version != '3.8'
+      - name: Install fmu-sumo-uploader for Python 3.9 and 3.10
+        if: matrix.python-version == '3.9' || matrix.python-version == '3.10'
+        run:
+          pip install \
+            "fmu-sumo-uploader @ git+https://github.com/equinor/fmu-sumo-uploader.git@1.0.12"
+
+       # fmu-sumo-uploader blocked by OpenVDS on Python 3.12
+      - name: Install fmu-sumo-uploader for Python 3.11
+        if: matrix.python-version == '3.11'
         run:
           pip install \
             "fmu-sumo-uploader @ git+https://github.com/equinor/fmu-sumo-uploader.git"

--- a/examples/example_metadata/aggregated_surface_depth.yml
+++ b/examples/example_metadata/aggregated_surface_depth.yml
@@ -58,7 +58,7 @@ fmu:
     name: MyCase
     user:
       id: user
-    uuid: 544edd1c-fbee-49b8-9021-864a7412df2f
+    uuid: 00000000-0000-0000-0000-000000000000
   context:
     stage: iteration
   ert:
@@ -68,7 +68,7 @@ fmu:
   iteration:
     id: 0
     name: iter-0
-    uuid: 1b2eff5c-39b0-a79c-0517-7e4c5a8cdf31
+    uuid: 00000000-0000-0000-0000-000000000000
   model:
     name: ff
     revision: 21.1.0.dev
@@ -97,13 +97,13 @@ tracklog:
   event: created
   sysinfo:
     fmu-dataio:
-      version: 2.9.2.dev20+g54255e6ba.d20250305
+      version: dummy_version
     operating_system:
       hostname: dummy_hostname
       operating_system: dummy_os
-      release: 24.3.0
-      system: Darwin
-      version: 'Darwin Kernel Version 24.3.0: Thu Jan  2 20:24:23 PST 2025; root:xnu-11215.81.4~3/RELEASE_ARM64_T6031'
+      release: dummy_release
+      system: dummy_system
+      version: dummy_version
   user:
     id: user
 version: 0.9.0

--- a/examples/example_metadata/fmu_case.yml
+++ b/examples/example_metadata/fmu_case.yml
@@ -9,7 +9,7 @@ fmu:
     name: MyCase
     user:
       id: user
-    uuid: 7ac53582-0054-4a99-b72e-d89dd89f7a4c
+    uuid: 00000000-0000-0000-0000-000000000000
   model:
     name: ff
     revision: 21.1.0.dev
@@ -32,17 +32,17 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-03-13T07:56:58.592853Z'
+- datetime: '2025-03-18T12:25:38.692257Z'
   event: created
   sysinfo:
     fmu-dataio:
-      version: 2.9.2.dev20+g54255e6ba.d20250305
+      version: dummy_version
     operating_system:
       hostname: dummy_hostname
       operating_system: dummy_os
-      release: 24.3.0
-      system: Darwin
-      version: 'Darwin Kernel Version 24.3.0: Thu Jan  2 20:24:23 PST 2025; root:xnu-11215.81.4~3/RELEASE_ARM64_T6031'
+      release: dummy_release
+      system: dummy_system
+      version: dummy_version
   user:
     id: user
 version: 0.9.0

--- a/examples/example_metadata/polygons_field_outline.yml
+++ b/examples/example_metadata/polygons_field_outline.yml
@@ -31,7 +31,7 @@ data:
   spec:
     npolys: 6
   stratigraphic: true
-  tagname: polgons_field_outline
+  tagname: polygons_field_outline
   undef_is_zero: false
   unit: m
   vertical_domain: depth
@@ -40,30 +40,30 @@ display:
 file:
   absolute_path: /some/absolute/path/
   checksum_md5: 370519102b2362716cdf5b8b67e44ed0
-  relative_path: example_exports/share/results/polygons/volantis_gp_base--polgons_field_outline.csv
+  relative_path: example_exports/share/results/polygons/volantis_gp_base--polygons_field_outline.csv
 fmu:
   case:
     name: MyCase
     user:
       id: user
-    uuid: 7ac53582-0054-4a99-b72e-d89dd89f7a4c
+    uuid: 00000000-0000-0000-0000-000000000000
   context:
     stage: realization
   ert:
     experiment:
-      id: 6a8e1e0f-9315-46bb-9648-8de87151f4c7
+      id: 00000000-0000-0000-0000-000000000000
     simulation_mode: test_run
   iteration:
     id: 0
     name: iter-0
-    uuid: 57761f5c-5683-6ab3-351f-e4bf305b6380
+    uuid: 00000000-0000-0000-0000-000000000000
   model:
     name: ff
     revision: 21.1.0.dev
   realization:
     id: 0
     name: example_exports
-    uuid: a661f29d-a286-e65d-5bf7-dfb2823eb0ee
+    uuid: 00000000-0000-0000-0000-000000000000
   workflow:
     reference: rms structural model
 masterdata:
@@ -85,17 +85,17 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-03-13T07:57:01.103531Z'
+- datetime: '2025-03-18T12:25:41.062894Z'
   event: created
   sysinfo:
     fmu-dataio:
-      version: 2.9.2.dev20+g54255e6ba.d20250305
+      version: dummy_version
     operating_system:
       hostname: dummy_hostname
       operating_system: dummy_os
-      release: 24.3.0
-      system: Darwin
-      version: 'Darwin Kernel Version 24.3.0: Thu Jan  2 20:24:23 PST 2025; root:xnu-11215.81.4~3/RELEASE_ARM64_T6031'
+      release: dummy_release
+      system: dummy_system
+      version: dummy_version
   user:
     id: user
 version: 0.9.0

--- a/examples/example_metadata/polygons_field_region.yml
+++ b/examples/example_metadata/polygons_field_region.yml
@@ -46,24 +46,24 @@ fmu:
     name: MyCase
     user:
       id: user
-    uuid: 7ac53582-0054-4a99-b72e-d89dd89f7a4c
+    uuid: 00000000-0000-0000-0000-000000000000
   context:
     stage: realization
   ert:
     experiment:
-      id: 6a8e1e0f-9315-46bb-9648-8de87151f4c7
+      id: 00000000-0000-0000-0000-000000000000
     simulation_mode: test_run
   iteration:
     id: 0
     name: iter-0
-    uuid: 57761f5c-5683-6ab3-351f-e4bf305b6380
+    uuid: 00000000-0000-0000-0000-000000000000
   model:
     name: ff
     revision: 21.1.0.dev
   realization:
     id: 0
     name: example_exports
-    uuid: a661f29d-a286-e65d-5bf7-dfb2823eb0ee
+    uuid: 00000000-0000-0000-0000-000000000000
   workflow:
     reference: rms structural model
 masterdata:
@@ -85,17 +85,17 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-03-13T07:57:01.079559Z'
+- datetime: '2025-03-18T12:25:41.032622Z'
   event: created
   sysinfo:
     fmu-dataio:
-      version: 2.9.2.dev20+g54255e6ba.d20250305
+      version: dummy_version
     operating_system:
       hostname: dummy_hostname
       operating_system: dummy_os
-      release: 24.3.0
-      system: Darwin
-      version: 'Darwin Kernel Version 24.3.0: Thu Jan  2 20:24:23 PST 2025; root:xnu-11215.81.4~3/RELEASE_ARM64_T6031'
+      release: dummy_release
+      system: dummy_system
+      version: dummy_version
   user:
     id: user
 version: 0.9.0

--- a/examples/example_metadata/preprocessed_surface_depth.yml
+++ b/examples/example_metadata/preprocessed_surface_depth.yml
@@ -51,12 +51,12 @@ fmu:
     name: MyCase
     user:
       id: user
-    uuid: 7ac53582-0054-4a99-b72e-d89dd89f7a4c
+    uuid: 00000000-0000-0000-0000-000000000000
   context:
     stage: case
   ert:
     experiment:
-      id: 6a8e1e0f-9315-46bb-9648-8de87151f4c7
+      id: 00000000-0000-0000-0000-000000000000
     simulation_mode: test_run
   model:
     name: ff
@@ -80,17 +80,17 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-03-13T07:57:04.570275Z'
+- datetime: '2025-03-18T12:25:44.497169Z'
   event: created
   sysinfo:
     fmu-dataio:
-      version: 2.9.2.dev20+g54255e6ba.d20250305
+      version: dummy_version
     operating_system:
       hostname: dummy_hostname
       operating_system: dummy_os
-      release: 24.3.0
-      system: Darwin
-      version: 'Darwin Kernel Version 24.3.0: Thu Jan  2 20:24:23 PST 2025; root:xnu-11215.81.4~3/RELEASE_ARM64_T6031'
+      release: dummy_release
+      system: dummy_system
+      version: dummy_version
   user:
     id: user
 version: 0.9.0

--- a/examples/example_metadata/surface_depth.yml
+++ b/examples/example_metadata/surface_depth.yml
@@ -51,24 +51,24 @@ fmu:
     name: MyCase
     user:
       id: user
-    uuid: 7ac53582-0054-4a99-b72e-d89dd89f7a4c
+    uuid: 00000000-0000-0000-0000-000000000000
   context:
     stage: realization
   ert:
     experiment:
-      id: 6a8e1e0f-9315-46bb-9648-8de87151f4c7
+      id: 00000000-0000-0000-0000-000000000000
     simulation_mode: test_run
   iteration:
     id: 0
     name: iter-0
-    uuid: 57761f5c-5683-6ab3-351f-e4bf305b6380
+    uuid: 00000000-0000-0000-0000-000000000000
   model:
     name: ff
     revision: 21.1.0.dev
   realization:
     id: 0
     name: example_exports
-    uuid: a661f29d-a286-e65d-5bf7-dfb2823eb0ee
+    uuid: 00000000-0000-0000-0000-000000000000
   workflow:
     reference: rms structural model
 masterdata:
@@ -90,17 +90,17 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-03-13T07:57:05.737288Z'
+- datetime: '2025-03-18T12:25:45.664806Z'
   event: created
   sysinfo:
     fmu-dataio:
-      version: 2.9.2.dev20+g54255e6ba.d20250305
+      version: dummy_version
     operating_system:
       hostname: dummy_hostname
       operating_system: dummy_os
-      release: 24.3.0
-      system: Darwin
-      version: 'Darwin Kernel Version 24.3.0: Thu Jan  2 20:24:23 PST 2025; root:xnu-11215.81.4~3/RELEASE_ARM64_T6031'
+      release: dummy_release
+      system: dummy_system
+      version: dummy_version
   user:
     id: user
 version: 0.9.0

--- a/examples/example_metadata/surface_fluid_contact.yml
+++ b/examples/example_metadata/surface_fluid_contact.yml
@@ -54,24 +54,24 @@ fmu:
     name: MyCase
     user:
       id: user
-    uuid: 7ac53582-0054-4a99-b72e-d89dd89f7a4c
+    uuid: 00000000-0000-0000-0000-000000000000
   context:
     stage: realization
   ert:
     experiment:
-      id: 6a8e1e0f-9315-46bb-9648-8de87151f4c7
+      id: 00000000-0000-0000-0000-000000000000
     simulation_mode: test_run
   iteration:
     id: 0
     name: iter-0
-    uuid: 57761f5c-5683-6ab3-351f-e4bf305b6380
+    uuid: 00000000-0000-0000-0000-000000000000
   model:
     name: ff
     revision: 21.1.0.dev
   realization:
     id: 0
     name: example_exports
-    uuid: a661f29d-a286-e65d-5bf7-dfb2823eb0ee
+    uuid: 00000000-0000-0000-0000-000000000000
   workflow:
     reference: rms structural model
 masterdata:
@@ -93,17 +93,17 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-03-13T07:57:05.757438Z'
+- datetime: '2025-03-18T12:25:45.696020Z'
   event: created
   sysinfo:
     fmu-dataio:
-      version: 2.9.2.dev20+g54255e6ba.d20250305
+      version: dummy_version
     operating_system:
       hostname: dummy_hostname
       operating_system: dummy_os
-      release: 24.3.0
-      system: Darwin
-      version: 'Darwin Kernel Version 24.3.0: Thu Jan  2 20:24:23 PST 2025; root:xnu-11215.81.4~3/RELEASE_ARM64_T6031'
+      release: dummy_release
+      system: dummy_system
+      version: dummy_version
   user:
     id: user
 version: 0.9.0

--- a/examples/example_metadata/surface_seismic_amplitude.yml
+++ b/examples/example_metadata/surface_seismic_amplitude.yml
@@ -72,24 +72,24 @@ fmu:
     name: MyCase
     user:
       id: user
-    uuid: 7ac53582-0054-4a99-b72e-d89dd89f7a4c
+    uuid: 00000000-0000-0000-0000-000000000000
   context:
     stage: realization
   ert:
     experiment:
-      id: 6a8e1e0f-9315-46bb-9648-8de87151f4c7
+      id: 00000000-0000-0000-0000-000000000000
     simulation_mode: test_run
   iteration:
     id: 0
     name: iter-0
-    uuid: 57761f5c-5683-6ab3-351f-e4bf305b6380
+    uuid: 00000000-0000-0000-0000-000000000000
   model:
     name: ff
     revision: 21.1.0.dev
   realization:
     id: 0
     name: example_exports
-    uuid: a661f29d-a286-e65d-5bf7-dfb2823eb0ee
+    uuid: 00000000-0000-0000-0000-000000000000
   workflow:
     reference: rms structural model
 masterdata:
@@ -111,17 +111,17 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-03-13T07:57:05.779322Z'
+- datetime: '2025-03-18T12:25:45.722039Z'
   event: created
   sysinfo:
     fmu-dataio:
-      version: 2.9.2.dev20+g54255e6ba.d20250305
+      version: dummy_version
     operating_system:
       hostname: dummy_hostname
       operating_system: dummy_os
-      release: 24.3.0
-      system: Darwin
-      version: 'Darwin Kernel Version 24.3.0: Thu Jan  2 20:24:23 PST 2025; root:xnu-11215.81.4~3/RELEASE_ARM64_T6031'
+      release: dummy_release
+      system: dummy_system
+      version: dummy_version
   user:
     id: user
 version: 0.9.0

--- a/examples/example_metadata/table_inplace_volumes.yml
+++ b/examples/example_metadata/table_inplace_volumes.yml
@@ -59,24 +59,24 @@ fmu:
     name: MyCase
     user:
       id: user
-    uuid: 7ac53582-0054-4a99-b72e-d89dd89f7a4c
+    uuid: 00000000-0000-0000-0000-000000000000
   context:
     stage: realization
   ert:
     experiment:
-      id: 6a8e1e0f-9315-46bb-9648-8de87151f4c7
+      id: 00000000-0000-0000-0000-000000000000
     simulation_mode: test_run
   iteration:
     id: 0
     name: iter-0
-    uuid: 57761f5c-5683-6ab3-351f-e4bf305b6380
+    uuid: 00000000-0000-0000-0000-000000000000
   model:
     name: ff
     revision: 21.1.0.dev
   realization:
     id: 0
     name: example_exports
-    uuid: a661f29d-a286-e65d-5bf7-dfb2823eb0ee
+    uuid: 00000000-0000-0000-0000-000000000000
   workflow:
     reference: Volume calculation
 masterdata:
@@ -98,17 +98,17 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-03-13T07:57:08.339280Z'
+- datetime: '2025-03-18T12:25:48.380480Z'
   event: created
   sysinfo:
     fmu-dataio:
-      version: 2.9.2.dev20+g54255e6ba.d20250305
+      version: dummy_version
     operating_system:
       hostname: dummy_hostname
       operating_system: dummy_os
-      release: 24.3.0
-      system: Darwin
-      version: 'Darwin Kernel Version 24.3.0: Thu Jan  2 20:24:23 PST 2025; root:xnu-11215.81.4~3/RELEASE_ARM64_T6031'
+      release: dummy_release
+      system: dummy_system
+      version: dummy_version
   user:
     id: user
 version: 0.9.0

--- a/examples/metadata_scripts/post_process_metadata.py
+++ b/examples/metadata_scripts/post_process_metadata.py
@@ -5,9 +5,18 @@ from pathlib import Path
 
 import yaml
 
+DUMMY_UUID = "00000000-0000-0000-0000-000000000000"
+
 
 def remove_machine_data(metadata_yaml: dict) -> dict:
     """Remove machine specific data from metadata file."""
+
+    if "fmu" in metadata_yaml:
+        metadata_yaml["fmu"]["case"]["uuid"] = DUMMY_UUID
+        if "realization" in metadata_yaml["fmu"]:
+            metadata_yaml["fmu"]["realization"]["uuid"] = DUMMY_UUID
+        if "iteration" in metadata_yaml["fmu"]:
+            metadata_yaml["fmu"]["iteration"]["uuid"] = DUMMY_UUID
 
     if "file" in metadata_yaml and "absolute_path" in metadata_yaml["file"]:
         metadata_yaml["file"]["absolute_path"] = "/some/absolute/path/"
@@ -15,16 +24,21 @@ def remove_machine_data(metadata_yaml: dict) -> dict:
     if "tracklog" in metadata_yaml:
         for tracklog_event in metadata_yaml["tracklog"]:
             tracklog_event["user"]["id"] = "user"
-            if (
-                "sysinfo" in tracklog_event
-                and "operating_system" in tracklog_event["sysinfo"]
-            ):
-                tracklog_event["sysinfo"]["operating_system"]["hostname"] = (
-                    "dummy_hostname"
-                )
-                tracklog_event["sysinfo"]["operating_system"]["operating_system"] = (
-                    "dummy_os"
-                )
+            if "sysinfo" in tracklog_event:
+                if "operating_system" in tracklog_event["sysinfo"]:
+                    tracklog_event["sysinfo"]["operating_system"] = {
+                        "hostname": "dummy_hostname",
+                        "operating_system": "dummy_os",
+                        "release": "dummy_release",
+                        "system": "dummy_system",
+                        "version": "dummy_version",
+                    }
+
+                if "fmu-dataio" in tracklog_event["sysinfo"]:
+                    tracklog_event["sysinfo"]["fmu-dataio"]["version"] = "dummy_version"
+
+                if "komodo" in tracklog_event["sysinfo"]:
+                    tracklog_event["sysinfo"]["komodo"]["version"] = "dummy_version"
 
     return metadata_yaml
 

--- a/examples/update_examples.sh
+++ b/examples/update_examples.sh
@@ -34,7 +34,7 @@ python metadata_scripts/create_case_metadata.py
 #--------- Export files and metadata using the example export scripts ---------#
 
 # fake an ERT FMU run
-export _ERT_EXPERIMENT_ID=6a8e1e0f-9315-46bb-9648-8de87151f4c7
+export _ERT_EXPERIMENT_ID=00000000-0000-0000-0000-000000000000
 export _ERT_ENSEMBLE_ID=b027f225-c45d-477d-8f33-73695217ba14
 export _ERT_SIMULATION_MODE=test_run
 export _ERT_RUNPATH=$examples_rootpath/example_exports


### PR DESCRIPTION
Resolves #1010 

Updated the `post_process_metadata.py` script to insert dummies for some additional fields:
* uuids are replaced with `00000000-0000-0000-0000-000000000000`
* All fields in the `operating_system` block are replaced with dummy values
* `komodo.version` and `fmu-dataio.version` are replaced by dummies.

In this way there will be less noise when the metadata is updated, making it easier to focus on the actual updates.

## Checklist

- [X] Tests added (if not, comment why)
- [X] Test coverage equal or up from main (run pytest with `--cov=<packagename> --cov-report term-missing`)
- [X] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [X] Docstrings are correct and updated
- [X] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [X] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅
