### PR TITLE
ENH: Add new simple export `export_structure_depth_isochores`

### DIFF
--- a/docs/src/standard_results/structure_depth_isochores.md
+++ b/docs/src/standard_results/structure_depth_isochores.md
@@ -1,0 +1,52 @@
+# Structure depth isochores
+
+This exports the modelled structural depth isochores from within RMS.
+These isochores are surfaces that represents the true vertical thickness of each
+stratigraphic zone (unit) from the final structural model in depth.
+
+:::{note} 
+It is only possible to export **one single set** of depth isochore predictions per 
+model workflow, i.e. one surface object per stratigraphic zone.
+:::
+
+:::{table} Current
+:widths: auto
+:align: left
+
+| Field | Value |
+| --- | --- |
+| Version | NA |
+| Output | `share/results/maps/structure_depth_isochores/zonename.gri` |
+:::
+
+## Requirements
+
+- RMS
+- thickness surfaces stored in a zone folder within RMS
+
+The surfaces must be located within a zone folder in RMS. This export function will automatically export
+all non-empty zones from the provided folder.
+
+:::{important}
+These surfaces should be extracted from the final depth horizon model using the `Extract Horizon/Zone Data`
+job in RMS. This will ensure that the surfaces are a true representation of the thickness of a zone in the
+model, e.g if there is an erosional surface, this is correctly reflected.
+:::
+
+
+## Usage
+
+```{eval-rst}
+.. autofunction:: fmu.dataio.export.rms.structure_depth_isochores.export_structure_depth_isochores
+```
+
+## Result
+
+The surfaces from the horizon folder will be exported as 'irap_binary'
+files to `share/results/maps/structure_depth_isochores/zonename.gri`.
+
+
+## Standard result schema
+
+This standard result is not presented in a tabular format; therefore, no validation
+schema exists.

--- a/src/fmu/dataio/_models/fmu_results/fmu_results.py
+++ b/src/fmu/dataio/_models/fmu_results/fmu_results.py
@@ -49,6 +49,7 @@ class FmuResultsSchema(SchemaBase):
     VERSION_CHANGELOG: str = """
     #### 0.10.0
 
+    - `data.standard_result` now supports `StructureDepthIsochoreStandardResult`
     - `data.standard_result` now supports `StructureDepthFaultLinesStandardResult`
     - `data.spec.columns` added as optional field for points, polygons
     - `data.spec.num_columns` added as optional field for points, polygons

--- a/src/fmu/dataio/export/rms/__init__.py
+++ b/src/fmu/dataio/export/rms/__init__.py
@@ -1,10 +1,12 @@
 from .inplace_volumes import export_inplace_volumes, export_rms_volumetrics
 from .structure_depth_fault_lines import export_structure_depth_fault_lines
+from .structure_depth_isochores import export_structure_depth_isochores
 from .structure_depth_surfaces import export_structure_depth_surfaces
 
 __all__ = [
     "export_structure_depth_fault_lines",
     "export_structure_depth_surfaces",
+    "export_structure_depth_isochores",
     "export_inplace_volumes",
     "export_rms_volumetrics",
 ]

--- a/src/fmu/dataio/export/rms/_utils.py
+++ b/src/fmu/dataio/export/rms/_utils.py
@@ -86,6 +86,22 @@ def validate_horizon_folder(project: Any, horizon_folder: str) -> None:
         )
 
 
+def validate_zones_folder(project: Any, zone_folder: str) -> None:
+    """
+    Check if a zone folder exist inside the project and that data exists for some
+    zones within the folder. Otherwise raise errors.
+    """
+    if zone_folder not in project.zones.representations:
+        raise ValueError(
+            f"The provided zone folder name {zone_folder} does not exist inside RMS."
+        )
+
+    if all(horizon[zone_folder].is_empty() for horizon in project.zones):
+        raise RuntimeError(
+            f"The provided zone folder name {zone_folder} contains only empty items."
+        )
+
+
 def get_horizons_in_folder(
     project: Any, horizon_folder: str
 ) -> list[xtgeo.RegularSurface]:
@@ -100,6 +116,19 @@ def get_horizons_in_folder(
             surfaces.append(
                 xtgeo.surface_from_roxar(project, horizon.name, horizon_folder)
             )
+    return surfaces
+
+
+def get_zones_in_folder(project: Any, zone_folder: str) -> list[xtgeo.RegularSurface]:
+    """Get all non-empty surfaces from a zones folder stratigraphically ordered."""
+
+    logger.debug("Reading surfaces from zone folder %s", zone_folder)
+    validate_zones_folder(project, zone_folder)
+
+    surfaces = []
+    for zone in project.zones:
+        if not zone[zone_folder].is_empty():
+            surfaces.append(xtgeo.surface_from_roxar(project, zone.name, zone_folder))
     return surfaces
 
 

--- a/tests/test_export_rms/conftest.py
+++ b/tests/test_export_rms/conftest.py
@@ -224,6 +224,7 @@ def mock_project_variable():
     # A mock_project variable for the RMS 'project' (potentially extend for later use)
     mock_project = MagicMock()
     mock_project.horizons.representations = ["DS_final"]
+    mock_project.zones.representations = ["IS_final"]
 
     yield mock_project
 
@@ -240,6 +241,23 @@ def xtgeo_surfaces(regsurf):
     regsurf_base = regsurf.copy()
     regsurf_base.name = "TopVolon"
     regsurf_base.values += 200
+
+    yield [regsurf_top, regsurf_mid, regsurf_base]
+
+
+@pytest.fixture
+def xtgeo_zones(regsurf):
+    regsurf_top = regsurf.copy()
+    regsurf_top.name = "Valysar"
+    regsurf_top.values = 30
+
+    regsurf_mid = regsurf.copy()
+    regsurf_mid.name = "Therys"
+    regsurf_mid.values = 50
+
+    regsurf_base = regsurf.copy()
+    regsurf_base.name = "Volon"
+    regsurf_base.values = 25
 
     yield [regsurf_top, regsurf_mid, regsurf_base]
 

--- a/tests/test_export_rms/test_export_structure_depth_isochores.py
+++ b/tests/test_export_rms/test_export_structure_depth_isochores.py
@@ -1,0 +1,129 @@
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from fmu import dataio
+from fmu.dataio._logging import null_logger
+from fmu.dataio._models.fmu_results.enums import StandardResultName
+from fmu.dataio.exceptions import ValidationError
+from tests.utils import inside_rms
+
+logger = null_logger(__name__)
+
+
+@pytest.fixture
+def mock_export_class(
+    mock_project_variable,
+    monkeypatch,
+    rmssetup_with_fmuconfig,
+    xtgeo_zones,
+):
+    # needed to find the global config at correct place
+    monkeypatch.chdir(rmssetup_with_fmuconfig)
+
+    from fmu.dataio.export.rms.structure_depth_isochores import (
+        _ExportStructureDepthIsochores,
+    )
+
+    with mock.patch(
+        "fmu.dataio.export.rms.structure_depth_isochores.get_zones_in_folder",
+        return_value=xtgeo_zones,
+    ):
+        yield _ExportStructureDepthIsochores(mock_project_variable, "IS_extracted")
+
+
+@inside_rms
+def test_files_exported_with_metadata(mock_export_class, rmssetup_with_fmuconfig):
+    """Test that the data is exported with metadata"""
+
+    mock_export_class.export()
+
+    export_folder = (
+        rmssetup_with_fmuconfig / "../../share/results/maps/structure_depth_isochore"
+    )
+    assert export_folder.exists()
+
+    assert (export_folder / "valysar.gri").exists()
+    assert (export_folder / "therys.gri").exists()
+    assert (export_folder / "volon.gri").exists()
+
+    assert (export_folder / ".valysar.gri.yml").exists()
+    assert (export_folder / ".therys.gri.yml").exists()
+    assert (export_folder / ".volon.gri.yml").exists()
+
+
+@inside_rms
+def test_standard_result_in_metadata(mock_export_class):
+    """Test that the standard_result is set correctly in the metadata"""
+
+    out = mock_export_class.export()
+    metadata = dataio.read_metadata(out.items[0].absolute_path)
+
+    assert "standard_result" in metadata["data"]
+    assert (
+        metadata["data"]["standard_result"]["name"]
+        == StandardResultName.structure_depth_isochore
+    )
+
+
+@inside_rms
+def test_public_export_function(mock_project_variable, mock_export_class):
+    """Test that the export function works"""
+
+    from fmu.dataio.export.rms import export_structure_depth_isochores
+
+    out = export_structure_depth_isochores(mock_project_variable, "IS_extracted")
+
+    assert len(out.items) == 3
+
+    metadata = dataio.read_metadata(out.items[0].absolute_path)
+
+    assert metadata["data"]["content"] == "thickness"
+    assert metadata["access"]["classification"] == "internal"
+    assert metadata["data"]["is_prediction"]
+    assert (
+        metadata["data"]["standard_result"]["name"]
+        == StandardResultName.structure_depth_isochore
+    )
+
+
+@inside_rms
+def test_validation_negative_values(
+    mock_project_variable, monkeypatch, rmssetup_with_fmuconfig, regsurf
+):
+    """Test that the export function raises error if negative values are detected"""
+
+    from fmu.dataio.export.rms import export_structure_depth_isochores
+
+    monkeypatch.chdir(rmssetup_with_fmuconfig)
+
+    surf_with_negative_values = regsurf.copy()
+    surf_with_negative_values.values = -20
+
+    with mock.patch(  # noqa
+        "fmu.dataio.export.rms.structure_depth_isochores.get_zones_in_folder",
+        return_value=[surf_with_negative_values],
+    ):
+        with pytest.raises(ValidationError, match="Negative values"):
+            export_structure_depth_isochores(mock_project_variable, "IS_extracted")
+
+
+@inside_rms
+def test_config_missing(mock_project_variable, rmssetup_with_fmuconfig, monkeypatch):
+    """Test that an exception is raised if the config is missing."""
+
+    from fmu.dataio.export.rms import export_structure_depth_isochores
+    from fmu.dataio.export.rms._utils import CONFIG_PATH
+
+    monkeypatch.chdir(rmssetup_with_fmuconfig)
+
+    config_path_modified = Path("wrong.yml")
+
+    CONFIG_PATH.rename(config_path_modified)
+
+    with pytest.raises(FileNotFoundError, match="Could not detect"):
+        export_structure_depth_isochores(mock_project_variable, "IS_extracted")
+
+    # restore the global config file for later tests
+    config_path_modified.rename(CONFIG_PATH)

--- a/tests/test_export_rms/test_utils.py
+++ b/tests/test_export_rms/test_utils.py
@@ -59,6 +59,58 @@ def test_get_horizons_in_folder_all_empty(mock_project_variable):
         get_horizons_in_folder(mock_project_variable, horizon_folder)
 
 
+def test_get_zones_in_folder(mock_project_variable):
+    from fmu.dataio.export.rms._utils import get_zones_in_folder
+
+    zone_folder = "IS_final"
+
+    zone1 = mock.MagicMock()
+    zone1[zone_folder].is_empty.return_value = False
+    zone1.name = "Valysar"
+
+    zone2 = mock.MagicMock()
+    zone2[zone_folder].is_empty.return_value = False
+    zone2.name = "Therys"
+
+    zone3 = mock.MagicMock()
+    zone3[zone_folder].is_empty.return_value = True
+    zone3.name = "Below"
+
+    mock_project_variable.zones.__iter__.return_value = [zone1, zone2, zone3]
+    # Mock xtgeo.surface_from_roxar to return just the surface name
+    with mock.patch(
+        "xtgeo.surface_from_roxar",
+        side_effect=lambda _project, name, _category: name,
+    ):
+        zones = get_zones_in_folder(mock_project_variable, zone_folder)
+
+        # cthe empty 'Below' surface should not be included
+        assert zones == ["Valysar", "Therys"]
+
+
+def test_get_zones_in_folder_folder_not_exist(mock_project_variable):
+    from fmu.dataio.export.rms._utils import get_zones_in_folder
+
+    zone_folder = "non_existent_folder"
+
+    with pytest.raises(ValueError, match="not exist inside RMS"):
+        get_zones_in_folder(mock_project_variable, zone_folder)
+
+
+def test_get_zones_in_folder_all_empty(mock_project_variable):
+    from fmu.dataio.export.rms._utils import get_zones_in_folder
+
+    zone_folder = "IS_final"
+
+    zone1 = mock.MagicMock()
+    zone1[zone_folder].is_empty.return_value = True
+
+    mock_project_variable.zones.__iter__.return_value = [zone1]
+
+    with pytest.raises(RuntimeError, match="only empty items"):
+        get_zones_in_folder(mock_project_variable, zone_folder)
+
+
 def test_get_polygons_in_folder_folder_not_exist(mock_project_variable):
     from fmu.dataio.export.rms._utils import get_polygons_in_folder
 


### PR DESCRIPTION
Resolves #1047 

PR to add a new simple export function for the standard result `structure_depth_isochore` to be used to export depth isochore surfaces from within a zones folder in RMS.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
