### PR TITLE
ENH: Add validation against stratigraphy for relevant simple exports

### DIFF
--- a/src/fmu/dataio/export/rms/_utils.py
+++ b/src/fmu/dataio/export/rms/_utils.py
@@ -213,3 +213,15 @@ def get_faultlines_in_folder(project: Any, horizon_folder: str) -> list[xtgeo.Po
         pol.set_dataframe(df)
 
     return fault_lines
+
+
+def validate_name_in_stratigraphy(name: str, config: GlobalConfiguration) -> None:
+    """Validate that an input name is present in the config.stratigraphy"""
+    assert config.stratigraphy is not None
+
+    if name not in config.stratigraphy:
+        raise ValidationError(
+            f"The stratigraphic {name=} is not listed in the 'stratigraphy' "
+            "block in the config. This is required, please add it and rerun."
+            ""
+        )

--- a/src/fmu/dataio/export/rms/structure_depth_fault_lines.py
+++ b/src/fmu/dataio/export/rms/structure_depth_fault_lines.py
@@ -22,6 +22,7 @@ from fmu.dataio.export.rms._utils import (
     get_open_polygons_id,
     get_rms_project_units,
     load_global_config,
+    validate_name_in_stratigraphy,
 )
 
 if TYPE_CHECKING:
@@ -117,9 +118,9 @@ class _ExportStructureDepthFaultLines:
 
     def _validate_data(self) -> None:
         """Data validations before export."""
-        # TODO: check that the fault lines have a stratigraphy entry.
 
         for pol in self._fault_lines:
+            validate_name_in_stratigraphy(pol.name, self._config)
             self._raise_on_open_polygons(pol)
 
     def export(self) -> ExportResult:

--- a/src/fmu/dataio/export/rms/structure_depth_isochores.py
+++ b/src/fmu/dataio/export/rms/structure_depth_isochores.py
@@ -18,6 +18,7 @@ from fmu.dataio.export.rms._utils import (
     get_rms_project_units,
     get_zones_in_folder,
     load_global_config,
+    validate_name_in_stratigraphy,
 )
 
 if TYPE_CHECKING:
@@ -87,8 +88,9 @@ class _ExportStructureDepthIsochores:
 
     def _validate_surfaces(self) -> None:
         """Surface validations."""
-        # TODO: check that the surfaces have a stratigraphy entry.
+
         for surf in self._surfaces:
+            validate_name_in_stratigraphy(surf.name, self._config)
             if (surf.values < 0).any():
                 raise ValidationError(
                     f"Negative values detected for the isochore surface {surf.name}. "

--- a/src/fmu/dataio/export/rms/structure_depth_surfaces.py
+++ b/src/fmu/dataio/export/rms/structure_depth_surfaces.py
@@ -13,6 +13,7 @@ from fmu.dataio.export.rms._utils import (
     get_horizons_in_folder,
     get_rms_project_units,
     load_global_config,
+    validate_name_in_stratigraphy,
 )
 
 if TYPE_CHECKING:
@@ -79,10 +80,12 @@ class _ExportStructureDepthSurfaces:
         """Surface validations."""
         # TODO: Add check that the surfaces are consistent, i.e. a stratigraphic
         # deeper surface should never have shallower values than the one above
-        # also check that the surfaces have a stratigraphy entry.
+        for surf in self._surfaces:
+            validate_name_in_stratigraphy(surf.name, self._config)
 
     def export(self) -> ExportResult:
         """Export the depth as a standard_result."""
+        self._validate_surfaces()
         return self._export_surfaces()
 
 

--- a/tests/test_export_rms/test_export_structure_depth_fault_lines.py
+++ b/tests/test_export_rms/test_export_structure_depth_fault_lines.py
@@ -126,6 +126,16 @@ def test_public_export_function(mock_project_variable, mock_export_class):
 
 
 @inside_rms
+def test_unknown_name_in_stratigraphy_raises(mock_export_class):
+    """Test that an error is raised if horizon name is missing in the stratigraphy"""
+
+    mock_export_class._fault_lines[0].name = "missing"
+
+    with pytest.raises(ValueError, match="not listed"):
+        mock_export_class.export()
+
+
+@inside_rms
 def test_config_missing(mock_project_variable, rmssetup_with_fmuconfig, monkeypatch):
     """Test that an exception is raised if the config is missing."""
 

--- a/tests/test_export_rms/test_export_structure_depth_isochores.py
+++ b/tests/test_export_rms/test_export_structure_depth_isochores.py
@@ -89,6 +89,16 @@ def test_public_export_function(mock_project_variable, mock_export_class):
 
 
 @inside_rms
+def test_unknown_name_in_stratigraphy_raises(mock_export_class):
+    """Test that an error is raised if horizon name is missing in the stratigraphy"""
+
+    mock_export_class._surfaces[0].name = "missing"
+
+    with pytest.raises(ValueError, match="not listed"):
+        mock_export_class.export()
+
+
+@inside_rms
 def test_validation_negative_values(
     mock_project_variable, monkeypatch, rmssetup_with_fmuconfig, regsurf
 ):
@@ -100,6 +110,7 @@ def test_validation_negative_values(
 
     surf_with_negative_values = regsurf.copy()
     surf_with_negative_values.values = -20
+    surf_with_negative_values.name = "TopVolantis"  # should be a startigraphic name
 
     with mock.patch(  # noqa
         "fmu.dataio.export.rms.structure_depth_isochores.get_zones_in_folder",

--- a/tests/test_export_rms/test_export_structure_depth_surfaces.py
+++ b/tests/test_export_rms/test_export_structure_depth_surfaces.py
@@ -90,6 +90,16 @@ def test_public_export_function(mock_project_variable, mock_export_class):
 
 
 @inside_rms
+def test_unknown_name_in_stratigraphy_raises(mock_export_class):
+    """Test that an error is raised if horizon name is missing in the stratigraphy"""
+
+    mock_export_class._surfaces[0].name = "missing"
+
+    with pytest.raises(ValueError, match="not listed"):
+        mock_export_class.export()
+
+
+@inside_rms
 def test_config_missing(mock_project_variable, rmssetup_with_fmuconfig, monkeypatch):
     """Test that an exception is raised if the config is missing."""
 


### PR DESCRIPTION
Resolves #1109 

PR to ensure horizons and units exported as standard_result through
- `export_structure_depth_surfaces`
- `export_structure_depth_isochores`
- `export_structure_fault_lines`

have a corresponding entry in the `stratigraphy` block in the global config.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
