### PR TITLE
MAINT: Standardise subfolder to be the standard result name

### DIFF
--- a/docs/src/standard_results/initial_inplace_volumes.md
+++ b/docs/src/standard_results/initial_inplace_volumes.md
@@ -9,7 +9,7 @@ This exports the initial inplace volumes of a single grid from within RMS.
 | Field | Value |
 | --- | --- |
 | Version | **{{ InplaceVolumesSchema.VERSION }}** |
-| Output | `share/results/tables/volumes/gridname.parquet` |
+| Output | `share/results/tables/inplace_volumes/gridname.parquet` |
 :::
 
 ## Requirements
@@ -55,7 +55,7 @@ The volumetric table from RMS undergoes a couple of transformations to adhere to
    is absent, it is set equal to the `BULK` column, assuming a net-to-gross ratio of one.
 
 Given a grid model name `Geogrid` the result file will be
-`share/results/tables/volumes/geogrid.parquet`.
+`share/results/tables/inplace_volumes/geogrid.parquet`.
 
 This is a tabular file that can be converted to `.csv` or similar. It contains
 the following columns with types validated as indicated.

--- a/docs/src/standard_results/structure_depth_surfaces.md
+++ b/docs/src/standard_results/structure_depth_surfaces.md
@@ -17,7 +17,7 @@ model workflow.
 | Field | Value |
 | --- | --- |
 | Version | NA |
-| Output | `share/results/maps/structure_depth_surfaces/surfacename.gri` |
+| Output | `share/results/maps/structure_depth_surface/surfacename.gri` |
 :::
 
 ## Requirements
@@ -38,7 +38,7 @@ This export function will automatically export all non-empty horizons from the p
 ## Result
 
 The surfaces from the horizon folder will be exported as 'irap_binary'
-files to `share/results/maps/structure_depth_surfaces/surfacename.gri`.
+files to `share/results/maps/structure_depth_surface/surfacename.gri`.
 
 
 ## Standard result schema

--- a/src/fmu/dataio/export/rms/inplace_volumes.py
+++ b/src/fmu/dataio/export/rms/inplace_volumes.py
@@ -79,6 +79,11 @@ class _ExportVolumetricsRMS:
         )
 
     @property
+    def _subfolder(self) -> str:
+        """Subfolder for exporting the data to."""
+        return self._standard_result.name.value
+
+    @property
     def _classification(self) -> Classification:
         """Get default classification."""
         return Classification.restricted
@@ -328,7 +333,7 @@ class _ExportVolumetricsRMS:
             unit="m3" if get_rms_project_units(self.project) == "metric" else "ft3",
             vertical_domain="depth",
             domain_reference="msl",
-            subfolder="volumes",
+            subfolder=self._subfolder,
             classification=self._classification,
             name=self.grid_name,
             rep_include=False,

--- a/src/fmu/dataio/export/rms/structure_depth_fault_lines.py
+++ b/src/fmu/dataio/export/rms/structure_depth_fault_lines.py
@@ -60,7 +60,7 @@ class _ExportStructureDepthFaultLines:
     @property
     def _subfolder(self) -> str:
         """Subfolder for exporting the data to."""
-        return StandardResultName.structure_depth_fault_lines.value
+        return self._standard_result.name.value
 
     def _export_fault_line(self, pol: xtgeo.Polygons) -> ExportResultItem:
         edata = dio.ExportData(

--- a/src/fmu/dataio/export/rms/structure_depth_surfaces.py
+++ b/src/fmu/dataio/export/rms/structure_depth_surfaces.py
@@ -47,6 +47,11 @@ class _ExportStructureDepthSurfaces:
         """Get default classification."""
         return Classification.internal
 
+    @property
+    def _subfolder(self) -> str:
+        """Subfolder for exporting the data to."""
+        return self._standard_result.name.value
+
     def _export_surface(self, surf: xtgeo.RegularSurface) -> ExportResultItem:
         edata = dio.ExportData(
             config=self._config,
@@ -54,7 +59,7 @@ class _ExportStructureDepthSurfaces:
             unit=self._unit,
             vertical_domain="depth",
             domain_reference="msl",
-            subfolder="structure_depth_surfaces",
+            subfolder=self._subfolder,
             is_prediction=True,
             name=surf.name,
             classification=self._classification,

--- a/tests/test_export_rms/test_export_inplace_volumes.py
+++ b/tests/test_export_rms/test_export_inplace_volumes.py
@@ -568,7 +568,7 @@ def test_rms_volumetrics_export_function(
 
     absolute_path = (
         rmssetup_with_fmuconfig.parent.parent
-        / "share/results/tables/volumes/geogrid.parquet"
+        / "share/results/tables/inplace_volumes/geogrid.parquet"
     )
 
     assert vol_table_file == absolute_path

--- a/tests/test_export_rms/test_export_structure_depth_surfaces.py
+++ b/tests/test_export_rms/test_export_structure_depth_surfaces.py
@@ -41,7 +41,7 @@ def test_files_exported_with_metadata(mock_export_class, rmssetup_with_fmuconfig
     mock_export_class.export()
 
     export_folder = (
-        rmssetup_with_fmuconfig / "../../share/results/maps/structure_depth_surfaces"
+        rmssetup_with_fmuconfig / "../../share/results/maps/structure_depth_surface"
     )
     assert export_folder.exists()
 


### PR DESCRIPTION
Resolves #1144

PR to align the convention for the subfolder for existing simple exports. This should always be set equal to the standard result name.

This should be implemented in the base class once #1101 is addressed.

Existing tests were modified.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
