### PR TITLE
DEV: Add .coveragerc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[report]
+exclude_also =
+    ; Ignore type checking blocks
+    if TYPE_CHECKING:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@ changes made to the code, and what the PR is solving."
 ## Checklist
 
 - [ ] Tests added (if not, comment why)
-- [ ] Test coverage equal or up from main (run pytest with `--cov=<packagename> --cov-report term-missing`)
+- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
 - [ ] If not squash merging, every commit passes tests
 - [ ] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
 - [ ] All debug prints and unnecessary comments removed


### PR DESCRIPTION
Resolves #1091

Code blocks that should not be considered for test coverage can be specified here. Also adjusted the PR template to reflect how this can be invoked.

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=<packagename> --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
