### PR TITLE
FIX: Truncate negative bulk/porv values in inplace_volumes

### DIFF
--- a/docs/src/standard_results/initial_inplace_volumes.md
+++ b/docs/src/standard_results/initial_inplace_volumes.md
@@ -44,6 +44,16 @@ should be moved to after the export for flow simulation.
 
 ## Result
 
+The volumetric table from RMS undergoes a couple of transformations to adhere to the
+`inplace_volumes` standard format:
+
+1. Water zone bulk and pore volumes are calculated by subtracting oil and gas zone
+   volumes from the total volumes. The total volumes are removed, and any negative
+   values caused by precision issues in RMS are truncated to zero.
+2. The fluid-specific columns are unfied into a single set of volumetric columns,
+   with an additional `FLUID` column indicating the fluid type. If the `NET` column
+   is absent, it is set equal to the `BULK` column, assuming a net-to-gross ratio of one.
+
 Given a grid model name `Geogrid` the result file will be
 `share/results/tables/volumes/geogrid.parquet`.
 
@@ -51,7 +61,7 @@ This is a tabular file that can be converted to `.csv` or similar. It contains
 the following columns with types validated as indicated.
 
 ```{eval-rst}
-.. autopydantic_model:: fmu.dataio._models.standard_result.inplace_volumes.InplaceVolumesResultRow
+.. autopydantic_model:: fmu.dataio._models.standard_results.inplace_volumes.InplaceVolumesResultRow
    :members:
    :inherited-members: BaseModel
    :model-show-config-summary: False


### PR DESCRIPTION
Resolves #1085 

PR to ensure negative values in the computed BULK/PORV column for the water zone are truncated to 0 before validation.


## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
