### PR TITLE
STY: Add most of TCH rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,8 @@ ignore = [
     "C901",  # mccabe complex-structure
     "PD901",  # Avoid using the generic variable name `df` for dataframes
     "PD011",  # Avoid using .values on dataframes (gives false positives)
+    "TC001",  # Move imports under TYPE_CHECKING. Breaks Pydantic annotations
+    "TC003",  # Move stdlib imports under TYPE_CHECKING. Breaks Pydantic annotations
 ]
 select = [
     "B",  # flake-8-bugbear
@@ -129,7 +131,7 @@ select = [
     "RET",  # flake8-return
     "RSE",  # flake8-raise
     "SIM",  # flake8-simplify
-    # "TCH",  # flake8-type-checking
+    "TCH",  # flake8-type-checking
     # "TID",  # flake8-tidy-imports
     "UP",  # pyupgrade
     "W",  # pylint-warnings

--- a/src/fmu/dataio/_models/standard_results/structure_depth_fault_lines.py
+++ b/src/fmu/dataio/_models/standard_results/structure_depth_fault_lines.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
 
-from pathlib import Path
 from typing import TYPE_CHECKING, List
 
 from pydantic import BaseModel, Field, RootModel
 
 from fmu.dataio._models._schema_base import FmuSchemas, SchemaBase
-from fmu.dataio.types import VersionStr
 
 if TYPE_CHECKING:
+    from pathlib import Path
     from typing import Any
+
+    from fmu.dataio.types import VersionStr
 
 
 class StructureDepthFaultLinesResultRow(BaseModel):

--- a/src/fmu/dataio/_utils.py
+++ b/src/fmu/dataio/_utils.py
@@ -9,7 +9,6 @@ import os
 import shlex
 import uuid
 from datetime import datetime
-from io import BufferedIOBase, BytesIO
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Final
 
@@ -22,12 +21,15 @@ import yaml
 
 from fmu.config import utilities as ut
 
-from . import types
 from ._logging import null_logger
 from .readers import FaultRoomSurface
 
 if TYPE_CHECKING:
+    from io import BufferedIOBase, BytesIO
+
     from fmu.dataio.providers.objectdata._base import ObjectDataProvider
+
+    from . import types
 
 
 logger: Final = null_logger(__name__)

--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -22,16 +22,12 @@ from typing import (
 )
 from warnings import warn
 
-if TYPE_CHECKING:
-    from . import types
-
 from fmu.dataio.aggregation import AggregatedData
 
 from ._logging import null_logger
 from ._metadata import generate_export_metadata
 from ._models.fmu_results import enums, global_configuration
 from ._models.fmu_results.global_configuration import GlobalConfiguration
-from ._models.fmu_results.standard_result import StandardResult
 from ._utils import (
     detect_inside_rms,  # dataio_examples,
     export_metadata_file,
@@ -46,6 +42,11 @@ from .preprocessed import ExportPreprocessedData
 from .providers._filedata import FileDataProvider
 from .providers._fmu import FmuProvider, get_fmu_context_from_environment
 from .providers.objectdata._provider import objectdata_provider_factory
+
+if TYPE_CHECKING:
+    from . import types
+    from ._models.fmu_results.standard_result import StandardResult
+
 
 # DATAIO_EXAMPLES: Final = dataio_examples()
 INSIDE_RMS: Final = detect_inside_rms()

--- a/src/fmu/dataio/providers/objectdata/_base.py
+++ b/src/fmu/dataio/providers/objectdata/_base.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING, Any, Final
 
-from fmu.dataio._definitions import ValidFormats
 from fmu.dataio._logging import null_logger
 from fmu.dataio._models.fmu_results.data import AnyData, Time, Timestamp
 from fmu.dataio._models.fmu_results.enums import Content
@@ -17,7 +16,6 @@ from fmu.dataio._models.fmu_results.global_configuration import (
     GlobalConfiguration,
     StratigraphyElement,
 )
-from fmu.dataio._models.fmu_results.standard_result import StandardResult
 from fmu.dataio._utils import generate_description, md5sum
 from fmu.dataio.exceptions import ConfigurationError
 from fmu.dataio.providers._base import Provider
@@ -31,6 +29,7 @@ from fmu.dataio.providers.objectdata._export_models import (
 if TYPE_CHECKING:
     from pydantic import BaseModel
 
+    from fmu.dataio._definitions import ValidFormats
     from fmu.dataio._models.fmu_results.data import (
         BoundingBox2D,
         BoundingBox3D,
@@ -38,6 +37,7 @@ if TYPE_CHECKING:
     )
     from fmu.dataio._models.fmu_results.enums import FileFormat, FMUClass, Layout
     from fmu.dataio._models.fmu_results.specification import AnySpecification
+    from fmu.dataio._models.fmu_results.standard_result import StandardResult
     from fmu.dataio.dataio import ExportData
     from fmu.dataio.types import Inferrable
 

--- a/src/fmu/dataio/providers/objectdata/_provider.py
+++ b/src/fmu/dataio/providers/objectdata/_provider.py
@@ -98,7 +98,6 @@ import xtgeo
 from fmu.dataio._definitions import ExportFolder, ValidFormats
 from fmu.dataio._logging import null_logger
 from fmu.dataio._models.fmu_results.enums import FileFormat, FMUClass, Layout
-from fmu.dataio._models.fmu_results.standard_result import StandardResult
 from fmu.dataio.readers import FaultRoomSurface
 
 from ._base import (
@@ -118,6 +117,7 @@ from ._xtgeo import (
 if TYPE_CHECKING:
     from io import BytesIO
 
+    from fmu.dataio._models.fmu_results.standard_result import StandardResult
     from fmu.dataio.dataio import ExportData
     from fmu.dataio.types import Inferrable
 

--- a/src/fmu/dataio/providers/objectdata/_utils.py
+++ b/src/fmu/dataio/providers/objectdata/_utils.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import warnings
+from typing import TYPE_CHECKING
 
-from fmu.dataio._models.fmu_results.global_configuration import Stratigraphy
+if TYPE_CHECKING:
+    from fmu.dataio._models.fmu_results.global_configuration import Stratigraphy
 
 
 class Utils:

--- a/tests/test_ert_integration/ert_config_utils.py
+++ b/tests/test_ert_integration/ert_config_utils.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def add_create_case_workflow(ert_config_path: Path | str) -> None:


### PR DESCRIPTION
Resolves #1088

Two rules to move things _under_ `TYPE_CHECKING` are ignored. They cause Pydantic classes to fail at construction since at runtime Pydantic cannot collect and use them.

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=<packagename> --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
