### PR TITLE
FIX: Silence overly strict table_index warning

### DIFF
--- a/src/fmu/dataio/providers/objectdata/_tables.py
+++ b/src/fmu/dataio/providers/objectdata/_tables.py
@@ -47,11 +47,16 @@ def _validate_input_table_index(
         )
 
     if content in STANDARD_TABLE_INDEX_COLUMNS:
-        standard_required_index = STANDARD_TABLE_INDEX_COLUMNS[content].required
-        if set(standard_required_index) != set(table_index):
+        standard_index = STANDARD_TABLE_INDEX_COLUMNS[content]
+
+        has_all_required = all(col in table_index for col in standard_index.required)
+        has_non_standard = any(col not in standard_index.columns for col in table_index)
+
+        if not has_all_required or has_non_standard:
             warnings.warn(
-                "The table index provided deviates from the standard: "
-                f"{standard_required_index}. This may not be allowed in the future.",
+                "The table index provided does not fully comply with the standard. "
+                f"Standard columns: {standard_index.columns}, with required ones: "
+                f"{standard_index.required}. This may not be allowed in the future.",
                 FutureWarning,
             )
 
@@ -67,13 +72,15 @@ def _derive_index_from_standard(
     standard_index = STANDARD_TABLE_INDEX_COLUMNS[content]
 
     table_index = [col for col in standard_index.columns if col in table_columns]
+    has_all_required = all(col in table_index for col in standard_index.required)
+
     if not table_index:
         warnings.warn(
             "Could not detect any standard index columns in table: "
             f"{standard_index.columns}. If the table has index columns they "
             "should be provided as input through the 'table_index' argument."
         )
-    elif set(standard_index.required) != set(table_index):
+    elif not has_all_required:
         warnings.warn(
             "The table provided does not contain all required standard "
             f"table index columns for this content: {standard_index.required}. "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -843,6 +843,7 @@ def fixture_mock_volumes():
             "ZONE": ["B", "A", "C"],
             "LICENSE": ["L3", "L2", "L1"],
             "FLUID": ["oil", "gas", "water"],
+            "REGION": ["N", "S", "E"],
             "nums": [1, 2, 3],
             "OTHER": ["q", "a", "f"],
         }

--- a/tests/test_units/test_contents.py
+++ b/tests/test_units/test_contents.py
@@ -223,13 +223,13 @@ def test_content_regions(polygons, globalconfig2):
     assert meta["data"]["content"] == "regions"
 
 
-def test_content_relperm(dataframe, globalconfig2):
+def test_content_relperm(mock_relperm, globalconfig2):
     """Test export of the relperm content."""
     meta = ExportData(
         config=globalconfig2,
         name="MyName",
         content="relperm",
-    ).generate_metadata(dataframe)
+    ).generate_metadata(mock_relperm)
 
     assert meta["data"]["content"] == "relperm"
 
@@ -251,13 +251,13 @@ def test_content_seismic(polygons, globalconfig2):
     # tested various other places
 
 
-def test_content_simulationtimeseries(dataframe, globalconfig2):
+def test_content_simulationtimeseries(mock_summary, globalconfig2):
     """Test export of the simulationtimeseries content."""
     meta = ExportData(
         config=globalconfig2,
         name="MyName",
         content="simulationtimeseries",
-    ).generate_metadata(dataframe)
+    ).generate_metadata(mock_summary)
 
     assert meta["data"]["content"] == "simulationtimeseries"
 
@@ -290,13 +290,13 @@ def test_content_time(polygons, globalconfig2):
     # tested various other places
 
 
-def test_content_timeseries(dataframe, globalconfig2):
+def test_content_timeseries(mock_summary, globalconfig2):
     """Test export of the timeseries content."""
     meta = ExportData(
         config=globalconfig2,
         name="MyName",
         content="timeseries",
-    ).generate_metadata(dataframe)
+    ).generate_metadata(mock_summary)
 
     assert meta["data"]["content"] == "timeseries"
 
@@ -323,24 +323,24 @@ def test_content_velocity(regsurf, globalconfig2):
     assert meta["data"]["content"] == "velocity"
 
 
-def test_content_volumes(polygons, globalconfig2):
+def test_content_volumes(mock_volumes, globalconfig2):
     """Test export of the volumes content."""
     meta = ExportData(
         config=globalconfig2,
         name="MyName",
         content="volumes",
-    ).generate_metadata(polygons)
+    ).generate_metadata(mock_volumes)
 
     assert meta["data"]["content"] == "volumes"
 
 
-def test_content_wellpicks(dataframe, globalconfig2):
+def test_content_wellpicks(wellpicks, globalconfig2):
     """Test export of the wellpicks content."""
     meta = ExportData(
         config=globalconfig2,
         name="MyName",
         content="wellpicks",
-    ).generate_metadata(dataframe)
+    ).generate_metadata(wellpicks)
 
     assert meta["data"]["content"] == "wellpicks"
 

--- a/tests/test_units/test_table.py
+++ b/tests/test_units/test_table.py
@@ -64,7 +64,7 @@ def test_inplace_volume_index(mock_volumes, globalconfig2, monkeypatch, tmp_path
     # TODO: Refactor tests and move away from outside/inside rms pattern
 
     monkeypatch.chdir(tmp_path)
-    answer = ["FLUID", "ZONE", "LICENSE"]
+    answer = ["FLUID", "ZONE", "REGION", "LICENSE"]
     exd = ExportData(config=globalconfig2, content="volumes", name="baretull")
     path = exd.export(mock_volumes)
     assert_correct_table_index(path, answer)
@@ -131,7 +131,8 @@ def test_set_from_exportdata(mock_volumes, globalconfig2, monkeypatch, tmp_path)
     exd = ExportData(
         config=globalconfig2, table_index=index, content="timeseries", name="baretull"
     )
-    path = exd.export(mock_volumes)
+    with pytest.warns(FutureWarning, match="table index"):
+        path = exd.export(mock_volumes)
     assert_correct_table_index(path, index)
 
 
@@ -145,9 +146,10 @@ def test_set_from_export(mock_volumes, globalconfig2, monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
     index = ["OTHER"]
     exd = ExportData(
-        config=globalconfig2, content="timeseries", table_index=index, name="baretull"
+        config=globalconfig2, content="volumes", table_index=index, name="baretull"
     )
-    path = exd.export(mock_volumes)
+    with pytest.warns(FutureWarning, match="table index"):
+        path = exd.export(mock_volumes)
     assert_correct_table_index(path, index)
 
 


### PR DESCRIPTION
Resolves #1158

PR to fix an too eager warning emitted when comparing the table_index to the standard table_index. 
The warning should only be emitted if required columns are missing or non-standard columns are present.

Also adjusted some tests to have more proper export data to reduce the number of warnings regarding table index when running the tests.  

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
