### PR TITLE
TST: Remove path unlinking since path is a tmp_path fixture

### DIFF
--- a/tests/test_units/test_table.py
+++ b/tests/test_units/test_table.py
@@ -14,7 +14,7 @@ from fmu.dataio.providers.objectdata._provider import objectdata_provider_factor
 from fmu.dataio.providers.objectdata._tables import _derive_index
 
 
-def _read_dict(file_path: str) -> None:
+def _read_dict(file_path: str) -> dict:
     """Reads text file into dictionary
     Args:
         file_path (string): path to generated file
@@ -23,10 +23,7 @@ def _read_dict(file_path: str) -> None:
     """
     path = Path(file_path)
     meta_path = path.parent / f".{path.name}.yml"
-    meta = yaml_load(meta_path)
-    path.unlink()
-    meta_path.unlink()
-    return meta
+    return yaml_load(meta_path)
 
 
 def assert_list_and_answer(index, answer, field_to_check):


### PR DESCRIPTION
Resolves #1087

Fixed issue with the test `test_set_from_exportdata`, which for some occasions when running the tests in distributed mode with `xdist`, fails when trying to unlink paths created under the `tmp_path` pytest fixture directory.

The fix is to remove the unlinking, as `tmp_path` will automatically clean up after the test have been run. As the test was created before `tmp_path` was used, the theory is that the unlinking of the paths is no longer needed. 

## Checklist

- [X] Tests added (if not, comment why): Test modified
- [X] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [X] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [X] Docstrings are correct and updated
- [X] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [X] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅
