### PR TITLE
ENH: Add simple export for standard result 'field_outline'

### DIFF
--- a/docs/src/standard_results/field_outline.md
+++ b/docs/src/standard_results/field_outline.md
@@ -1,0 +1,88 @@
+# Field outline
+
+This exports the modelled field outline from within RMS.
+This field outline is a polygon representing the outline of the hydrocarbon-filled
+reservoir under initial conditions.
+
+The field outline is typically calculated as the intersection between the modelled
+top reservoir surface (in depth) and the fluid contact surface. Some assets may
+choose to further refine the outline by limiting it to areas with `net` reservoir
+properties. It is up to each asset to decide which definition best suits their field.
+
+The primary use case for the field outline is visualization. Unlike the deterministic
+outlines from NPD, it is derived directly from the reservoir model, providing greater
+precision, alignment with recent data, and adaptability to the unique structure and
+fluid contact of each realization.   
+
+:::{note} 
+It is only possible to export **one** field outline object per model workflow.
+For exporting outlines specific to different fluid types and zones, the
+`fluid_contact_outline` standard result should be used instead.
+:::
+
+:::{table} Current
+:widths: auto
+:align: left
+
+| Field | Value |
+| --- | --- |
+| Version | **{{ FieldOutlineSchema.VERSION }}** |
+| Output | `share/results/polygons/field_outline/field_outline.parquet` |
+:::
+
+## Requirements
+
+- RMS
+- a field outline polygon stored in the `General 2D data` folder within RMS.
+
+The field outline polygon object must be named `field_outline` and be located
+within the root of the `General 2D data` folder in RMS. 
+
+The export function will ensure that the polygon object consists of closed polygons
+before proceeding with the export.
+
+
+## Usage
+
+```{eval-rst}
+.. autofunction:: fmu.dataio.export.rms.field_outline.export_field_outline
+```
+
+## Result
+
+The result file will be `share/results/polygons/field_outline/field_outline.parquet`.
+
+This is a tabular file on `.parquet` format. It contains
+the following columns with types validated as indicated.
+
+```{eval-rst}
+.. autopydantic_model:: fmu.dataio._models.standard_result.field_outline.FieldOutlineResultRow
+   :members:
+   :inherited-members: BaseModel
+   :model-show-config-summary: False
+   :model-show-json: False
+   :model-show-validator-members: False
+   :model-show-validator-summary: False
+   :field-list-validators: False
+```
+
+
+## Standard result schema
+
+This standard result is made available with a validation schema that can be
+used by consumers. A reference to the URL where this schema is located is
+present within the `data.standard_result` key in its associated object metadata.
+
+| Field | Value |
+| --- | --- |
+| Version | {{ FieldOutlineSchema.VERSION }} |
+| Filename | {{ FieldOutlineSchema.FILENAME }} |
+| Path | {{ FieldOutlineSchema.PATH }} |
+| Prod URL | {{ '[{}]({}) 🔒'.format(FieldOutlineSchema.prod_url(), FieldOutlineSchema.prod_url()) }}
+| Dev URL | {{ '[{}]({}) 🔒'.format(FieldOutlineSchema.dev_url(), FieldOutlineSchema.dev_url()) }}
+
+### JSON schema
+
+The current JSON schema is embedded here.
+
+{{ FieldOutlineSchema.literalinclude }}

--- a/src/fmu/dataio/export/rms/__init__.py
+++ b/src/fmu/dataio/export/rms/__init__.py
@@ -1,3 +1,4 @@
+from .field_outline import export_field_outline
 from .inplace_volumes import export_inplace_volumes, export_rms_volumetrics
 from .structure_depth_fault_lines import export_structure_depth_fault_lines
 from .structure_depth_isochores import export_structure_depth_isochores
@@ -9,4 +10,5 @@ __all__ = [
     "export_structure_depth_isochores",
     "export_inplace_volumes",
     "export_rms_volumetrics",
+    "export_field_outline",
 ]

--- a/src/fmu/dataio/export/rms/_utils.py
+++ b/src/fmu/dataio/export/rms/_utils.py
@@ -92,6 +92,19 @@ def validate_global_config(config: dict[str, Any]) -> GlobalConfiguration:
         ) from err
 
 
