### PR TITLE
SCHEMA: Add Ensemble model, and add fmu.ensemble to Realization object

### DIFF
--- a/examples/example_metadata/fmu_case.yml
+++ b/examples/example_metadata/fmu_case.yml
@@ -32,7 +32,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-04-01T19:38:23.822230Z'
+- datetime: '2025-04-02T13:56:35.152852Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/polygons_field_outline.yml
+++ b/examples/example_metadata/polygons_field_outline.yml
@@ -97,7 +97,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-04-01T19:38:27.191869Z'
+- datetime: '2025-04-02T13:56:38.868928Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/polygons_field_region.yml
+++ b/examples/example_metadata/polygons_field_region.yml
@@ -97,7 +97,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-04-01T19:38:27.170458Z'
+- datetime: '2025-04-02T13:56:38.849590Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/preprocessed_surface_depth.yml
+++ b/examples/example_metadata/preprocessed_surface_depth.yml
@@ -80,7 +80,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-04-01T19:38:31.957296Z'
+- datetime: '2025-04-02T13:56:44.303313Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/sumo_ensemble.yml
+++ b/examples/example_metadata/sumo_ensemble.yml
@@ -1,7 +1,7 @@
-# Example metadata for an FMU Iteration object.
+# Example metadata for an FMU Ensemble object.
 
-$schema: https://main-fmu-schemas-dev.radix.equinor.com/schemas/0.8.0/fmu_results.json
-version: "0.8.0"
+$schema: https://main-fmu-schemas-dev.radix.equinor.com/schemas/0.10.0/fmu_results.json
+version: "0.10.0"
 source: fmu
 tracklog:
   - datetime: 2020-10-28T14:28:02
@@ -13,7 +13,7 @@ tracklog:
       id: user
     event: updated
 
-class: iteration # class is the main identifier of the data type.
+class: ensemble # class is the main identifier of the data type.
 
 fmu: # the fmu-block contains information directly related to the FMU context
   model:
@@ -33,9 +33,9 @@ fmu: # the fmu-block contains information directly related to the FMU context
       - optional
 
   context:
-    stage: iteration
+    stage: ensemble
 
-  iteration:
+  ensemble:
     id: 0
     name: iter-0
     uuid: fd6e8f2a-f298-434a-80f4-90f0f6f84688

--- a/examples/example_metadata/sumo_realization.yml
+++ b/examples/example_metadata/sumo_realization.yml
@@ -1,7 +1,7 @@
 # Example metadata for an FMU Realization object.
 
-$schema: https://main-fmu-schemas-dev.radix.equinor.com/schemas/0.8.0/fmu_results.json
-version: "0.8.0"
+$schema: https://main-fmu-schemas-dev.radix.equinor.com/schemas/0.10.0/fmu_results.json
+version: "0.10.0"
 source: fmu
 tracklog:
   - datetime: 2020-10-28T14:28:02
@@ -35,7 +35,7 @@ fmu: # the fmu-block contains information directly related to the FMU context
   context:
     stage: realization
 
-  iteration:
+  ensemble:
     id: 0
     name: iter-0
     uuid: fd6e8f2a-f298-434a-80f4-90f0f6f84688

--- a/examples/example_metadata/surface_depth.yml
+++ b/examples/example_metadata/surface_depth.yml
@@ -94,7 +94,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-04-01T19:38:33.577263Z'
+- datetime: '2025-04-02T13:56:46.145142Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/surface_fluid_contact.yml
+++ b/examples/example_metadata/surface_fluid_contact.yml
@@ -97,7 +97,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-04-01T19:38:33.621336Z'
+- datetime: '2025-04-02T13:56:46.189734Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/surface_seismic_amplitude.yml
+++ b/examples/example_metadata/surface_seismic_amplitude.yml
@@ -115,7 +115,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-04-01T19:38:33.666034Z'
+- datetime: '2025-04-02T13:56:46.233925Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/table_inplace_volumes.yml
+++ b/examples/example_metadata/table_inplace_volumes.yml
@@ -102,7 +102,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-04-01T19:38:37.449102Z'
+- datetime: '2025-04-02T13:56:50.190059Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/schemas/0.10.0/fmu_results.json
+++ b/schemas/0.10.0/fmu_results.json
@@ -1054,6 +1054,67 @@
       "title": "Ensemble",
       "type": "object"
     },
