### PR TITLE
MAINT: Import rmsapi instead of deprecated roxar

### DIFF
--- a/src/fmu/dataio/_utils.py
+++ b/src/fmu/dataio/_utils.py
@@ -48,9 +48,9 @@ def detect_inside_rms() -> bool:
     properly
     """
     with contextlib.suppress(ModuleNotFoundError):
-        import roxar
+        import rmsapi
 
-        logger.info("Roxar version is %s", roxar.__version__)
+        logger.info("RMSAPI version is %s", rmsapi.__version__)
         return True
     logger.info("Running truly in RMS GUI status: %s", False)
     return False


### PR DESCRIPTION
Resolves #1002 

PR to change from importing `roxar` to importing `rmsapi`. 
We no longer support python 3.8 hence this will only be applied to RMS versions >=14.2 where `rmsapi` exists.

Tested running pytest in a rmsvenv, and it works as expected.

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
