### PR TITLE
ENH: Enable setting `data.table_index` for points/polygons

### DIFF
--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -234,8 +234,10 @@ class ExportData:
 
         grid_model: Currently allowed but planned for deprecation. See `geometry`.
 
-        table_index: This applies to Pandas (table) data only, and is a list of the
-            column names to use as index columns e.g. ["ZONE", "REGION"].
+        table_index: This applies to tabular data and is a list of the column names
+            to use as index columns e.g. ["ZONE", "REGION"]. This can also be applied
+            to points or polygons objects that are exported in table format to specify
+            attributes that should act as index columns.
 
         is_prediction: True (default) if model prediction data
 

--- a/src/fmu/dataio/providers/objectdata/_xtgeo.py
+++ b/src/fmu/dataio/providers/objectdata/_xtgeo.py
@@ -25,6 +25,7 @@ from fmu.dataio._models.fmu_results.specification import (
 from fmu.dataio._utils import get_geometry_ref, npfloat_to_float
 
 from ._base import ObjectDataProvider
+from ._tables import _derive_index
 
 if TYPE_CHECKING:
     from io import BytesIO
@@ -141,11 +142,7 @@ class PolygonsDataProvider(ObjectDataProvider):
             self.obj.xname = "X"
             self.obj.yname = "Y"
             self.obj.zname = "Z"
-            # self.obj.pname = "ID"
-
-            # TODO: remove this hack when possible to set pname
-            self.obj._df_column_rename("ID", "POLY_ID")
-            self.obj._pname = "ID"
+            self.obj.pname = "ID"
 
         super().__post_init__()
 
@@ -170,8 +167,16 @@ class PolygonsDataProvider(ObjectDataProvider):
         return Layout.unset
 
     @property
-    def table_index(self) -> None:
+    def table_index(self) -> list[str] | None:
         """Return the table index."""
+        if self.fmt == FileFormat.irap_ascii:
+            return None
+
+        return _derive_index(
+            table_index=self.dataio.table_index,
+            table_columns=list(self.obj_dataframe.columns),
+            content=self.dataio._get_content_enum(),
+        )
 
     @property
     def obj_dataframe(self) -> pd.DataFrame:
@@ -263,8 +268,16 @@ class PointsDataProvider(ObjectDataProvider):
         return Layout.unset
 
     @property
-    def table_index(self) -> None:
+    def table_index(self) -> list[str] | None:
         """Return the table index."""
+        if self.fmt == FileFormat.irap_ascii:
+            return None
+
+        return _derive_index(
+            table_index=self.dataio.table_index,
+            table_columns=list(self.obj_dataframe.columns),
+            content=self.dataio._get_content_enum(),
+        )
 
     @property
     def obj_dataframe(self) -> pd.DataFrame:

--- a/tests/test_export_rms/test_export_structure_depth_fault_lines.py
+++ b/tests/test_export_rms/test_export_structure_depth_fault_lines.py
@@ -121,8 +121,7 @@ def test_public_export_function(mock_project_variable, mock_export_class):
         "POLY_ID",
         "NAME",
     }
-    # TODO: Add table index to metadata
-    # assert set(metadata["data"]["table_index"]) == {"POLY_ID", "NAME"}
+    assert set(metadata["data"]["table_index"]) == {"POLY_ID", "NAME"}
 
 
 @inside_rms

