### PR TITLE
SCHEMA: Add new standard result structure_depth_isochore

### DIFF
--- a/examples/example_metadata/fmu_case.yml
+++ b/examples/example_metadata/fmu_case.yml
@@ -32,7 +32,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-03-19T08:27:01.414447Z'
+- datetime: '2025-03-24T11:51:31.444646Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/polygons_field_outline.yml
+++ b/examples/example_metadata/polygons_field_outline.yml
@@ -93,7 +93,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-03-19T08:27:05.294349Z'
+- datetime: '2025-03-24T11:51:35.964159Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/polygons_field_region.yml
+++ b/examples/example_metadata/polygons_field_region.yml
@@ -93,7 +93,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-03-19T08:27:05.273462Z'
+- datetime: '2025-03-24T11:51:35.942139Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/preprocessed_surface_depth.yml
+++ b/examples/example_metadata/preprocessed_surface_depth.yml
@@ -80,7 +80,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-03-19T08:27:11.196533Z'
+- datetime: '2025-03-24T11:51:42.196067Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/surface_depth.yml
+++ b/examples/example_metadata/surface_depth.yml
@@ -90,7 +90,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-03-19T08:27:13.220071Z'
+- datetime: '2025-03-24T11:51:44.333369Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/surface_fluid_contact.yml
+++ b/examples/example_metadata/surface_fluid_contact.yml
@@ -93,7 +93,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-03-19T08:27:13.281063Z'
+- datetime: '2025-03-24T11:51:44.381336Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/surface_seismic_amplitude.yml
+++ b/examples/example_metadata/surface_seismic_amplitude.yml
@@ -111,7 +111,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-03-19T08:27:13.335143Z'
+- datetime: '2025-03-24T11:51:44.431762Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/table_inplace_volumes.yml
+++ b/examples/example_metadata/table_inplace_volumes.yml
@@ -98,7 +98,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-03-19T08:27:18.060744Z'
+- datetime: '2025-03-24T11:51:49.000428Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/schemas/0.10.0/fmu_results.json
+++ b/schemas/0.10.0/fmu_results.json
@@ -212,6 +212,9 @@
           "$ref": "#/$defs/StructureDepthSurfaceStandardResult"
         },
         {
+          "$ref": "#/$defs/StructureDepthIsochoreStandardResult"
+        },
+        {
           "$ref": "#/$defs/StructureDepthFaultLinesStandardResult"
         }
       ],
@@ -7688,6 +7691,32 @@
         "name"
       ],
       "title": "StructureDepthFaultLinesStandardResult",
+      "type": "object"
+    },
+    "StructureDepthIsochoreStandardResult": {
+      "description": "The ``standard_result`` field contains information about which standard results this\ndata object represent.\nThis class contains metadata for the 'structure_depth_isochore' standard result.",
+      "properties": {
+        "file_schema": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FileSchema"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "name": {
+          "const": "structure_depth_isochore",
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "StructureDepthIsochoreStandardResult",
       "type": "object"
     },
     "StructureDepthSurfaceStandardResult": {

--- a/src/fmu/dataio/_models/fmu_results/enums.py
+++ b/src/fmu/dataio/_models/fmu_results/enums.py
@@ -9,6 +9,7 @@ class StandardResultName(str, Enum):
 
     inplace_volumes = "inplace_volumes"
     structure_depth_surface = "structure_depth_surface"
+    structure_depth_isochore = "structure_depth_isochore"
     structure_depth_fault_lines = "structure_depth_fault_lines"
 
 

--- a/src/fmu/dataio/_models/fmu_results/standard_result.py
+++ b/src/fmu/dataio/_models/fmu_results/standard_result.py
@@ -71,6 +71,17 @@ class StructureDepthSurfaceStandardResult(StandardResult):
     """The identifying name for the 'structure_depth_surface' standard result."""
 
 
+class StructureDepthIsochoreStandardResult(StandardResult):
+    """
+    The ``standard_result`` field contains information about which standard results this
+    data object represent.
+    This class contains metadata for the 'structure_depth_isochore' standard result.
+    """
+
+    name: Literal[enums.StandardResultName.structure_depth_isochore]
+    """The identifying name for the 'structure_depth_isochore' standard result."""
+
+
 class StructureDepthFaultLinesStandardResult(StandardResult):
     """
     The ``standard_result`` field contains information about which standard results this
@@ -106,6 +117,7 @@ class AnyStandardResult(RootModel):
         Union[
             InplaceVolumesStandardResult,
             StructureDepthSurfaceStandardResult,
+            StructureDepthIsochoreStandardResult,
             StructureDepthFaultLinesStandardResult,
         ],
         Field(discriminator="name"),


### PR DESCRIPTION
Adresses #1047 

Add new standard result `structure_depth_isochore` option to the FmuResults schema `0.10.0` .

Will add test when implementing the simple export function for this standard result.

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
