### PR TITLE
ENH: Improve case metadata exists warning

### DIFF
--- a/src/fmu/dataio/case.py
+++ b/src/fmu/dataio/case.py
@@ -106,9 +106,13 @@ class CreateCaseMetadata:  # pylint: disable=too-few-public-methods
         """
         if not self._establish_metadata_files():
             exists_warning = (
-                "The case metadata file already exists and will not be overwritten. "
-                "To make new case metadata delete the old case or run on a different "
-                "runpath."
+                "Using existing case metadata from runpath: "
+                "All data exported to Sumo will be stored to this existing case in "
+                "Sumo. If you want to create a new case in Sumo to store your data to, "
+                "delete the old case through Ert, or run on a different runpath "
+                "by editing it in your Ert configuration model.\n\n"
+                "Ignore this warning if your model is not enabled for Sumo yet, "
+                "or if storing to the existing case in Sumo is what you want."
             )
             logger.warning(exists_warning)
             warnings.warn(exists_warning, UserWarning)

--- a/tests/test_ert_integration/test_wf_create_case_metadata.py
+++ b/tests/test_ert_integration/test_wf_create_case_metadata.py
@@ -54,7 +54,7 @@ def test_create_case_metadata_warns_without_overwriting(
     with open(fmu_case_yml, encoding="utf-8") as f:
         first_run = yaml.safe_load(f)
 
-    with pytest.warns(UserWarning, match="The case metadata file already exists"):
+    with pytest.warns(UserWarning, match="Using existing case metadata from runpath:"):
         ert.__main__.main()
 
     ls_share_metadata = os.listdir(share_metadata)

--- a/tests/test_units/test_initialize_case.py
+++ b/tests/test_units/test_initialize_case.py
@@ -137,7 +137,7 @@ def test_create_case_metadata_generate_metadata_warn_if_exists(
         casename="abc",
         caseuser="user",
     )
-    with pytest.warns(UserWarning, match=r"The case metadata file already exists"):
+    with pytest.warns(UserWarning, match=r"Using existing case metadata from runpath:"):
         icase.generate_metadata()
 
 


### PR DESCRIPTION
Resolves #997 

Improved warning displayed to user when case metadata already exists on the runpath, with more information on what that actually means to the user and how they can avoid it.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