--- a/tests/test_units/test_ert_context.py
+++ b/tests/test_units/test_ert_context.py
@@ -163,7 +163,10 @@ def test_polys_export_file_use_xtgeo_names(
     os.chdir(fmurun_w_casemetadata)
 
     edata = dataio.ExportData(
-        config=rmsglobalconfig, content="depth", name="TopVolantis"
+        config=rmsglobalconfig,
+        content="depth",
+        name="TopVolantis",
+        table_index=[polygons.pname],
     )
 
     edata.polygons_fformat = "csv|xtgeo"  # override
@@ -171,6 +174,9 @@ def test_polys_export_file_use_xtgeo_names(
 
     thefile = pd.read_csv(output)
     assert set(thefile.columns) == {"X_UTME", "Y_UTMN", "Z_TVDSS", "POLY_ID"}
+
+    meta = dataio.read_metadata(output)
+    assert meta["data"]["table_index"] == [polygons.pname]
 
     edata.polygons_fformat = "csv"  # reset
 
@@ -182,7 +188,10 @@ def test_polys_export_file_as_parquet(fmurun_w_casemetadata, rmsglobalconfig, po
     os.chdir(fmurun_w_casemetadata)
 
     edata = dataio.ExportData(
-        config=rmsglobalconfig, content="depth", name="TopVolantis"
+        config=rmsglobalconfig,
+        content="depth",
+        name="TopVolantis",
+        table_index=[polygons.pname],
     )
 
     edata.polygons_fformat = "parquet"  # override
@@ -200,6 +209,7 @@ def test_polys_export_file_as_parquet(fmurun_w_casemetadata, rmsglobalconfig, po
 
     meta = dataio.read_metadata(output)
     assert meta["data"]["format"] == "parquet"
+    assert meta["data"]["table_index"] == [polygons.pname]
 
     edata.polygons_fformat = "csv"  # reset
 
@@ -213,7 +223,10 @@ def test_polys_export_file_as_irap_ascii(
     os.chdir(fmurun_w_casemetadata)
 
     edata = dataio.ExportData(
-        config=rmsglobalconfig, content="depth", name="TopVolantis"
+        config=rmsglobalconfig,
+        content="depth",
+        name="TopVolantis",
+        table_index=[polygons.pname],
     )
 
     edata.polygons_fformat = "irap_ascii"  # override
@@ -223,6 +236,9 @@ def test_polys_export_file_as_irap_ascii(
     assert output == (
         edata._rootpath / "realization-0/iter-0/share/results/polygons/topvolantis.pol"
     )
+    # check that data.table_index is not set in the metadata
+    meta = dataio.read_metadata(output)
+    assert "table_index" not in meta["data"]
     edata.polygons_fformat = "csv"  # reset
 
 
@@ -233,7 +249,10 @@ def test_points_export_file_set_name(fmurun_w_casemetadata, rmsglobalconfig, poi
     os.chdir(fmurun_w_casemetadata)
 
     edata = dataio.ExportData(
-        config=rmsglobalconfig, content="depth", name="TopVolantis"
+        config=rmsglobalconfig,
+        content="depth",
+        name="TopVolantis",
+        table_index=["WellName"],
     )
 
     output = edata.export(points)
@@ -251,6 +270,7 @@ def test_points_export_file_set_name(fmurun_w_casemetadata, rmsglobalconfig, poi
 
     meta = dataio.read_metadata(output)
     assert meta["data"]["spec"]["attributes"] == ["WellName"]
+    assert meta["data"]["table_index"] == ["WellName"]
 
 
 def test_points_export_file_set_name_xtgeoheaders(
@@ -295,7 +315,10 @@ def test_points_export_file_as_irap_ascii(
     os.chdir(fmurun_w_casemetadata)
 
     edata = dataio.ExportData(
-        config=rmsglobalconfig, content="depth", name="TopVolantis"
+        config=rmsglobalconfig,
+        content="depth",
+        name="TopVolantis",
+        table_index=["WellName"],
     )
 
     edata.points_fformat = "irap_ascii"  # override
@@ -305,6 +328,10 @@ def test_points_export_file_as_irap_ascii(
     assert output == (
         edata._rootpath / "realization-0/iter-0/share/results/points/topvolantis.poi"
     )
+    # check that data.table_index is not set in the metadata
+    meta = dataio.read_metadata(output)
+    assert "table_index" not in meta["data"]
+
     edata.points_fformat = "csv"  # reset
 
 


### PR DESCRIPTION
Resolves #1146 

PR to enable setting `data.table_index` for points/polygons when they are exported on a tabular format.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
