### PR TITLE
SCHEMA: Add fmu.ensemble as duplicate of fmu.iteration

### DIFF
--- a/examples/example_metadata/fmu_case.yml
+++ b/examples/example_metadata/fmu_case.yml
@@ -32,7 +32,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-03-27T09:24:43.814407Z'
+- datetime: '2025-04-01T19:38:23.822230Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/polygons_field_outline.yml
+++ b/examples/example_metadata/polygons_field_outline.yml
@@ -57,6 +57,10 @@ fmu:
     uuid: 00000000-0000-0000-0000-000000000000
   context:
     stage: realization
+  ensemble:
+    id: 0
+    name: iter-0
+    uuid: 00000000-0000-0000-0000-000000000000
   ert:
     experiment:
       id: 00000000-0000-0000-0000-000000000000
@@ -93,7 +97,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-03-27T09:24:47.339602Z'
+- datetime: '2025-04-01T19:38:27.191869Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/polygons_field_region.yml
+++ b/examples/example_metadata/polygons_field_region.yml
@@ -57,6 +57,10 @@ fmu:
     uuid: 00000000-0000-0000-0000-000000000000
   context:
     stage: realization
+  ensemble:
+    id: 0
+    name: iter-0
+    uuid: 00000000-0000-0000-0000-000000000000
   ert:
     experiment:
       id: 00000000-0000-0000-0000-000000000000
@@ -93,7 +97,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-03-27T09:24:47.319069Z'
+- datetime: '2025-04-01T19:38:27.170458Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/preprocessed_surface_depth.yml
+++ b/examples/example_metadata/preprocessed_surface_depth.yml
@@ -80,7 +80,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-03-27T09:24:52.514594Z'
+- datetime: '2025-04-01T19:38:31.957296Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/surface_depth.yml
+++ b/examples/example_metadata/surface_depth.yml
@@ -54,6 +54,10 @@ fmu:
     uuid: 00000000-0000-0000-0000-000000000000
   context:
     stage: realization
+  ensemble:
+    id: 0
+    name: iter-0
+    uuid: 00000000-0000-0000-0000-000000000000
   ert:
     experiment:
       id: 00000000-0000-0000-0000-000000000000
@@ -90,7 +94,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-03-27T09:24:54.234957Z'
+- datetime: '2025-04-01T19:38:33.577263Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/surface_fluid_contact.yml
+++ b/examples/example_metadata/surface_fluid_contact.yml
@@ -57,6 +57,10 @@ fmu:
     uuid: 00000000-0000-0000-0000-000000000000
   context:
     stage: realization
+  ensemble:
+    id: 0
+    name: iter-0
+    uuid: 00000000-0000-0000-0000-000000000000
   ert:
     experiment:
       id: 00000000-0000-0000-0000-000000000000
@@ -93,7 +97,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-03-27T09:24:54.278768Z'
+- datetime: '2025-04-01T19:38:33.621336Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/surface_seismic_amplitude.yml
+++ b/examples/example_metadata/surface_seismic_amplitude.yml
@@ -75,6 +75,10 @@ fmu:
     uuid: 00000000-0000-0000-0000-000000000000
   context:
     stage: realization
+  ensemble:
+    id: 0
+    name: iter-0
+    uuid: 00000000-0000-0000-0000-000000000000
   ert:
     experiment:
       id: 00000000-0000-0000-0000-000000000000
@@ -111,7 +115,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-03-27T09:24:54.324195Z'
+- datetime: '2025-04-01T19:38:33.666034Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/table_inplace_volumes.yml
+++ b/examples/example_metadata/table_inplace_volumes.yml
@@ -62,6 +62,10 @@ fmu:
     uuid: 00000000-0000-0000-0000-000000000000
   context:
     stage: realization
+  ensemble:
+    id: 0
+    name: iter-0
+    uuid: 00000000-0000-0000-0000-000000000000
   ert:
     experiment:
       id: 00000000-0000-0000-0000-000000000000
@@ -98,7 +102,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-03-27T09:24:58.433947Z'
+- datetime: '2025-04-01T19:38:37.449102Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/metadata_scripts/post_process_metadata.py
+++ b/examples/metadata_scripts/post_process_metadata.py
@@ -17,6 +17,8 @@ def remove_machine_data(metadata_yaml: dict) -> dict:
             metadata_yaml["fmu"]["realization"]["uuid"] = DUMMY_UUID
         if "iteration" in metadata_yaml["fmu"]:
             metadata_yaml["fmu"]["iteration"]["uuid"] = DUMMY_UUID
