### PR TITLE
ENH: Include fault names in standard result structure_depth_fault_line

### DIFF
--- a/schemas/file_formats/0.1.0/structure_depth_fault_lines.json
+++ b/schemas/file_formats/0.1.0/structure_depth_fault_lines.json
@@ -3,6 +3,10 @@
     "StructureDepthFaultLinesResultRow": {
       "description": "Represents the columns of a row in a structure depth fault lines export.\n\nThese fields are the current agreed upon standard result. Changes to the fields or\ntheir validation should cause the version defined in the standard result schema to\nincrease the version number in a way that corresponds to the schema versioning\nspecification (i.e. they are a patch, minor, or major change).",
       "properties": {
+        "NAME": {
+          "title": "Name",
+          "type": "string"
+        },
         "POLY_ID": {
           "minimum": 0,
           "title": "Poly Id",
@@ -25,7 +29,8 @@
         "X_UTME",
         "Y_UTMN",
         "Z_TVDSS",
-        "POLY_ID"
+        "POLY_ID",
+        "NAME"
       ],
       "title": "StructureDepthFaultLinesResultRow",
       "type": "object"

--- a/src/fmu/dataio/_models/standard_results/structure_depth_fault_lines.py
+++ b/src/fmu/dataio/_models/standard_results/structure_depth_fault_lines.py
@@ -33,6 +33,9 @@ class StructureDepthFaultLinesResultRow(BaseModel):
     POLY_ID: int = Field(ge=0)
     """Index column. The id of the polygon which this row represents. Required."""
 
+    NAME: str
+    """Index column. The name of the fault this row represents. Required."""
+
 
 class StructureDepthFaultLinesResult(RootModel):
     """Represents the resultant structure depth fault lines parquet file, which is

--- a/src/fmu/dataio/export/_enums.py
+++ b/src/fmu/dataio/export/_enums.py
@@ -74,3 +74,18 @@ class InplaceVolumes:
     def table_columns() -> list[str]:
         """Returns a list of all table columns."""
         return InplaceVolumes.index_columns() + InplaceVolumes.value_columns()
+
+
+class FaultLines:
+    """Enumerations relevant to fault lines tables."""
+
+    class TableIndexColumns(str, Enum):
+        """The index columns for a fault lines table."""
+
+        POLY_ID = "POLY_ID"
+        NAME = "NAME"
+
+    @staticmethod
+    def index_columns() -> list[str]:
+        """Returns a list of the index columns."""
+        return [k.value for k in FaultLines.TableIndexColumns]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -527,6 +527,21 @@ def fixture_polygons():
     )
 
 
+@pytest.fixture(name="fault_line", scope="module")
+def fixture_fault_line():
+    """Create an xtgeo polygons."""
+    logger.debug("Ran %s", _current_function_name())
+    return xtgeo.Polygons(
+        [
+            [1, 22, 3, 0, "F1"],
+            [6, 25, 4, 0, "F1"],
+            [8, 27, 6, 0, "F1"],
+            [1, 22, 3, 0, "F1"],
+        ],
+        attributes={"NAME": "str"},
+    )
+
+
 @pytest.fixture(name="points", scope="module")
 def fixture_points():
     """Create an xtgeo points instance."""

--- a/tests/test_export_rms/conftest.py
+++ b/tests/test_export_rms/conftest.py
@@ -263,15 +263,20 @@ def xtgeo_zones(regsurf):
 
 
 @pytest.fixture
-def xtgeo_fault_lines(polygons):
-    top = polygons.copy()
+def xtgeo_fault_lines(fault_line):
+    """
+    Create a set of fault line polygons, with stratigraphic names and a
+    NAME (fault names) column present in the dataframe.
+    """
+
+    top = fault_line.copy()
     top.name = "TopVolantis"
 
-    mid = polygons.copy()
+    mid = fault_line.copy()
     mid.name = "TopTherys"
     mid.get_dataframe(copy=False)[mid.zname] += 100
 
-    base = polygons.copy()
+    base = fault_line.copy()
     base.name = "TopVolon"
     base.get_dataframe(copy=False)[base.zname] += 200
 

--- a/tests/test_export_rms/test_utils.py
+++ b/tests/test_export_rms/test_utils.py
@@ -137,6 +137,63 @@ def test_get_polygons_in_folder_all_empty(mock_project_variable):
         get_polygons_in_folder(mock_project_variable, horizon_folder)
 
 
+def test_get_faultlines_in_folder(mock_project_variable, polygons):
+    """
+    Test that the get_faultlines_in_folder works as expected when the
+    'Name' attribute is present.
+    """
+    from fmu.dataio.export.rms._utils import get_faultlines_in_folder
+
+    fault_line = polygons.copy()
+    df = fault_line.get_dataframe()
+
+    # make sure test assumpions are correct
+    assert "NAME" not in df
+    assert "Name" not in df
+
+    # fault lines from RMS will have a 'Name' attribute
+    df["Name"] = "F1"
+    fault_line.set_dataframe(df)
+
+    with (
+        mock.patch(
+            "fmu.dataio.export.rms._utils.get_polygons_in_folder",
+            return_value=[fault_line],
+        ),
+    ):
+        fault_lines = get_faultlines_in_folder(mock_project_variable, "DL_faultlines")
+
+        # Check that the 'Name' column has been translated to uppercase
+        assert "NAME" in fault_lines[0].get_dataframe(copy=False)
+        assert "Name" not in fault_lines[0].get_dataframe(copy=False)
+
+
+def test_get_faultlines_in_folder_raises_if_missing_name(
+    mock_project_variable, polygons
+):
+    """
+    Test that the get_faultlines_in_folder raises error when the
+    'Name' attribute is missing.
+    """
+    from fmu.dataio.export.rms._utils import get_faultlines_in_folder
+
+    fault_line = polygons.copy()
+    df = fault_line.get_dataframe()
+
+    # make sure test assumpions are correct
+    assert "NAME" not in df
+    assert "Name" not in df
+
+    with (
+        mock.patch(
+            "fmu.dataio.export.rms._utils.get_polygons_in_folder",
+            return_value=[fault_line],
+        ),
+        pytest.raises(ValueError, match="missing"),
+    ):
+        get_faultlines_in_folder(mock_project_variable, "DL_faultlines")
+
+
 def test_validate_global_config(globalconfig1):
     from fmu.dataio.export.rms._utils import validate_global_config
 


### PR DESCRIPTION
Resolves #1118

PR to add fault names to the `structure_depth_fault_lines` standard result table. Possible now after the release of XTGeo 4.7.0 🙂 

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
