### PR TITLE
BUG: Read isochores from zones folder

### DIFF
--- a/src/fmu/dataio/export/rms/_utils.py
+++ b/src/fmu/dataio/export/rms/_utils.py
@@ -152,7 +152,9 @@ def get_horizons_in_folder(
     for horizon in project.horizons:
         if not horizon[horizon_folder].is_empty():
             surfaces.append(
-                xtgeo.surface_from_roxar(project, horizon.name, horizon_folder)
+                xtgeo.surface_from_roxar(
+                    project, horizon.name, horizon_folder, stype="horizons"
+                )
             )
     return surfaces
 
@@ -166,7 +168,9 @@ def get_zones_in_folder(project: Any, zone_folder: str) -> list[xtgeo.RegularSur
     surfaces = []
     for zone in project.zones:
         if not zone[zone_folder].is_empty():
-            surfaces.append(xtgeo.surface_from_roxar(project, zone.name, zone_folder))
+            surfaces.append(
+                xtgeo.surface_from_roxar(project, zone.name, zone_folder, stype="zones")
+            )
     return surfaces
 
 
@@ -183,7 +187,11 @@ def get_polygons_in_folder(
         if not horizon[horizon_folder].is_empty():
             polygons.append(
                 xtgeo.polygons_from_roxar(
-                    project, horizon.name, horizon_folder, attributes=attributes
+                    project,
+                    horizon.name,
+                    horizon_folder,
+                    attributes=attributes,
+                    stype="horizons",
                 )
             )
     return polygons

--- a/tests/test_export_rms/test_utils.py
+++ b/tests/test_export_rms/test_utils.py
@@ -31,7 +31,7 @@ def test_get_horizons_in_folder(mock_project_variable):
     # Mock xtgeo.surface_from_roxar to return just the surface name
     with mock.patch(
         "xtgeo.surface_from_roxar",
-        side_effect=lambda _project, name, _category: name,
+        side_effect=lambda _project, name, _category, stype: name,
     ):
         surfaces = get_horizons_in_folder(mock_project_variable, horizon_folder)
 
@@ -83,7 +83,7 @@ def test_get_zones_in_folder(mock_project_variable):
     # Mock xtgeo.surface_from_roxar to return just the surface name
     with mock.patch(
         "xtgeo.surface_from_roxar",
-        side_effect=lambda _project, name, _category: name,
+        side_effect=lambda _project, name, _category, stype: name,
     ):
         zones = get_zones_in_folder(mock_project_variable, zone_folder)
 


### PR DESCRIPTION
Resolves #1156

PR to fix that the export_structure_depth_isochores reads from the zones folder instead of the horizons folder.

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [ ] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [ ] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [ ] Checked the boxes in this checklist ✅