+def get_open_polygons_id(pol: xtgeo.Polygons) -> list[int]:
+    """
+    Return list of id's for open polygons within an xtgeo.Polygon.
+    In an open polygon the first and last row of the dataframe are not equal
+    i.e. different coordinates.
+    """
+    open_polygons = []
+    for polid, poldf in pol.get_dataframe(copy=False).groupby("POLY_ID"):
+        if not poldf.iloc[0].equals(poldf.iloc[-1]):
+            open_polygons.append(polid)
+    return open_polygons
+
+
 def validate_horizon_folder(project: Any, horizon_folder: str) -> None:
     """
     Check if a horizon folder exist inside the project and that data exists for some

--- a/src/fmu/dataio/export/rms/field_outline.py
+++ b/src/fmu/dataio/export/rms/field_outline.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Final
+
+import xtgeo
+
+import fmu.dataio as dio
+from fmu.dataio._logging import null_logger
+from fmu.dataio._models.fmu_results.enums import (
+    Classification,
+    Content,
+    FluidContactType,
+    StandardResultName,
+)
+from fmu.dataio._models.fmu_results.standard_result import FieldOutlineStandardResult
+from fmu.dataio.exceptions import ValidationError
+from fmu.dataio.export._decorators import experimental
+from fmu.dataio.export._export_result import ExportResult, ExportResultItem
+from fmu.dataio.export.rms._utils import get_open_polygons_id, load_global_config
+
+_logger: Final = null_logger(__name__)
+
+
+class _ExportFieldOutline:
+    def __init__(self, project: Any) -> None:
+        _logger.debug("Process data, establish state prior to export.")
+        self._config = load_global_config()
+        self._field_outline = self._get_field_outline_from_rms(project)
+
+        _logger.debug("Process data... DONE")
+
+    @property
+    def _standard_result(self) -> FieldOutlineStandardResult:
+        """Standard result type for the exported data."""
+        return FieldOutlineStandardResult(name=StandardResultName.field_outline)
+
+    @property
+    def _classification(self) -> Classification:
+        """Get default classification."""
+        return Classification.internal
+
+    @property
+    def _subfolder(self) -> str:
+        """Subfolder for exporting the data to."""
+        return self._standard_result.name.value
+
+    def _get_field_outline_from_rms(self, project: Any) -> xtgeo.Polygons:
+        """Fetch the field outline polygon from RMS."""
+        try:
+            return xtgeo.polygons_from_roxar(
+                project, "field_outline", category="", stype="general2d_data"
+            )
+        except Exception as err:
+            raise ValueError(
+                "Could not load the field outline polygon from RMS. "
+                "Ensure a polygon named 'field_outline' exists in the root "
+                "of the 'General 2D data' folder."
+            ) from err
+
+    def _export_field_outline(self) -> ExportResult:
+        edata = dio.ExportData(
+            config=self._config,
+            content=Content.field_outline.value,
+            content_metadata={"contact": FluidContactType.fwl},
+            vertical_domain="depth",
+            domain_reference="msl",
+            subfolder=self._subfolder,
+            is_prediction=True,
+            name=StandardResultName.field_outline.value,
+            classification=self._classification,
+            rep_include=True,
+        )
+
+        edata.polygons_fformat = "parquet"  # type: ignore
+
+        absolute_export_path = edata._export_with_standard_result(
+            self._field_outline, standard_result=self._standard_result
+        )
+        _logger.debug("Field outline exported to: %s", absolute_export_path)
+
+        return ExportResult(
+            items=[ExportResultItem(absolute_path=Path(absolute_export_path))],
+        )
+
+    def _validate_data(self) -> None:
+        """Data validations before export."""
+        if get_open_polygons_id(self._field_outline):
+            raise ValidationError(
+                "The field outline object can only contain closed polygons. "
+            )
+
+    def export(self) -> ExportResult:
+        """Export the field outline as a standard_result."""
+        self._validate_data()
+        return self._export_field_outline()
+
+
+@experimental
+def export_field_outline(project: Any) -> ExportResult:
+    """Simplified interface when exporting field outline from RMS.
+
+    Args:
+        project: The 'magic' project variable in RMS.
+    Note:
+        This function is experimental and may change in future versions.
+
+    Examples:
+        Example usage in an RMS script::
+
+            from fmu.dataio.export.rms import export_field_outline
+
+            export_results = export_field_outline(project)
+
+            for result in export_results.items:
+                print(f"Output field outline polygon to {result.absolute_path}")
+
+    """
+
+    return _ExportFieldOutline(project).export()

--- a/src/fmu/dataio/export/rms/structure_depth_fault_lines.py
+++ b/src/fmu/dataio/export/rms/structure_depth_fault_lines.py
@@ -17,6 +17,7 @@ from fmu.dataio.exceptions import ValidationError
 from fmu.dataio.export._decorators import experimental
 from fmu.dataio.export._export_result import ExportResult, ExportResultItem
 from fmu.dataio.export.rms._utils import (
+    get_open_polygons_id,
     get_polygons_in_folder,
     get_rms_project_units,
     load_global_config,
@@ -92,14 +93,10 @@ class _ExportStructureDepthFaultLines:
 
     def _raise_on_open_polygons(self, pol: xtgeo.Polygons) -> None:
         """
