### PR TITLE
ENH: Set table_index to None instead of empty list for points

### DIFF
--- a/src/fmu/dataio/providers/objectdata/_xtgeo.py
+++ b/src/fmu/dataio/providers/objectdata/_xtgeo.py
@@ -301,10 +301,13 @@ class PointsDataProvider(ObjectDataProvider):
         if self.fmt == FileFormat.irap_ascii:
             return None
 
-        return _derive_index(
-            table_index=self.dataio.table_index,
-            table_columns=list(self.obj_dataframe.columns),
-            content=self.dataio._get_content_enum(),
+        return (
+            _derive_index(
+                table_index=self.dataio.table_index,
+                table_columns=list(self.obj_dataframe.columns),
+                content=self.dataio._get_content_enum(),
+            )
+            or None
         )
 
     @property

--- a/tests/test_units/test_ert_context.py
+++ b/tests/test_units/test_ert_context.py
@@ -328,6 +328,28 @@ def test_points_export_file_set_name_xtgeoheaders(
     dataio.ExportData.points_fformat = "csv"
 
 
+def test_points_export_file_as_parquet_no_table_index(
+    fmurun_w_casemetadata, rmsglobalconfig, points
+):
+    """Export the points to file without table index."""
+
+    logger.info("Active folder is %s", fmurun_w_casemetadata)
+    os.chdir(fmurun_w_casemetadata)
+
+    edata = dataio.ExportData(
+        config=rmsglobalconfig, content="depth", name="TopVolantis"
+    )
+
+    edata.points_fformat = "parquet"  # override
+    output = Path(edata.export(points))
+
+    meta = dataio.read_metadata(output)
+    assert meta["data"]["format"] == "parquet"
+    assert "table_index" not in meta["data"]
+
+    edata.points_fformat = "csv"  # reset
+
+
 def test_points_export_file_as_irap_ascii(
     fmurun_w_casemetadata, rmsglobalconfig, points
 ):


### PR DESCRIPTION
Use same `table_index` logic for points as for polygons #1172, i.e. set it to `None` if not provided.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
