### PR TITLE
BUG: Fix missing BytesIO import in ObjectDataProvider

### DIFF
--- a/src/fmu/dataio/providers/objectdata/_base.py
+++ b/src/fmu/dataio/providers/objectdata/_base.py
@@ -4,6 +4,7 @@ import warnings
 from abc import abstractmethod
 from dataclasses import dataclass, field
 from datetime import datetime
+from io import BytesIO
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING, Any, Final
@@ -28,9 +29,6 @@ from fmu.dataio.providers.objectdata._export_models import (
 )
 
 if TYPE_CHECKING:
-    from io import BytesIO
-    from pathlib import Path
-
     from pydantic import BaseModel
 
     from fmu.dataio._models.fmu_results.data import (

--- a/src/fmu/dataio/providers/objectdata/_provider.py
+++ b/src/fmu/dataio/providers/objectdata/_provider.py
@@ -117,7 +117,6 @@ from ._xtgeo import (
 
 if TYPE_CHECKING:
     from io import BytesIO
-    from pathlib import Path
 
     from fmu.dataio.dataio import ExportData
     from fmu.dataio.types import Inferrable

--- a/tests/test_units/test_objectdataprovider_class.py
+++ b/tests/test_units/test_objectdataprovider_class.py
@@ -170,3 +170,12 @@ def test_regsurf_preprocessed_observation(
     with open(out.parent / f".{out.name}.yml", encoding="utf-8") as f:
         metadata = yaml.safe_load(f)
     assert metadata["data"] == case_meta["data"]
+
+
+def test_objectdata_compute_md5(gridproperty, edataobj1):
+    """Test compute_md5 function works and gives same result as in the metadata"""
+
+    myobj = objectdata_provider_factory(gridproperty, edataobj1)
+
+    metadata = edataobj1.generate_metadata(gridproperty)
+    assert metadata["file"]["checksum_md5"] == myobj.compute_md5()


### PR DESCRIPTION
Resolves #1086

PR to fix missing `BytesIO` import, it was only included in the `TYPE_CHECKING` imports.

This led to an exception for all objects when they tried to compute the checksum_md5 from memory stream, hence the checksum was computed using the `NamedTemporaryFile` instead.

This should improve the flaky test that was failing, now checksum_md5 will no longer be calculated using temporary files for grid. It is mainly XTGeo cubes that does not support writing to memory stream.

Added a test of the checksum_md5 method directly, that failed prior to the bugfix included here. 

We should enable the ruff rule https://docs.astral.sh/ruff/rules/runtime-import-in-type-checking-block/ to prevent situations like this from going undetected again.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=<packagename> --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
