### PR TITLE
ENH: Enable to input content_metadata as pydantic model

### DIFF
--- a/src/fmu/dataio/_models/fmu_results/data.py
+++ b/src/fmu/dataio/_models/fmu_results/data.py
@@ -74,6 +74,18 @@ class Seismic(BaseModel):
     zrange: float | None = Field(default=None, allow_inf_nan=False)
     """The z-range of these data."""
 
+    @model_validator(mode="before")
+    @classmethod
+    def _deprecated_offset_to_stacking_offset(cls, values: dict) -> dict:
+        if "offset" in values:
+            warnings.warn(
+                "Content seismic.offset is deprecated. "
+                "Please use seismic.stacking_offset insted.",
+                DeprecationWarning,
+            )
+            values["stacking_offset"] = values.pop("offset")
+        return values
+
 
 class Property(BaseModel):
     """A block describing property data. Shall be present if ``data.content`

--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -39,6 +39,8 @@ from .providers._fmu import FmuProvider, get_fmu_context_from_environment
 from .providers.objectdata._provider import objectdata_provider_factory
 
 if TYPE_CHECKING:
+    from pydantic import BaseModel
+
     from . import types
     from ._models.fmu_results.standard_result import StandardResult
 
@@ -194,8 +196,10 @@ class ExportData:
             Some contents like 'seismic' requires additional information. This
             should be provided through the 'content_metadata' argument.
 
-        content_metadata: Optional. Dictionary with additional information about the
-            provided content. Only required for some contents, e.g. 'seismic'.
+        content_metadata: Optional. Additional information about the provided content.
+            This can be input as either a dictionary or an instance of
+            the corresponding Pydantic model for the content.
+            Only required for certain contents, such as 'seismic'.
             Example {"attribute": "amplitude", "calculation": "mean"}.
 
         fmu_context: Optional string with value ``realization`` or ``case``. If not
@@ -332,7 +336,7 @@ class ExportData:
     classification: str | None = None
     config: dict | GlobalConfiguration = field(default_factory=dict)
     content: dict | str | None = None
-    content_metadata: dict | None = None
+    content_metadata: dict | BaseModel | None = None
     depth_reference: str | None = None  # deprecated
     domain_reference: str = "msl"
     description: str | list = ""
@@ -509,7 +513,7 @@ class ExportData:
             f"content string: {[m.value for m in enums.Content]}"
         )
 
-    def _get_content_metadata(self) -> dict | None:
+    def _get_content_metadata(self) -> dict | BaseModel | None:
         """
         Get the content metadata if provided by as input, else return None.
         Validation takes place in the objectdata provider.

--- a/src/fmu/dataio/export/rms/field_outline.py
+++ b/src/fmu/dataio/export/rms/field_outline.py
@@ -7,6 +7,7 @@ import xtgeo
 
 import fmu.dataio as dio
 from fmu.dataio._logging import null_logger
+from fmu.dataio._models.fmu_results import data
 from fmu.dataio._models.fmu_results.enums import (
     Classification,
     Content,
@@ -62,7 +63,7 @@ class _ExportFieldOutline:
         edata = dio.ExportData(
             config=self._config,
             content=Content.field_outline.value,
-            content_metadata={"contact": FluidContactType.fwl},
+            content_metadata=data.FieldOutline(contact=FluidContactType.fwl),
             vertical_domain="depth",
             domain_reference="msl",
             subfolder=self._subfolder,

--- a/src/fmu/dataio/providers/objectdata/_base.py
+++ b/src/fmu/dataio/providers/objectdata/_base.py
@@ -197,13 +197,16 @@ class ObjectDataProvider(Provider):
                     return self._raise_error_for_missing_content_metadata(content)
 
                 content_metadata_model = content_metadata_factory(content)
-                if not isinstance(content_metadata, dict):
-                    raise ValueError(
-                        "The 'content_metadata' needs to be input as a dictionary. "
-                        f"Possible keys for content '{content.value}' are: "
-                        f"{list(content_metadata_model.model_fields)}. "
-                    )
-                return content_metadata_model.model_validate(content_metadata)
+
+                if isinstance(content_metadata, dict | content_metadata_model):
+                    return content_metadata_model.model_validate(content_metadata)
+
+                raise ValueError(
+                    "The 'content_metadata' needs to be input as a dictionary, "
+                    f"or as an instance of {content_metadata_model}. "
+                    f"Possible keys for content '{content.value}' are: "
+                    f"{list(content_metadata_model.model_fields)}. "
+                )
 
             if content_metadata:
                 warnings.warn(

--- a/src/fmu/dataio/providers/objectdata/_export_models.py
+++ b/src/fmu/dataio/providers/objectdata/_export_models.py
@@ -13,7 +13,6 @@ from typing import Final, Literal
 
 from pydantic import (
     BaseModel,
-    Field,
     model_validator,
 )
 
@@ -39,22 +38,6 @@ def property_warn() -> None:
         ),
         FutureWarning,
     )
-
-
-class AllowedContentSeismic(data.Seismic):
-    # Deprecated
-    offset: str | None = Field(default=None)
-
-    @model_validator(mode="after")
-    def _check_depreciated(self) -> AllowedContentSeismic:
-        if self.offset is not None:
-            warnings.warn(
-                "Content seismic.offset is deprecated. "
-                "Please use seismic.stacking_offset insted.",
-                DeprecationWarning,
-            )
-            self.stacking_offset, self.offset = self.offset, None
-        return self
 
 
 class UnsetData(data.Data):
@@ -84,7 +67,7 @@ def content_metadata_factory(content: enums.Content) -> type[BaseModel]:
     if content == enums.Content.property:
         return data.Property
     if content == enums.Content.seismic:
-        return AllowedContentSeismic
+        return data.Seismic
     raise ValueError(f"No content_metadata model exist for content {str(content)}")
 
 


### PR DESCRIPTION
Resolves #1119 

PR to start allowing to input the `content_metadata` as the corresponding content_metadata pydantic model.

**Note** also removed the `AllowedContentSeismic` and moved the deprecation warning for the `offset` field to the `data.Seismic` model instead. This was to be able to use the `data.Seismic` field as the input model for the `content_metadata` argument.
This is covered by existing tests.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
