### PR TITLE
TST: Remove path unlinking since path is a tmp_path fixture (#1159)

### DIFF
--- a/.github/workflows/ci-fmudataio.yml
+++ b/.github/workflows/ci-fmudataio.yml
@@ -2,7 +2,7 @@ name: Test
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, "version-*"]
   schedule:
     - cron: "0 0 * * *"
 
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8"] #Only test with Python 3.8 for this branch
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -2,14 +2,14 @@ name: Mypy
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, "version-*"]
 
 jobs:
   mypy:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.10", "3.11", "3.12"]
+        python-version: ["3.8"] #Only test with Python 3.8 for this branch
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/schemas-up-to-date.yml
+++ b/.github/workflows/schemas-up-to-date.yml
@@ -2,7 +2,7 @@ name: Schema up to date
 
 on:
   pull_request:
-    branches: [main, staging]
+    branches: [main, staging, "version-*"]
   schedule:
     - cron: "0 0 * * *"
 

--- a/tests/test_units/test_table.py
+++ b/tests/test_units/test_table.py
@@ -14,7 +14,7 @@ from fmu.dataio.providers.objectdata._provider import objectdata_provider_factor
 from fmu.dataio.providers.objectdata._tables import _derive_index
 
 
-def _read_dict(file_path: str) -> None:
+def _read_dict(file_path: str) -> dict:
     """Reads text file into dictionary
     Args:
         file_path (string): path to generated file
@@ -23,10 +23,7 @@ def _read_dict(file_path: str) -> None:
     """
     path = Path(file_path)
     meta_path = path.parent / f".{path.name}.yml"
-    meta = yaml_load(meta_path)
-    path.unlink()
-    meta_path.unlink()
-    return meta
+    return yaml_load(meta_path)
 
 
 def assert_list_and_answer(index, answer, field_to_check):


### PR DESCRIPTION
Resolves #1087 (also for Python 3.8)

Fixed issue with the test `test_set_from_exportdata` which was solved through https://github.com/equinor/fmu-dataio/pull/1159 for the `main` branch, but that also needs to be fixed for the `fmu-dataio` version that still supports `Python 3.8`.

This is simply a cherry-pick of 605e9e1c7a785bbee2255b57e1de6748e9213500 

## Checklist

- [X] Tests added (if not, comment why)
- [X] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [X] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [X] Docstrings are correct and updated
- [X] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [X] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅
