### PR TITLE
SCHEMA: Remove iterative_ensemble_smoother as valid ert.simulation_mode

### DIFF
--- a/examples/example_metadata/fmu_case.yml
+++ b/examples/example_metadata/fmu_case.yml
@@ -32,10 +32,12 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-04-24T16:56:20.248005Z'
+- datetime: '2025-04-28T11:54:56.698683Z'
   event: created
   sysinfo:
     fmu-dataio:
+      version: dummy_version
+    komodo:
       version: dummy_version
     operating_system:
       hostname: dummy_hostname

--- a/examples/example_metadata/polygons_field_outline.yml
+++ b/examples/example_metadata/polygons_field_outline.yml
@@ -39,7 +39,6 @@ data:
     num_rows: 1059
     size: 4236
   stratigraphic: true
-  table_index: []
   tagname: polygons_field_outline
   undef_is_zero: false
   unit: m
@@ -98,10 +97,12 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-04-24T16:56:22.675819Z'
+- datetime: '2025-04-28T11:55:00.056349Z'
   event: created
   sysinfo:
     fmu-dataio:
+      version: dummy_version
+    komodo:
       version: dummy_version
     operating_system:
       hostname: dummy_hostname

--- a/examples/example_metadata/polygons_field_region.yml
+++ b/examples/example_metadata/polygons_field_region.yml
@@ -39,7 +39,6 @@ data:
     num_rows: 1059
     size: 4236
   stratigraphic: true
-  table_index: []
   tagname: polygons_field_region
   undef_is_zero: false
   unit: m
@@ -98,10 +97,12 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-04-24T16:56:22.656132Z'
+- datetime: '2025-04-28T11:55:00.030803Z'
   event: created
   sysinfo:
     fmu-dataio:
+      version: dummy_version
+    komodo:
       version: dummy_version
     operating_system:
       hostname: dummy_hostname

--- a/examples/example_metadata/preprocessed_surface_depth.yml
+++ b/examples/example_metadata/preprocessed_surface_depth.yml
@@ -80,10 +80,12 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-04-24T16:56:26.236491Z'
+- datetime: '2025-04-28T11:55:04.480798Z'
   event: created
   sysinfo:
     fmu-dataio:
+      version: dummy_version
+    komodo:
       version: dummy_version
     operating_system:
       hostname: dummy_hostname

--- a/examples/example_metadata/surface_depth.yml
+++ b/examples/example_metadata/surface_depth.yml
@@ -94,10 +94,12 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-04-24T16:56:27.450355Z'
+- datetime: '2025-04-28T11:55:05.958325Z'
   event: created
   sysinfo:
     fmu-dataio:
+      version: dummy_version
+    komodo:
       version: dummy_version
     operating_system:
       hostname: dummy_hostname

--- a/examples/example_metadata/surface_fluid_contact.yml
+++ b/examples/example_metadata/surface_fluid_contact.yml
@@ -97,10 +97,12 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-04-24T16:56:27.470508Z'
+- datetime: '2025-04-28T11:55:06.009504Z'
   event: created
   sysinfo:
     fmu-dataio:
+      version: dummy_version
+    komodo:
       version: dummy_version
     operating_system:
       hostname: dummy_hostname

--- a/examples/example_metadata/surface_seismic_amplitude.yml
+++ b/examples/example_metadata/surface_seismic_amplitude.yml
@@ -115,10 +115,12 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-04-24T16:56:27.491622Z'
+- datetime: '2025-04-28T11:55:06.058375Z'
   event: created
   sysinfo:
     fmu-dataio:
+      version: dummy_version
+    komodo:
       version: dummy_version
     operating_system:
       hostname: dummy_hostname

--- a/examples/example_metadata/table_inplace_volumes.yml
+++ b/examples/example_metadata/table_inplace_volumes.yml
@@ -52,7 +52,7 @@ display:
   name: geogrid
 file:
   absolute_path: /some/absolute/path/
-  checksum_md5: 173c646133f5a47c9bfbc4432a0a2812
+  checksum_md5: 0cb778f91e6074c471b4bbce1f919165
   relative_path: example_exports/share/results/tables/geogrid--volumes.csv
 fmu:
   case:
@@ -102,10 +102,12 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-04-24T16:56:30.062548Z'
+- datetime: '2025-04-28T11:55:09.806278Z'
   event: created
   sysinfo:
     fmu-dataio:
+      version: dummy_version
+    komodo:
       version: dummy_version
     operating_system:
       hostname: dummy_hostname

--- a/schemas/0.11.0/fmu_results.json
+++ b/schemas/0.11.0/fmu_results.json
@@ -1139,7 +1139,6 @@
         "ensemble_smoother",
         "es_mda",
         "evaluate_ensemble",
-        "iterative_ensemble_smoother",
         "manual_update",
         "test_run",
         "workflow"

--- a/src/fmu/dataio/_models/fmu_results/enums.py
+++ b/src/fmu/dataio/_models/fmu_results/enums.py
@@ -74,9 +74,6 @@ class ErtSimulationMode(str, Enum):
     ensemble_smoother = "ensemble_smoother"
     es_mda = "es_mda"
     evaluate_ensemble = "evaluate_ensemble"
-    # TODO: Remove 'iterative_ensemble_smoother' when Python 3.8 deprecated. It was
-    # removed with Ert 14.0.0.
-    iterative_ensemble_smoother = "iterative_ensemble_smoother"
     manual_update = "manual_update"
     test_run = "test_run"
     workflow = "workflow"

--- a/src/fmu/dataio/_models/fmu_results/fmu_results.py
+++ b/src/fmu/dataio/_models/fmu_results/fmu_results.py
@@ -52,6 +52,8 @@ class FmuResultsSchema(SchemaBase):
 
     - improved validation of grid numbering
     - improved validation of grid increments
+    - `fmu.ert.simulation_mode` no longer supports `iterative_ensemble_smoother`
+
 
 
     #### 0.10.0

--- a/tests/test_units/test_fmuprovider_class.py
+++ b/tests/test_units/test_fmuprovider_class.py
@@ -415,8 +415,6 @@ def test_ert_simulation_modes_one_to_one() -> None:
 
     - `MODULE_MODE` is skipped due to seemingly being relevant to Ert internally.
       The modes are duplicated there.
-    - `iterative_ensemble_mode` was removed in Ert 14. It must be ignored here for as
-      long as we support Python 3.8.
     """
     ert_mode_definitions = importlib.import_module("ert.mode_definitions")
     ert_modes = {
@@ -427,10 +425,5 @@ def test_ert_simulation_modes_one_to_one() -> None:
         and isinstance(getattr(ert_mode_definitions, name), str)
     }
     dataio_known_modes = {mode.value for mode in ErtSimulationMode}
-
-    # TODO: Remove this check when Python 3.8 deprecated.
-    ert_version = importlib.metadata.version("ert")
-    if int(ert_version.split(".")[0]) >= 14:
-        dataio_known_modes.discard("iterative_ensemble_smoother")
 
     assert ert_modes == dataio_known_modes


### PR DESCRIPTION
Resolves #1052 

PR to remove the `iterative_ensemble_smoother` valid `ert.simulation_mode.` It was removed in Ert 14.

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
