### PR TITLE
SCHEMA: Add `fmu.ert.experiment.id` to contractuals

### DIFF
--- a/examples/example_metadata/fmu_case.yml
+++ b/examples/example_metadata/fmu_case.yml
@@ -32,7 +32,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-04-28T11:54:56.698683Z'
+- datetime: '2025-05-05T11:10:30.365157Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/polygons_field_outline.yml
+++ b/examples/example_metadata/polygons_field_outline.yml
@@ -97,7 +97,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-04-28T11:55:00.056349Z'
+- datetime: '2025-05-05T11:10:33.634725Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/polygons_field_region.yml
+++ b/examples/example_metadata/polygons_field_region.yml
@@ -97,7 +97,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-04-28T11:55:00.030803Z'
+- datetime: '2025-05-05T11:10:33.611243Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/preprocessed_surface_depth.yml
+++ b/examples/example_metadata/preprocessed_surface_depth.yml
@@ -80,7 +80,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-04-28T11:55:04.480798Z'
+- datetime: '2025-05-05T11:10:38.129851Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/surface_depth.yml
+++ b/examples/example_metadata/surface_depth.yml
@@ -94,7 +94,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-04-28T11:55:05.958325Z'
+- datetime: '2025-05-05T11:10:39.630925Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/surface_fluid_contact.yml
+++ b/examples/example_metadata/surface_fluid_contact.yml
@@ -97,7 +97,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-04-28T11:55:06.009504Z'
+- datetime: '2025-05-05T11:10:39.683189Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/surface_seismic_amplitude.yml
+++ b/examples/example_metadata/surface_seismic_amplitude.yml
@@ -115,7 +115,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-04-28T11:55:06.058375Z'
+- datetime: '2025-05-05T11:10:39.732619Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/table_inplace_volumes.yml
+++ b/examples/example_metadata/table_inplace_volumes.yml
@@ -102,7 +102,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-04-28T11:55:09.806278Z'
+- datetime: '2025-05-05T11:10:43.384028Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/schemas/0.11.0/fmu_results.json
+++ b/schemas/0.11.0/fmu_results.json
@@ -28,6 +28,7 @@
     "fmu.context.stage",
     "fmu.ensemble.name",
     "fmu.ensemble.uuid",
+    "fmu.ert.experiment.id",
     "fmu.iteration.name",
     "fmu.iteration.uuid",
     "fmu.model",

--- a/src/fmu/dataio/_models/fmu_results/fmu_results.py
+++ b/src/fmu/dataio/_models/fmu_results/fmu_results.py
@@ -50,11 +50,10 @@ class FmuResultsSchema(SchemaBase):
     VERSION_CHANGELOG: str = """
     #### 0.11.0
 
+    - `fmu.ert.experiment.id` is added as contractual field
     - improved validation of grid numbering
     - improved validation of grid increments
     - `fmu.ert.simulation_mode` no longer supports `iterative_ensemble_smoother`
-
-
 
     #### 0.10.0
 
@@ -145,6 +144,7 @@ class FmuResultsSchema(SchemaBase):
         "fmu.context.stage",
         "fmu.ensemble.name",
         "fmu.ensemble.uuid",
+        "fmu.ert.experiment.id",
         "fmu.iteration.name",
         "fmu.iteration.uuid",
         "fmu.model",


### PR DESCRIPTION
Resolves #1150 

PR to add `fmu.ert.experiment.id` to the contractuals to make it searchable by elastic search.

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
