### PR TITLE
MAINT: Set file extension in each objdataprovider

### DIFF
--- a/src/fmu/dataio/_definitions.py
+++ b/src/fmu/dataio/_definitions.py
@@ -11,45 +11,15 @@ from fmu.dataio._models.fmu_results.enums import Content
 from fmu.dataio.export._enums import InplaceVolumes
 
 
-class ValidFormats(Enum):
-    surface = {
-        "irap_binary": ".gri",
-    }
-
-    grid = {
-        "hdf": ".hdf",
-        "roff": ".roff",
-    }
-
-    cube = {
-        "segy": ".segy",
-    }
-
-    table = {
-        "hdf": ".hdf",
-        "csv": ".csv",
-        "parquet": ".parquet",
-    }
-
-    polygons = {
-        "hdf": ".hdf",
-        "csv": ".csv",  # columns will be X Y Z, ID
-        "csv|xtgeo": ".csv",  # use default xtgeo columns: X_UTME, ... POLY_ID
-        "irap_ascii": ".pol",
-        "parquet": ".parquet",
-    }
-
-    points = {
-        "hdf": ".hdf",
-        "csv": ".csv",  # columns will be X Y Z
-        "csv|xtgeo": ".csv",  # use default xtgeo columns: X_UTME, Y_UTMN, Z_TVDSS
-        "irap_ascii": ".poi",
-        "parquet": ".parquet",
-    }
-
-    dictionary = {
-        "json": ".json",
-    }
+class FileExtension(str, Enum):
+    gri = ".gri"
+    roff = ".roff"
+    segy = ".segy"
+    csv = ".csv"
+    parquet = ".parquet"
+    pol = ".pol"
+    poi = ".poi"
+    json = ".json"
 
 
 class ExportFolder(str, Enum):

--- a/src/fmu/dataio/providers/objectdata/_base.py
+++ b/src/fmu/dataio/providers/objectdata/_base.py
@@ -17,7 +17,6 @@ from fmu.dataio._models.fmu_results.global_configuration import (
     StratigraphyElement,
 )
 from fmu.dataio._utils import generate_description, md5sum