+    "EnsembleContext": {
+      "description": "The ``fmu.context`` block contains the FMU context in which this data object\nwas produced. Here ``stage`` is required to be ``ensemble``.",
+      "properties": {
+        "stage": {
+          "const": "ensemble",
+          "default": "ensemble",
+          "title": "Stage",
+          "type": "string"
+        }
+      },
+      "title": "EnsembleContext",
+      "type": "object"
+    },
+    "EnsembleMetadata": {
+      "description": "The FMU metadata model for an FMU ensemble.\n\nAn object representing a single Ensemble of a specific case.",
+      "properties": {
+        "$schema": {
+          "format": "uri",
+          "minLength": 1,
+          "title": "$Schema",
+          "type": "string"
+        },
+        "access": {
+          "$ref": "#/$defs/Access"
+        },
+        "class": {
+          "const": "ensemble",
+          "title": "metadata_class",
+          "type": "string"
+        },
+        "fmu": {
+          "$ref": "#/$defs/FMUEnsemble"
+        },
+        "masterdata": {
+          "$ref": "#/$defs/Masterdata"
+        },
+        "source": {
+          "default": "fmu",
+          "title": "Source",
+          "type": "string"
+        },
+        "tracklog": {
+          "$ref": "#/$defs/Tracklog"
+        },
+        "version": {
+          "default": "0.10.0",
+          "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)",
+          "title": "Version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "class",
+        "masterdata",
+        "tracklog",
+        "fmu",
+        "access"
+      ],
+      "title": "EnsembleMetadata",
+      "type": "object"
+    },
     "Ert": {
       "description": "The ``fmu.ert`` block contains information about the current ert run.",
       "properties": {
@@ -1232,8 +1293,33 @@
       "title": "FMUContext",
       "type": "string"
     },
+    "FMUEnsemble": {
+      "description": "The ``fmu`` block contains all attributes specific to FMU. The idea is that the FMU\nresults data model can be applied to data from *other* sources - in which the\nfmu-specific stuff may not make sense or be applicable.\nThis is a specialization of the FMU block for ``ensemble`` objects.",
+      "properties": {
+        "case": {
+          "$ref": "#/$defs/Case"
+        },
+        "context": {
+          "$ref": "#/$defs/EnsembleContext"
+        },
+        "ensemble": {
+          "$ref": "#/$defs/Ensemble"
+        },
+        "model": {
+          "$ref": "#/$defs/Model"
+        }
+      },
+      "required": [
+        "case",
+        "model",
+        "context",
+        "ensemble"
+      ],
+      "title": "FMUEnsemble",
+      "type": "object"
+    },
     "FMUIteration": {
-      "description": "The ``fmu`` block contains all attributes specific to FMU. The idea is that the FMU\nresults data model can be applied to data from *other* sources - in which the\nfmu-specific stuff may not make sense or be applicable.\nThis is a specialization of the FMU block for ``iteration`` objects.",
+      "description": "Deprecated and replaced by :class:`FMUEnsemble`.",
       "properties": {
         "case": {
           "$ref": "#/$defs/Case"
@@ -1266,8 +1352,19 @@
         "context": {
           "$ref": "#/$defs/RealizationContext"
         },
-        "iteration": {
+        "ensemble": {
           "$ref": "#/$defs/Ensemble"
+        },
+        "iteration": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Ensemble"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "model": {
           "$ref": "#/$defs/Model"
@@ -1280,7 +1377,7 @@
         "case",
         "model",
         "context",
-        "iteration",
+        "ensemble",
         "realization"
       ],
       "title": "FMURealization",
@@ -3413,7 +3510,7 @@
       "type": "object"
     },
     "IterationMetadata": {
-      "description": "The FMU metadata model for an FMU Iteration.\n\nAn object representing a single Iteration of a specific case.",
+      "description": "Deprecated and replaced by :class:`EnsembleMetadata`.",
       "properties": {
         "$schema": {
           "format": "uri",
@@ -6315,7 +6412,7 @@
       "type": "object"
     },
     "RealizationMetadata": {
-      "description": "The FMU metadata model for an FMU Realization.\n\nAn object representing a single Realization of a specific Iteration.",
+      "description": "The FMU metadata model for an FMU Realization.\n\nAn object representing a single Realization of a specific Ensemble.",
       "properties": {
         "$schema": {
           "format": "uri",
@@ -10567,6 +10664,9 @@
     },
     {
       "$ref": "#/$defs/IterationMetadata"
+    },
+    {
+      "$ref": "#/$defs/EnsembleMetadata"
     }
   ],
   "then": {

--- a/src/fmu/dataio/_models/fmu_results/enums.py
+++ b/src/fmu/dataio/_models/fmu_results/enums.py
@@ -88,6 +88,7 @@ class FMUClass(str, Enum):
     case = "case"
     realization = "realization"
     iteration = "iteration"
+    ensemble = "ensemble"
     surface = "surface"
     table = "table"
     cpgrid = "cpgrid"

--- a/src/fmu/dataio/_models/fmu_results/fields.py
+++ b/src/fmu/dataio/_models/fmu_results/fields.py
@@ -553,6 +553,15 @@ class IterationContext(Context):
     )
 
 
+class EnsembleContext(Context):
+    """
+    The ``fmu.context`` block contains the FMU context in which this data object
+    was produced. Here ``stage`` is required to be ``ensemble``.
+    """
+
+    stage: Literal[enums.FMUContext.ensemble] = Field(default=enums.FMUContext.ensemble)
+
+
 class RealizationContext(Context):
     """
     The ``fmu.context`` block contains the FMU context in which this data object
@@ -581,12 +590,7 @@ class FMUBase(BaseModel):
 
 
 class FMUIteration(FMUBase):
-    """
-    The ``fmu`` block contains all attributes specific to FMU. The idea is that the FMU
-    results data model can be applied to data from *other* sources - in which the
-    fmu-specific stuff may not make sense or be applicable.
-    This is a specialization of the FMU block for ``iteration`` objects.
-    """
+    """Deprecated and replaced by :class:`FMUEnsemble`."""
 
     context: IterationContext
     """The ``fmu.context`` block contains the FMU context in which this data object
@@ -596,6 +600,24 @@ class FMUIteration(FMUBase):
     iteration: Ensemble
     """The ``fmu.iteration`` block contains information about the iteration this data
     object belongs to. See :class:`Iteration`. """
+
+
+class FMUEnsemble(FMUBase):
+    """
+    The ``fmu`` block contains all attributes specific to FMU. The idea is that the FMU
+    results data model can be applied to data from *other* sources - in which the
+    fmu-specific stuff may not make sense or be applicable.
+    This is a specialization of the FMU block for ``ensemble`` objects.
+    """
+
+    context: EnsembleContext
+    """The ``fmu.context`` block contains the FMU context in which this data object
+    was produced. See :class:`Context`. For ``ensemble`` the context is ``ensemble``.
+    """
+
+    ensemble: Ensemble
+    """The ``fmu.ensemble`` block contains information about the ensemble this data
+    object belongs to. See :class:`ensemble`. """
 
 
 class FMURealization(FMUBase):
@@ -612,9 +634,12 @@ class FMURealization(FMUBase):
     ``realization``.
     """
 
-    iteration: Ensemble
-    """The ``fmu.iteration`` block contains information about the iteration this data
-    object belongs to. See :class:`Iteration`. """
+    ensemble: Ensemble
+    """The ``fmu.ensemble`` block contains information about the ensemble this data
+    object belongs to. See :class:`ensemble`. """
+
+    iteration: Ensemble | None = Field(default=None)
+    """Deprecated and replaced by ``fmu.ensemble``"""
 
     realization: Realization
     """The ``fmu.realization`` block contains information about the realization this

--- a/src/fmu/dataio/_models/fmu_results/fmu_results.py
+++ b/src/fmu/dataio/_models/fmu_results/fmu_results.py
@@ -27,6 +27,7 @@ from .fields import (
     Display,
     File,
     FMUBase,
+    FMUEnsemble,
     FMUIteration,
     FMURealization,
     Masterdata,
@@ -49,6 +50,10 @@ class FmuResultsSchema(SchemaBase):
     VERSION_CHANGELOG: str = """
     #### 0.10.0
 
+    - `Ensemble` objects with `class=ensemble` is now supported, and will
+      in the future replace `Iteration` objects
+    - `fmu.context.stage` now supports option `ensemble`
+    - `$contractual.fmu.ensemble.uuid` and `$contractual.fmu.ensemble.name` added
     - `fmu.ensemble` added as duplicate and future replacement of `fmu.iteration`
     - `data.property` added as optional field for data of content `property`
     - `data.property.attribute` added as optional field.
@@ -215,10 +220,7 @@ class CaseMetadata(MetadataBase):
 
 
 class IterationMetadata(MetadataBase):
-    """The FMU metadata model for an FMU Iteration.
-
-    An object representing a single Iteration of a specific case.
-    """
+    """Deprecated and replaced by :class:`EnsembleMetadata`."""
 
     class_: Literal[FMUClass.iteration] = Field(alias="class", title="metadata_class")
     """The class of this metadata object. In this case, always an FMU iteration."""
@@ -232,10 +234,28 @@ class IterationMetadata(MetadataBase):
     this data object. See :class:`Access`."""
 
 
+class EnsembleMetadata(MetadataBase):
+    """The FMU metadata model for an FMU ensemble.
+
+    An object representing a single Ensemble of a specific case.
+    """
+
+    class_: Literal[FMUClass.ensemble] = Field(alias="class", title="metadata_class")
+    """The class of this metadata object. In this case, always an FMU ensemble."""
+
+    fmu: FMUEnsemble
+    """The ``fmu`` block contains all attributes specific to FMU.
+    See :class:`FMU`."""
+
+    access: Access
+    """The ``access`` block contains information related to access control for
+    this data object. See :class:`Access`."""
+
+
 class RealizationMetadata(MetadataBase):
     """The FMU metadata model for an FMU Realization.
 
-    An object representing a single Realization of a specific Iteration.
+    An object representing a single Realization of a specific Ensemble.
     """
 
     class_: Literal[FMUClass.realization] = Field(alias="class", title="metadata_class")
@@ -294,7 +314,11 @@ class ObjectMetadata(MetadataBase):
 class FmuResults(
     RootModel[
         Annotated[
-            CaseMetadata | ObjectMetadata | RealizationMetadata | IterationMetadata,
+            CaseMetadata
+            | ObjectMetadata
+            | RealizationMetadata
+            | IterationMetadata
+            | EnsembleMetadata,
             Field(discriminator="class_"),
         ]
     ]

--- a/tests/test_schema/test_pydantic_logic.py
+++ b/tests/test_schema/test_pydantic_logic.py
@@ -458,10 +458,10 @@ def test_zmin_zmax_not_present_for_surfaces(metadata_examples):
     assert isinstance(model.root.data.root.bbox, data.BoundingBox2D)
 
 
-def test_sumo_iteration(metadata_examples):
+def test_sumo_ensemble(metadata_examples):
     """Asserting validation failure when illegal contents in case example"""
 
-    example = metadata_examples["sumo_iteration.yml"]
+    example = metadata_examples["sumo_ensemble.yml"]
 
     # assert validation with no changes
     FmuResults.model_validate(example)
@@ -473,14 +473,14 @@ def test_sumo_iteration(metadata_examples):
     with pytest.raises(ValidationError):
         FmuResults.model_validate(_example)
 
-    # assert validation error when "fmu.iteration" is missing
+    # assert validation error when "fmu.ensemble" is missing
     _example = deepcopy(example)
-    del _example["fmu"]["iteration"]
+    del _example["fmu"]["ensemble"]
 
     with pytest.raises(ValidationError):
         FmuResults.model_validate(_example)
 
-    # assert validation error when "fmu.context.stage" is not iteration
+    # assert validation error when "fmu.context.stage" is not ensemble
     _example = deepcopy(example)
     _example["fmu"]["context"]["stage"] = "case"
 


### PR DESCRIPTION
Resolves #1135 

PR with following additions to the `FmuResultsSchema`

- add `fmu.ensemble` to the `Realization` object, and set `fmu.iteration` to optional. 
- add an `Ensemble` object to the schema with `class=ensemble` (will eventually replace the `Iteration` object)



## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