-        Check that all fault line polygons within the polygon set are closed. In a
-        closed polygon the first and last row of the dataframe are equal i.e. equal
-        coordinates. If an open polygon is found an error is given.
+        Check that all fault line polygons within the polygon set are closed.
+        Raise error if open polygons are found.
         """
-        open_polygons = []
-        for polid, poldf in pol.get_dataframe(copy=False).groupby("POLY_ID"):
-            if not poldf.iloc[0].equals(poldf.iloc[-1]):
-                open_polygons.append(polid)
+        open_polygons = get_open_polygons_id(pol)
 
         # TODO provide fault names when NAME attribute is possible to
         # fetch with xtgeo.

--- a/tests/test_export_rms/test_export_field_outline.py
+++ b/tests/test_export_rms/test_export_field_outline.py
@@ -1,0 +1,153 @@
+from pathlib import Path
+from unittest import mock
+
+import jsonschema
+import numpy as np
+import pyarrow.parquet as pq
+import pytest
+
+from fmu import dataio
+from fmu.dataio._logging import null_logger
+from fmu.dataio._models.fmu_results.enums import StandardResultName
+from fmu.dataio._models.standard_results.field_outline import (
+    FieldOutlineResult,
+    FieldOutlineSchema,
+)
+from tests.utils import inside_rms
+
+logger = null_logger(__name__)
+
+
+@pytest.fixture
+def mock_export_class(
+    mock_project_variable,
+    monkeypatch,
+    rmssetup_with_fmuconfig,
+    xtgeo_fault_lines,
+):
+    # needed to find the global config at correct place
+    monkeypatch.chdir(rmssetup_with_fmuconfig)
+
+    from fmu.dataio.export.rms.field_outline import (
+        _ExportFieldOutline,
+    )
+
+    with mock.patch(
+        "fmu.dataio.export.rms.field_outline.xtgeo.polygons_from_roxar"
+    ) as mock_polygons_from_roxar:
+        # Mock the return value of xtgeo.polygons_from_roxar
+        mock_polygons_from_roxar.return_value = xtgeo_fault_lines[0]
+
+        yield _ExportFieldOutline(mock_project_variable)
+
+
+@inside_rms
+def test_files_exported_with_metadata(mock_export_class, rmssetup_with_fmuconfig):
+    """Test that the standard_result is set correctly in the metadata"""
+
+    mock_export_class.export()
+
+    export_folder = (
+        rmssetup_with_fmuconfig / "../../share/results/polygons/field_outline"
+    )
+    assert export_folder.exists()
+
+    assert (export_folder / "field_outline.parquet").exists()
+
+
+@inside_rms
+def test_standard_result_in_metadata(mock_export_class):
+    """Test that the standard_result is set correctly in the metadata"""
+
+    out = mock_export_class.export()
+    metadata = dataio.read_metadata(out.items[0].absolute_path)
+
+    assert "standard_result" in metadata["data"]
+    assert (
+        metadata["data"]["standard_result"]["name"] == StandardResultName.field_outline
+    )
+    assert (
+        metadata["data"]["standard_result"]["file_schema"]["version"]
+        == FieldOutlineSchema.VERSION
+    )
+    assert (
+        metadata["data"]["standard_result"]["file_schema"]["url"]
+        == FieldOutlineSchema.url()
+    )
+
+
+@inside_rms
+def test_public_export_function(mock_project_variable, mock_export_class):
+    """Test that the export function works"""
+
+    from fmu.dataio.export.rms import export_field_outline
+
+    out = export_field_outline(mock_project_variable)
+
+    assert len(out.items) == 1
+
+    metadata = dataio.read_metadata(out.items[0].absolute_path)
+
+    assert metadata["data"]["content"] == "field_outline"
+    assert metadata["data"]["field_outline"]["contact"] == "fwl"
+    assert metadata["access"]["classification"] == "internal"
+    assert (
+        metadata["data"]["standard_result"]["name"] == StandardResultName.field_outline
+    )
+    assert metadata["data"]["format"] == "parquet"
+
+
+@inside_rms
+def test_config_missing(mock_project_variable, rmssetup_with_fmuconfig, monkeypatch):
+    """Test that an exception is raised if the config is missing."""
+
+    from fmu.dataio.export.rms import export_field_outline
+    from fmu.dataio.export.rms._utils import CONFIG_PATH
+
+    monkeypatch.chdir(rmssetup_with_fmuconfig)
+
+    config_path_modified = Path("wrong.yml")
+
+    CONFIG_PATH.rename(config_path_modified)
+
+    with pytest.raises(FileNotFoundError, match="Could not detect"):
+        export_field_outline(mock_project_variable)
+
+    # restore the global config file for later tests
+    config_path_modified.rename(CONFIG_PATH)
+
+
+@inside_rms
+def test_payload_validates_against_model(
+    mock_export_class,
+):
+    """Tests that the table exported is validated against the payload result
+    model."""
+
+    out = mock_export_class.export()
+    df = (
+        pq.read_table(out.items[0].absolute_path)
+        .to_pandas()
+        .replace(np.nan, None)
+        .to_dict(orient="records")
+    )
+    FieldOutlineResult.model_validate(df)  # Throws if invalid
+
+
+@inside_rms
+def test_payload_validates_against_schema(
+    mock_export_class,
+):
+    """Tests that the table exported is validated against the payload result
+    schema."""
+
+    out = mock_export_class.export()
+    df = (
+        pq.read_table(out.items[0].absolute_path)
+        .to_pandas()
+        .replace(np.nan, None)
+        .to_dict(orient="records")
+    )
+    jsonschema.validate(
+        instance=df, schema=FieldOutlineSchema.dump()
+    )  # Throws if invalid

--- a/tests/test_export_rms/test_utils.py
+++ b/tests/test_export_rms/test_utils.py
@@ -1,5 +1,6 @@
 from unittest import mock
 
+import pandas as pd
 import pytest
 
 from fmu.dataio._models.fmu_results.global_configuration import GlobalConfiguration
@@ -136,14 +137,14 @@ def test_get_polygons_in_folder_all_empty(mock_project_variable):
         get_polygons_in_folder(mock_project_variable, horizon_folder)
 
 
-def test_validate_global_config(mock_project_variable, globalconfig1):
+def test_validate_global_config(globalconfig1):
     from fmu.dataio.export.rms._utils import validate_global_config
 
     config = validate_global_config(globalconfig1)
     assert isinstance(config, GlobalConfiguration)
 
 
-def test_validate_global_config_invalid(mock_project_variable, globalconfig1):
+def test_validate_global_config_invalid(globalconfig1):
     from fmu.dataio.export.rms._utils import validate_global_config
 
     invalid_config = globalconfig1.copy()
@@ -151,3 +152,21 @@ def test_validate_global_config_invalid(mock_project_variable, globalconfig1):
 
     with pytest.raises(ValueError, match="valid config"):
         validate_global_config(invalid_config)
+
+
+def test_get_open_polygons_id(polygons):
+    """Test the function to list open polygons in an xtgoe.Polygons object"""
+    from fmu.dataio.export.rms._utils import get_open_polygons_id
+
+    df_closed = polygons.get_dataframe()
+
+    # create an open polygon dataframe
+    df_open = polygons.get_dataframe().drop(index=0)
+    df_open[polygons.pname] = 2  # set id to 2 for the open polygon
+
+    # add the open polygon to the polygons object
+    df_combined = pd.concat([df_closed, df_open])
+    polygons.set_dataframe(df_combined)
+
+    open_polygons = get_open_polygons_id(polygons)
+    assert open_polygons == [2]


### PR DESCRIPTION
Resolves #765 
Resolves #304

PR to add a new simple export for the standard result `field_outline`.
 
This requires a field outline polygon with name `field_outline` at the root of the `General 2D data` folder within RMS.

Note only **one** `field_outline` can be exported per realization. Outlines related to fluid contact outlines should be exported as the planned future standard result `fluid_contact_outline`. Where multiple outlines can be exported, for different fluid contact types and zones. 

Note, only RMS >=14.2 will have access to this export function hence API support for accessing the `General 2D data` folder is in place.


## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
