### PR TITLE
SCHEMA: Add ensemble as `fmu.context.stage` option

### DIFF
--- a/schemas/0.10.0/fmu_results.json
+++ b/schemas/0.10.0/fmu_results.json
@@ -1226,6 +1226,7 @@
       "enum": [
         "case",
         "iteration",
+        "ensemble",
         "realization"
       ],
       "title": "FMUContext",

--- a/src/fmu/dataio/_models/fmu_results/enums.py
+++ b/src/fmu/dataio/_models/fmu_results/enums.py
@@ -115,6 +115,7 @@ class FMUContext(str, Enum):
 
     case = "case"
     iteration = "iteration"
+    ensemble = "ensemble"
     realization = "realization"
 
 

--- a/src/fmu/dataio/aggregation.py
+++ b/src/fmu/dataio/aggregation.py
@@ -246,8 +246,8 @@ class AggregatedData:
         template["fmu"]["aggregation"]["realization_ids"] = real_ids
         template["fmu"]["aggregation"]["id"] = self.aggregation_id
 
-        # fmu.context.stage should be 'iteration'
-        template["fmu"]["context"]["stage"] = FMUContext.iteration.value
+        # fmu.context.stage should be 'ensemble'
+        template["fmu"]["context"]["stage"] = FMUContext.ensemble.value
 
         # next, the new object will trigger update of: 'file', 'data' (some fields) and
         # 'tracklog'.

--- a/tests/test_units/test_aggregated_surfaces.py
+++ b/tests/test_units/test_aggregated_surfaces.py
@@ -32,7 +32,7 @@ def test_regsurf_aggregated(fmurun_w_casemetadata, aggr_surfs_mean):
     newmeta = aggdata.generate_metadata(aggr_mean)
     logger.debug("New metadata:\n%s", utils.prettyprint_dict(newmeta))
     assert newmeta["fmu"]["aggregation"]["id"] == aggregation_uuid
-    assert newmeta["fmu"]["context"]["stage"] == "iteration"
+    assert newmeta["fmu"]["context"]["stage"] == "ensemble"
 
 
 def test_regsurf_aggregated_content_seismic(
@@ -60,7 +60,7 @@ def test_regsurf_aggregated_content_seismic(
     newmeta = aggdata.generate_metadata(aggr_mean)
     logger.debug("New metadata:\n%s", utils.prettyprint_dict(newmeta))
     assert newmeta["fmu"]["aggregation"]["id"] == aggregation_uuid
-    assert newmeta["fmu"]["context"]["stage"] == "iteration"
+    assert newmeta["fmu"]["context"]["stage"] == "ensemble"
 
 
 def test_regsurf_aggregated_export(fmurun_w_casemetadata, aggr_surfs_mean):


### PR DESCRIPTION
Resolves #1131 

PR to start adding `ensemble` as a valid option for `fmu.context.stage` and to use this value for aggregated data instead of `iteration`

## Checklist

- [x] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