-from fmu.dataio.exceptions import ConfigurationError
 from fmu.dataio.providers._base import Provider
 from fmu.dataio.providers.objectdata._export_models import (
     UnsetData,
@@ -29,7 +28,6 @@ from fmu.dataio.providers.objectdata._export_models import (
 if TYPE_CHECKING:
     from pydantic import BaseModel
 
-    from fmu.dataio._definitions import ValidFormats
     from fmu.dataio._models.fmu_results.data import (
         BoundingBox2D,
         BoundingBox3D,
@@ -303,14 +301,3 @@ class ObjectDataProvider(Provider):
         self.time0, self.time1 = start.value, stop.value if stop else None
 
         return Time(t0=start, t1=stop)
-
-    @staticmethod
-    def _validate_get_ext(fmt: str, validator: ValidFormats) -> str:
-        """Validate that fmt (file format) matches data and return legal extension."""
-        try:
-            return validator.value[fmt]
-        except KeyError as e:
-            raise ConfigurationError(
-                f"The file format {fmt} is not supported. ",
-                f"Valid formats are: {list(validator.value.keys())}",
-            ) from e

--- a/src/fmu/dataio/providers/objectdata/_faultroom.py
+++ b/src/fmu/dataio/providers/objectdata/_faultroom.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Final
 
-from fmu.dataio._definitions import ExportFolder, ValidFormats
+from fmu.dataio._definitions import ExportFolder, FileExtension
 from fmu.dataio._logging import null_logger
 from fmu.dataio._models.fmu_results.data import BoundingBox3D
 from fmu.dataio._models.fmu_results.enums import FileFormat, FMUClass, Layout
@@ -41,11 +41,11 @@ class FaultRoomSurfaceProvider(ObjectDataProvider):
 
     @property
     def extension(self) -> str:
-        return self._validate_get_ext(self.fmt.value, ValidFormats.dictionary)
+        return FileExtension.json.value
 
     @property
     def fmt(self) -> FileFormat:
-        return FileFormat(self.dataio.dict_fformat)
+        return FileFormat.json
 
     @property
     def layout(self) -> Layout:

--- a/src/fmu/dataio/providers/objectdata/_provider.py
+++ b/src/fmu/dataio/providers/objectdata/_provider.py
@@ -95,7 +95,7 @@ import pandas as pd
 import pyarrow as pa
 import xtgeo
 
-from fmu.dataio._definitions import ExportFolder, ValidFormats
+from fmu.dataio._definitions import ExportFolder, FileExtension
 from fmu.dataio._logging import null_logger
 from fmu.dataio._models.fmu_results.enums import FileFormat, FMUClass, Layout
 from fmu.dataio.readers import FaultRoomSurface
@@ -196,11 +196,11 @@ class DictionaryDataProvider(ObjectDataProvider):
 
     @property
     def extension(self) -> str:
-        return self._validate_get_ext(self.fmt.value, ValidFormats.dictionary)
+        return FileExtension.json.value
 
     @property
     def fmt(self) -> FileFormat:
-        return FileFormat(self.dataio.dict_fformat)
+        return FileFormat.json
 
     @property
     def layout(self) -> Layout:

--- a/src/fmu/dataio/providers/objectdata/_tables.py
+++ b/src/fmu/dataio/providers/objectdata/_tables.py
@@ -10,11 +10,12 @@ import pyarrow.parquet as pq
 from fmu.dataio._definitions import (
     STANDARD_TABLE_INDEX_COLUMNS,
     ExportFolder,
-    ValidFormats,
+    FileExtension,
 )
 from fmu.dataio._logging import null_logger
 from fmu.dataio._models.fmu_results.enums import Content, FileFormat, FMUClass, Layout
 from fmu.dataio._models.fmu_results.specification import TableSpecification
+from fmu.dataio.exceptions import ConfigurationError
 
 from ._base import (
     ObjectDataProvider,
@@ -157,7 +158,16 @@ class DataFrameDataProvider(ObjectDataProvider):
 
     @property
     def extension(self) -> str:
-        return self._validate_get_ext(self.fmt.value, ValidFormats.table)
+        if self.fmt == FileFormat.parquet:
+            return FileExtension.parquet.value
+
+        if self.fmt == FileFormat.csv:
+            return FileExtension.csv.value
+
+        raise ConfigurationError(
+            f"The file format {self.fmt.value} is not supported. ",
+            f"Valid formats are: {['parquet', 'csv']}",
+        )
 
     @property
     def fmt(self) -> FileFormat:
@@ -217,11 +227,11 @@ class ArrowTableDataProvider(ObjectDataProvider):
 
     @property
     def extension(self) -> str:
-        return self._validate_get_ext(self.fmt.value, ValidFormats.table)
+        return FileExtension.parquet.value
 
     @property
     def fmt(self) -> FileFormat:
-        return FileFormat(self.dataio.arrow_fformat)
+        return FileFormat.parquet
 
     @property
     def layout(self) -> Layout:

--- a/src/fmu/dataio/providers/objectdata/_xtgeo.py
+++ b/src/fmu/dataio/providers/objectdata/_xtgeo.py
@@ -9,7 +9,7 @@ import numpy as np
 import pyarrow as pa
 import pyarrow.parquet as pq
 
-from fmu.dataio._definitions import ExportFolder, ValidFormats
+from fmu.dataio._definitions import ExportFolder, FileExtension
 from fmu.dataio._logging import null_logger
 from fmu.dataio._models.fmu_results.data import BoundingBox2D, BoundingBox3D, Geometry
 from fmu.dataio._models.fmu_results.enums import FileFormat, FMUClass, Layout
@@ -23,6 +23,7 @@ from fmu.dataio._models.fmu_results.specification import (
     ZoneDefinition,
 )
 from fmu.dataio._utils import get_geometry_ref, npfloat_to_float
+from fmu.dataio.exceptions import ConfigurationError
 
 from ._base import ObjectDataProvider
 from ._tables import _derive_index
@@ -66,11 +67,11 @@ class RegularSurfaceDataProvider(ObjectDataProvider):
 
     @property
     def extension(self) -> str:
-        return self._validate_get_ext(self.fmt.value, ValidFormats.surface)
+        return FileExtension.gri.value
 
     @property
     def fmt(self) -> FileFormat:
-        return FileFormat(self.dataio.surface_fformat)
+        return FileFormat.irap_binary
 
     @property
     def layout(self) -> Layout:
@@ -156,7 +157,19 @@ class PolygonsDataProvider(ObjectDataProvider):
 
     @property
     def extension(self) -> str:
-        return self._validate_get_ext(self.fmt.value, ValidFormats.polygons)
+        if self.fmt == FileFormat.irap_ascii:
+            return FileExtension.pol.value
+
+        if self.fmt == FileFormat.parquet:
+            return FileExtension.parquet.value
+
+        if self.fmt in [FileFormat.csv, FileFormat.csv_xtgeo]:
+            return FileExtension.csv.value
+
+        raise ConfigurationError(
+            f"The file format {self.fmt.value} is not supported. ",
+            f"Valid formats are: {['irap_ascii', 'csv', 'csv|xtgeo', 'parquet']}",
+        )
 
     @property
     def fmt(self) -> FileFormat:
@@ -257,7 +270,19 @@ class PointsDataProvider(ObjectDataProvider):
 
     @property
     def extension(self) -> str:
-        return self._validate_get_ext(self.fmt.value, ValidFormats.points)
+        if self.fmt == FileFormat.irap_ascii:
+            return FileExtension.poi.value
+
+        if self.fmt == FileFormat.parquet:
+            return FileExtension.parquet.value
+
+        if self.fmt in [FileFormat.csv, FileFormat.csv_xtgeo]:
+            return FileExtension.csv.value
+
+        raise ConfigurationError(
+            f"The file format {self.fmt.value} is not supported. ",
+            f"Valid formats are: {['irap_ascii', 'csv', 'csv|xtgeo', 'parquet']}",
+        )
 
     @property
     def fmt(self) -> FileFormat:
@@ -349,11 +374,11 @@ class CubeDataProvider(ObjectDataProvider):
 
     @property
     def extension(self) -> str:
-        return self._validate_get_ext(self.fmt.value, ValidFormats.cube)
+        return FileExtension.segy.value
 
     @property
     def fmt(self) -> FileFormat:
-        return FileFormat(self.dataio.cube_fformat)
+        return FileFormat.segy
 
     @property
     def layout(self) -> Layout:
@@ -437,11 +462,11 @@ class CPGridDataProvider(ObjectDataProvider):
 
     @property
     def extension(self) -> str:
-        return self._validate_get_ext(self.fmt.value, ValidFormats.grid)
+        return FileExtension.roff.value
 
     @property
     def fmt(self) -> FileFormat:
-        return FileFormat(self.dataio.grid_fformat)
+        return FileFormat.roff
 
     @property
     def layout(self) -> Layout:
@@ -527,11 +552,11 @@ class CPGridPropertyDataProvider(ObjectDataProvider):
 
     @property
     def extension(self) -> str:
-        return self._validate_get_ext(self.fmt.value, ValidFormats.grid)
+        return FileExtension.roff.value
 
     @property
     def fmt(self) -> FileFormat:
-        return FileFormat(self.dataio.grid_fformat)
+        return FileFormat.roff
 
     @property
     def layout(self) -> Layout:

--- a/tests/test_units/test_objectdataprovider_class.py
+++ b/tests/test_units/test_objectdataprovider_class.py
@@ -7,7 +7,6 @@ import pytest
 import yaml
 
 from fmu import dataio
-from fmu.dataio._definitions import ValidFormats
 from fmu.dataio._models.fmu_results.specification import FaultRoomSurfaceSpecification
 from fmu.dataio.exceptions import ConfigurationError
 from fmu.dataio.providers.objectdata._faultroom import FaultRoomSurfaceProvider
@@ -69,20 +68,20 @@ def test_objectdata_faultroom_fault_juxtaposition_get_stratigraphy_differ(
 def test_objectdata_regularsurface_validate_extension(regsurf, edataobj1):
     """Test a valid extension for RegularSurface object."""
 
-    ext = objectdata_provider_factory(regsurf, edataobj1)._validate_get_ext(
-        "irap_binary", ValidFormats.surface
-    )
+    objdata = objectdata_provider_factory(regsurf, edataobj1)
 
-    assert ext == ".gri"
+    assert objdata.extension == ".gri"
 
 
-def test_objectdata_regularsurface_validate_extension_shall_fail(regsurf, edataobj1):
-    """Test an invalid extension for RegularSurface object."""
+def test_objectdata_table_validate_extension_shall_fail(dataframe, edataobj1):
+    """Test an invalid extension for a table object."""
+
+    edataobj1.table_fformat = "roff"  # set to invalid format
 
     with pytest.raises(ConfigurationError):
-        objectdata_provider_factory(regsurf, edataobj1)._validate_get_ext(
-            "some_invalid", ValidFormats.surface
-        )
+        ext = objectdata_provider_factory(dataframe, edataobj1).extension
+        assert ext == ".roff"
+    edataobj1.table_fformat = None  # reset to default
 
 
 def test_objectdata_regularsurface_spec_bbox(regsurf, edataobj1):


### PR DESCRIPTION
Resolves #1165
Resolves #1071

PR to remove the `ValidFormats` and set the file `extension` property directly inside each `objectdataprovider` to centralize the logic and to make it more clear what is used as extension.
Also dropped the `hdf` format, it was never possible to export with this format anyway. 

Modified a couple of tests, but existing tests should be sufficient here.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
