### PR TITLE
SCHEMA: Add new standard result 'field_outline'

### DIFF
--- a/examples/example_metadata/fmu_case.yml
+++ b/examples/example_metadata/fmu_case.yml
@@ -32,7 +32,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-03-24T11:51:31.444646Z'
+- datetime: '2025-03-25T09:30:43.827177Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/polygons_field_outline.yml
+++ b/examples/example_metadata/polygons_field_outline.yml
@@ -93,7 +93,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-03-24T11:51:35.964159Z'
+- datetime: '2025-03-25T09:30:48.655241Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/polygons_field_region.yml
+++ b/examples/example_metadata/polygons_field_region.yml
@@ -93,7 +93,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-03-24T11:51:35.942139Z'
+- datetime: '2025-03-25T09:30:48.632461Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/preprocessed_surface_depth.yml
+++ b/examples/example_metadata/preprocessed_surface_depth.yml
@@ -80,7 +80,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-03-24T11:51:42.196067Z'
+- datetime: '2025-03-25T09:30:55.744852Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/surface_depth.yml
+++ b/examples/example_metadata/surface_depth.yml
@@ -90,7 +90,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-03-24T11:51:44.333369Z'
+- datetime: '2025-03-25T09:30:57.993616Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/surface_fluid_contact.yml
+++ b/examples/example_metadata/surface_fluid_contact.yml
@@ -93,7 +93,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-03-24T11:51:44.381336Z'
+- datetime: '2025-03-25T09:30:58.045815Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/surface_seismic_amplitude.yml
+++ b/examples/example_metadata/surface_seismic_amplitude.yml
@@ -111,7 +111,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-03-24T11:51:44.431762Z'
+- datetime: '2025-03-25T09:30:58.100840Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/table_inplace_volumes.yml
+++ b/examples/example_metadata/table_inplace_volumes.yml
@@ -98,7 +98,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-03-24T11:51:49.000428Z'
+- datetime: '2025-03-25T09:31:03.224361Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/schemas/0.10.0/fmu_results.json
+++ b/schemas/0.10.0/fmu_results.json
@@ -206,6 +206,9 @@
       },
       "oneOf": [
         {
+          "$ref": "#/$defs/FieldOutlineStandardResult"
+        },
+        {
           "$ref": "#/$defs/InplaceVolumesStandardResult"
         },
         {
@@ -2505,6 +2508,28 @@
         "field_outline"
       ],
       "title": "FieldOutlineData",
+      "type": "object"
+    },
+    "FieldOutlineStandardResult": {
+      "description": "The ``standard_result`` field contains information about which standard results this\ndata object represent.\nThis class contains metadata for the 'field_outline' standard result.",
+      "properties": {
+        "file_schema": {
+          "$ref": "#/$defs/FileSchema",
+          "default": {
+            "url": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/file_formats/0.1.0/field_outline.json",
+            "version": "0.1.0"
+          }
+        },
+        "name": {
+          "const": "field_outline",
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "FieldOutlineStandardResult",
       "type": "object"
     },
     "FieldRegion": {

--- a/schemas/file_formats/0.1.0/field_outline.json
+++ b/schemas/file_formats/0.1.0/field_outline.json
@@ -1,0 +1,43 @@
+{
+  "$defs": {
+    "FieldOutlineResultRow": {
+      "description": "Represents the columns of a row in a field outline export.\n\nThese fields are the current agreed upon standard result. Changes to the fields or\ntheir validation should cause the version defined in the standard result schema to\nincrease the version number in a way that corresponds to the schema versioning\nspecification (i.e. they are a patch, minor, or major change).",
+      "properties": {
+        "POLY_ID": {
+          "minimum": 0,
+          "title": "Poly Id",
+          "type": "integer"
+        },
+        "X_UTME": {
+          "title": "X Utme",
+          "type": "number"
+        },
+        "Y_UTMN": {
+          "title": "Y Utmn",
+          "type": "number"
+        },
+        "Z_TVDSS": {
+          "title": "Z Tvdss",
+          "type": "number"
+        }
+      },
+      "required": [
+        "X_UTME",
+        "Y_UTMN",
+        "Z_TVDSS",
+        "POLY_ID"
+      ],
+      "title": "FieldOutlineResultRow",
+      "type": "object"
+    }
+  },
+  "$id": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/file_formats/0.1.0/field_outline.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Represents the resultant field outline parquet file, which is\nnaturally a list of rows.\n\nConsumers who retrieve this parquet file must read it into a json-dictionary\nequivalent format to validate it against the schema.",
+  "items": {
+    "$ref": "#/$defs/FieldOutlineResultRow"
+  },
+  "title": "FieldOutlineResult",
+  "type": "array",
+  "version": "0.1.0"
+}

--- a/src/fmu/dataio/_models/__init__.py
+++ b/src/fmu/dataio/_models/__init__.py
@@ -1,5 +1,7 @@
 from .fmu_results import FmuResults, FmuResultsSchema
 from .standard_results import (
+    FieldOutlineResult,
+    FieldOutlineSchema,
     InplaceVolumesResult,
     InplaceVolumesSchema,
     StructureDepthFaultLinesResult,
@@ -9,6 +11,8 @@ from .standard_results import (
 __all__ = [
     "FmuResults",
     "FmuResultsSchema",
+    "FieldOutlineResult",
+    "FieldOutlineSchema",
     "InplaceVolumesResult",
     "InplaceVolumesSchema",
     "StructureDepthFaultLinesResult",
@@ -17,6 +21,7 @@ __all__ = [
 
 schemas = [
     FmuResultsSchema,
+    FieldOutlineSchema,
     InplaceVolumesSchema,
     StructureDepthFaultLinesSchema,
 ]

--- a/src/fmu/dataio/_models/fmu_results/enums.py
+++ b/src/fmu/dataio/_models/fmu_results/enums.py
@@ -6,6 +6,7 @@ from enum import Enum, IntEnum
 class StandardResultName(str, Enum):
     """The standard result name of a given data object."""
 
+    field_outline = "field_outline"
     inplace_volumes = "inplace_volumes"
     structure_depth_surface = "structure_depth_surface"
     structure_depth_isochore = "structure_depth_isochore"

--- a/src/fmu/dataio/_models/fmu_results/standard_result.py
+++ b/src/fmu/dataio/_models/fmu_results/standard_result.py
@@ -10,6 +10,7 @@ from pydantic import (
 )
 
 from fmu.dataio._models.standard_results import (
+    FieldOutlineSchema,
     InplaceVolumesSchema,
     StructureDepthFaultLinesSchema,
 )
@@ -101,6 +102,25 @@ class StructureDepthFaultLinesStandardResult(StandardResult):
     """
 
 
+class FieldOutlineStandardResult(StandardResult):
+    """
+    The ``standard_result`` field contains information about which standard results this
+    data object represent.
+    This class contains metadata for the 'field_outline' standard result.
+    """
+
+    name: Literal[enums.StandardResultName.field_outline]
+    """The identifying name for the 'field_outline' standard result."""
+
+    file_schema: FileSchema = FileSchema(
+        version=FieldOutlineSchema.VERSION,
+        url=AnyHttpUrl(FieldOutlineSchema.url()),
+    )
+    """
+    The schema identifying the format of the 'field_outline' standard result.
+    """
+
+
 class AnyStandardResult(RootModel):
     """
     The ``standard result`` field contains information about which standard result this
@@ -113,7 +133,8 @@ class AnyStandardResult(RootModel):
     """
 
     root: Annotated[
-        InplaceVolumesStandardResult
+        FieldOutlineStandardResult
+        | InplaceVolumesStandardResult
         | StructureDepthSurfaceStandardResult
         | StructureDepthIsochoreStandardResult
         | StructureDepthFaultLinesStandardResult,

--- a/src/fmu/dataio/_models/standard_results/__init__.py
+++ b/src/fmu/dataio/_models/standard_results/__init__.py
@@ -1,3 +1,4 @@
+from .field_outline import FieldOutlineResult, FieldOutlineSchema
 from .inplace_volumes import InplaceVolumesResult, InplaceVolumesSchema
 from .structure_depth_fault_lines import (
     StructureDepthFaultLinesResult,
@@ -5,6 +6,8 @@ from .structure_depth_fault_lines import (
 )
 
 __all__ = [
+    "FieldOutlineResult",
+    "FieldOutlineSchema",
     "InplaceVolumesResult",
     "InplaceVolumesSchema",
     "StructureDepthFaultLinesSchema",

--- a/src/fmu/dataio/_models/standard_results/field_outline.py
+++ b/src/fmu/dataio/_models/standard_results/field_outline.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field, RootModel
+
+from fmu.dataio._models._schema_base import FmuSchemas, SchemaBase
+
+if TYPE_CHECKING:
+    from pathlib import Path
+    from typing import Any
+
+    from fmu.dataio.types import VersionStr
+
+
+class FieldOutlineResultRow(BaseModel):
+    """Represents the columns of a row in a field outline export.
+
+    These fields are the current agreed upon standard result. Changes to the fields or
+    their validation should cause the version defined in the standard result schema to
+    increase the version number in a way that corresponds to the schema versioning
+    specification (i.e. they are a patch, minor, or major change)."""
+
+    X_UTME: float
+    """The X coordinate this row represents. Required."""
+
+    Y_UTMN: float
+    """The Y coordinate this row represents. Required."""
+
+    Z_TVDSS: float
+    """The Z coordinate (depth) this row represents. Required."""
+
+    POLY_ID: int = Field(ge=0)
+    """Index column. The id of the polygon which this row represents. Required."""
+
+
+class FieldOutlineResult(RootModel):
+    """Represents the resultant field outline parquet file, which is
+    naturally a list of rows.
+
+    Consumers who retrieve this parquet file must read it into a json-dictionary
+    equivalent format to validate it against the schema."""
+
+    root: list[FieldOutlineResultRow]
+
+
+class FieldOutlineSchema(SchemaBase):
+    """This class represents the schema that is used to validate the fault lines
+    table being exported. This means that the version, schema filename, and schema
+    location corresponds directly with the values and their validation constraints,
+    documented above."""
+
+    VERSION: VersionStr = "0.1.0"
+    """The version of this schema."""
+
+    VERSION_CHANGELOG: str = """
+    #### 0.1.0
+
+    This is the initial schema version.
+    """
+
+    FILENAME: str = "field_outline.json"
+    """The filename this schema is written to."""
+
+    PATH: Path = FmuSchemas.PATH / "file_formats" / VERSION / FILENAME
+    """The local and URL path of this schema."""
+
+    @classmethod
+    def dump(cls) -> dict[str, Any]:
+        return FieldOutlineResult.model_json_schema(
+            schema_generator=cls.default_generator()
+        )


### PR DESCRIPTION
Adresses #765

PR to add a new standard result `field_outline` to the `FmuResult` schema and to add a separate schema for the file format.
- the data type is a `xtgeo.Polygon` and will be stored as a parquet file.

Tests will be added when corresponding simple export function is implemented. 

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