+        if "ensemble" in metadata_yaml["fmu"]:
+            metadata_yaml["fmu"]["ensemble"]["uuid"] = DUMMY_UUID
 
     if "file" in metadata_yaml and "absolute_path" in metadata_yaml["file"]:
         metadata_yaml["file"]["absolute_path"] = "/some/absolute/path/"

--- a/schemas/0.10.0/fmu_results.json
+++ b/schemas/0.10.0/fmu_results.json
@@ -26,6 +26,8 @@
     "fmu.aggregation.realization_ids",
     "fmu.case",
     "fmu.context.stage",
+    "fmu.ensemble.name",
+    "fmu.ensemble.uuid",
     "fmu.iteration.name",
     "fmu.iteration.uuid",
     "fmu.model",
@@ -417,7 +419,7 @@
       "type": "object"
     },
     "Case": {
-      "description": "The ``fmu.case`` block contains information about the case from which this data\nobject was exported.\n\nA case represent a set of iterations that belong together, either by being part of\nthe same run (i.e. history matching) or by being placed together by the user,\ncorresponding to /scratch/<asset>/<user>/<my case name>/.\n\n.. note:: If an FMU data object is exported outside the case context, this block\n   will not be present.",
+      "description": "The ``fmu.case`` block contains information about the case from which this data\nobject was exported.\n\nA case represent a set of ensembles that belong together, either by being part of\nthe same run (i.e. history matching) or by being placed together by the user,\ncorresponding to /scratch/<asset>/<user>/<my case name>/.\n\n.. note:: If an FMU data object is exported outside the case context, this block\n   will not be present.",
       "properties": {
         "description": {
           "anyOf": [
@@ -1004,6 +1006,54 @@
       "title": "DomainReference",
       "type": "string"
     },
+    "Ensemble": {
+      "description": "The ``fmu.ensemble`` block contains information about the ensemble this data\nobject belongs to.",
+      "properties": {
+        "id": {
+          "minimum": 0,
+          "title": "Id",
+          "type": "integer"
+        },
+        "name": {
+          "examples": [
+            "iter-0"
+          ],
+          "title": "Name",
+          "type": "string"
+        },
+        "restart_from": {
+          "anyOf": [
+            {
+              "format": "uuid",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "15ce3b84-766f-4c93-9050-b154861f9100"
+          ],
+          "title": "Restart From"
+        },
+        "uuid": {
+          "examples": [
+            "15ce3b84-766f-4c93-9050-b154861f9100"
+          ],
+          "format": "uuid",
+          "title": "Uuid",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "name",
+        "uuid"
+      ],
+      "title": "Ensemble",
+      "type": "object"
+    },
     "Ert": {
       "description": "The ``fmu.ert`` block contains information about the current ert run.",
       "properties": {
@@ -1087,6 +1137,17 @@
         "context": {
           "$ref": "#/$defs/Context"
         },
+        "ensemble": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Ensemble"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "ert": {
           "anyOf": [
             {
@@ -1101,7 +1162,7 @@
         "iteration": {
           "anyOf": [
             {
-              "$ref": "#/$defs/Iteration"
+              "$ref": "#/$defs/Ensemble"
             },
             {
               "type": "null"
@@ -1180,7 +1241,7 @@
           "$ref": "#/$defs/IterationContext"
         },
         "iteration": {
-          "$ref": "#/$defs/Iteration"
+          "$ref": "#/$defs/Ensemble"
         },
         "model": {
           "$ref": "#/$defs/Model"
@@ -1205,7 +1266,7 @@
           "$ref": "#/$defs/RealizationContext"
         },
         "iteration": {
-          "$ref": "#/$defs/Iteration"
+          "$ref": "#/$defs/Ensemble"
         },
         "model": {
           "$ref": "#/$defs/Model"
@@ -3335,54 +3396,6 @@
         "name"
       ],
       "title": "InplaceVolumesStandardResult",
-      "type": "object"
-    },
-    "Iteration": {
-      "description": "The ``fmu.iteration`` block contains information about the iteration this data\nobject belongs to.",
-      "properties": {
-        "id": {
-          "minimum": 0,
-          "title": "Id",
-          "type": "integer"
-        },
-        "name": {
-          "examples": [
-            "iter-0"
-          ],
-          "title": "Name",
-          "type": "string"
-        },
-        "restart_from": {
-          "anyOf": [
-            {
-              "format": "uuid",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "examples": [
-            "15ce3b84-766f-4c93-9050-b154861f9100"
-          ],
-          "title": "Restart From"
-        },
-        "uuid": {
-          "examples": [
-            "15ce3b84-766f-4c93-9050-b154861f9100"
-          ],
-          "format": "uuid",
-          "title": "Uuid",
-          "type": "string"
-        }
-      },
-      "required": [
-        "id",
-        "name",
-        "uuid"
-      ],
-      "title": "Iteration",
       "type": "object"
     },
     "IterationContext": {

--- a/src/fmu/dataio/_models/fmu_results/fmu_results.py
+++ b/src/fmu/dataio/_models/fmu_results/fmu_results.py
@@ -49,6 +49,7 @@ class FmuResultsSchema(SchemaBase):
     VERSION_CHANGELOG: str = """
     #### 0.10.0
 
+    - `fmu.ensemble` added as duplicate and future replacement of `fmu.iteration`
     - `data.property` added as optional field for data of content `property`
     - `data.property.attribute` added as optional field.
     - `data.property.is_discrete` added as optional field.
@@ -128,6 +129,8 @@ class FmuResultsSchema(SchemaBase):
         "fmu.aggregation.realization_ids",
         "fmu.case",
         "fmu.context.stage",
+        "fmu.ensemble.name",
+        "fmu.ensemble.uuid",
         "fmu.iteration.name",
         "fmu.iteration.uuid",
         "fmu.model",

--- a/src/fmu/dataio/providers/_fmu.py
+++ b/src/fmu/dataio/providers/_fmu.py
@@ -195,7 +195,7 @@ class FmuProvider(Provider):
             context=self._get_fmucontext_meta(),
             model=self.model or case_meta.fmu.model,
             workflow=self._get_workflow_meta() if self.workflow else None,
-            iteration=self._get_iteration_meta(iter_uuid),
+            ensemble=self._get_iteration_meta(iter_uuid),
             realization=self._get_realization_meta(real_uuid),
             ert=self._get_ert_meta(),
         )
@@ -316,8 +316,8 @@ class FmuProvider(Provider):
             uuid=real_uuid,
         )
 
-    def _get_iteration_meta(self, iter_uuid: UUID) -> fields.Iteration:
-        return fields.Iteration(
+    def _get_iteration_meta(self, iter_uuid: UUID) -> fields.Ensemble:
+        return fields.Ensemble(
             id=self._iter_id,
             name=self._iter_name,
             uuid=iter_uuid,

--- a/tests/test_schema/test_pydantic_logic.py
+++ b/tests/test_schema/test_pydantic_logic.py
@@ -516,3 +516,27 @@ def test_sumo_realization(metadata_examples):
 
     with pytest.raises(ValidationError):
         FmuResults.model_validate(_example)
+
+
+def test_fmu_iteration_set_from_fmu_ensemble(metadata_examples):
+    """Test that fmu.iteration is set from the fmu.ensemble."""
+
+    # fetch example
+    example = metadata_examples["surface_depth.yml"]
+
+    # assert validation with no changes
+    FmuResults.model_validate(example)
+
+    assert "iteration" in example["fmu"]
+    assert "ensemble" in example["fmu"]
+
+    # delete fmu.iteration and see that is set from the fmu.ensemble
+    _example = deepcopy(example)
+    del _example["fmu"]["iteration"]
+    _example["fmu"]["ensemble"]["name"] = "pytest"
+
+    model = FmuResults.model_validate(_example)
+
+    assert hasattr(model.root.fmu, "iteration")
+    assert model.root.fmu.iteration == model.root.fmu.ensemble
+    assert model.root.fmu.iteration.name == "pytest"

--- a/tests/test_units/test_dataio.py
+++ b/tests/test_units/test_dataio.py
@@ -799,6 +799,9 @@ def test_exportdata_no_iter_folder(
         metadata = yaml.safe_load(f)
     assert metadata["fmu"]["realization"]["name"] == "realization-1"
     assert metadata["fmu"]["realization"]["id"] == 1
+    assert metadata["fmu"]["ensemble"]["name"] == "iter-0"
+    assert metadata["fmu"]["ensemble"]["id"] == 0
+    # check that also iteration is added to the metadata
     assert metadata["fmu"]["iteration"]["name"] == "iter-0"
     assert metadata["fmu"]["iteration"]["id"] == 0
 


### PR DESCRIPTION
Resolves #1132
Resolves #1134 

PR to start adding `fmu.ensemble` to the `FmuResults` schema and outgoing metadata. The `fmu.iteration` is still kept.
Also added `fmu.ensemble.name` and `fmu.ensemble.uuid` to `CONTRACTUALS`

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
