### PR TITLE
ENH, SCHEMA: Added file.runpath_relative_path field to outgoing metadata

### DIFF
--- a/examples/example_metadata/fmu_case.yml
+++ b/examples/example_metadata/fmu_case.yml
@@ -32,7 +32,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-05-06T20:30:21.346007Z'
+- datetime: '2025-05-07T18:03:29.805945Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/polygons_field_outline.yml
+++ b/examples/example_metadata/polygons_field_outline.yml
@@ -49,6 +49,7 @@ file:
   absolute_path: /some/absolute/path/
   checksum_md5: 370519102b2362716cdf5b8b67e44ed0
   relative_path: example_exports/share/results/polygons/volantis_gp_base--polygons_field_outline.csv
+  runpath_relative_path: share/results/polygons/volantis_gp_base--polygons_field_outline.csv
 fmu:
   case:
     name: MyCase
@@ -97,7 +98,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-05-06T20:30:24.722469Z'
+- datetime: '2025-05-07T18:03:33.325795Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/polygons_field_region.yml
+++ b/examples/example_metadata/polygons_field_region.yml
@@ -49,6 +49,7 @@ file:
   absolute_path: /some/absolute/path/
   checksum_md5: 370519102b2362716cdf5b8b67e44ed0
   relative_path: example_exports/share/results/polygons/volantis_gp_base--polygons_field_region.csv
+  runpath_relative_path: share/results/polygons/volantis_gp_base--polygons_field_region.csv
 fmu:
   case:
     name: MyCase
@@ -97,7 +98,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-05-06T20:30:24.698799Z'
+- datetime: '2025-05-07T18:03:33.300702Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/preprocessed_surface_depth.yml
+++ b/examples/example_metadata/preprocessed_surface_depth.yml
@@ -80,7 +80,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-05-06T20:30:29.369227Z'
+- datetime: '2025-05-07T18:03:38.298586Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/surface_depth.yml
+++ b/examples/example_metadata/surface_depth.yml
@@ -46,6 +46,7 @@ file:
   absolute_path: /some/absolute/path/
   checksum_md5: ab0fb42049138871749c6c367d2d094f
   relative_path: example_exports/share/results/maps/topvolantis--ds_extract_geogrid.gri
+  runpath_relative_path: share/results/maps/topvolantis--ds_extract_geogrid.gri
 fmu:
   case:
     name: MyCase
@@ -94,7 +95,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-05-06T20:30:30.929283Z'
+- datetime: '2025-05-07T18:03:40.026613Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/surface_fluid_contact.yml
+++ b/examples/example_metadata/surface_fluid_contact.yml
@@ -49,6 +49,7 @@ file:
   absolute_path: /some/absolute/path/
   checksum_md5: ab0fb42049138871749c6c367d2d094f
   relative_path: example_exports/share/results/maps/surface_fluid_contact.gri
+  runpath_relative_path: share/results/maps/surface_fluid_contact.gri
 fmu:
   case:
     name: MyCase
@@ -97,7 +98,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-05-06T20:30:30.978106Z'
+- datetime: '2025-05-07T18:03:40.081814Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/surface_seismic_amplitude.yml
+++ b/examples/example_metadata/surface_seismic_amplitude.yml
@@ -67,6 +67,7 @@ file:
   absolute_path: /some/absolute/path/
   checksum_md5: ab0fb42049138871749c6c367d2d094f
   relative_path: example_exports/share/results/maps/surface_seismic_amplitude--20201028_20201028.gri
+  runpath_relative_path: share/results/maps/surface_seismic_amplitude--20201028_20201028.gri
 fmu:
   case:
     name: MyCase
@@ -115,7 +116,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-05-06T20:30:31.030166Z'
+- datetime: '2025-05-07T18:03:40.142761Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/table_inplace_volumes.yml
+++ b/examples/example_metadata/table_inplace_volumes.yml
@@ -54,6 +54,7 @@ file:
   absolute_path: /some/absolute/path/
   checksum_md5: 0cb778f91e6074c471b4bbce1f919165
   relative_path: example_exports/share/results/tables/geogrid--volumes.csv
+  runpath_relative_path: share/results/tables/geogrid--volumes.csv
 fmu:
   case:
     name: MyCase
@@ -102,7 +103,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-05-06T20:30:34.677956Z'
+- datetime: '2025-05-07T18:03:44.195246Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/schemas/0.11.0/fmu_results.json
+++ b/schemas/0.11.0/fmu_results.json
@@ -3334,10 +3334,25 @@
         },
         "relative_path": {
           "examples": [
-            "share/results/maps/volantis_gp_base--depth.gri"
+            "realization-0/iter-0/share/results/maps/volantis_gp_base--depth.gri"
           ],
           "title": "Relative Path",
           "type": "string"
+        },
+        "runpath_relative_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "share/results/maps/volantis_gp_base--depth.gri"
+          ],
+          "title": "Runpath Relative Path"
         },
         "size_bytes": {
           "anyOf": [

--- a/src/fmu/dataio/_models/fmu_results/fields.py
+++ b/src/fmu/dataio/_models/fmu_results/fields.py
@@ -94,9 +94,20 @@ class File(BaseModel):
     """The absolute path of a file, e.g. /scratch/field/user/case/etc."""
 
     relative_path: Path = Field(
-        examples=["share/results/maps/volantis_gp_base--depth.gri"],
+        examples=[
+            "realization-0/iter-0/share/results/maps/volantis_gp_base--depth.gri"
+        ],
     )
     """The path of a file relative to the case root."""
+
+    runpath_relative_path: Path | None = Field(
+        default=None,
+        examples=["share/results/maps/volantis_gp_base--depth.gri"],
+    )
+    """
+    The path of a file relative to the runpath root of the realization.
+    For files exported with the fmu.context ``case`` the field will be None.
+    """
 
     checksum_md5: MD5HashStr = Field(examples=["fa4d055b113ae5282796e328cde0ffa4"])
     """A valid MD5 checksum of the file."""

--- a/src/fmu/dataio/_models/fmu_results/fmu_results.py
+++ b/src/fmu/dataio/_models/fmu_results/fmu_results.py
@@ -50,6 +50,7 @@ class FmuResultsSchema(SchemaBase):
     VERSION_CHANGELOG: str = """
     #### 0.11.0
 
+    - `file.runpath_relative_path` added as optional field
     - `fmu.ert.experiment.id` is added as contractual field
     - improved validation of grid numbering
     - improved validation of grid increments

--- a/tests/test_units/test_dataio.py
+++ b/tests/test_units/test_dataio.py
@@ -1452,3 +1452,46 @@ def test_export_with_standard_result_invalid_config(mock_volumes):
                 name=StandardResultName.inplace_volumes
             ),
         )
+
+
+def test_file_paths_realization_context(
+    fmurun_w_casemetadata, globalconfig2, monkeypatch, regsurf
+):
+    """
+    Testing the file paths set in the metadata with a realization context.
+    Here the file.runpath_relative_path and the file.relative_path should not be equal.
+    """
+    monkeypatch.chdir(fmurun_w_casemetadata)
+
+    meta = ExportData(
+        config=globalconfig2, name="myname", content="depth"
+    ).generate_metadata(regsurf)
+
+    share_location = "share/results/maps/myname.gri"
+
+    assert meta["file"]["runpath_relative_path"] == share_location
+    assert meta["file"]["relative_path"] == "realization-0/iter-0/" + share_location
+    assert meta["file"]["absolute_path"] == str(fmurun_w_casemetadata / share_location)
+
+
+def test_file_paths_case_context(fmurun_w_casemetadata, globalconfig2, regsurf):
+    """
+    Testing the paths set in the filedata provider with a case context.
+    Here the file.runpath_relative_path should not be present.
+    """
+
+    casepath = fmurun_w_casemetadata.parent.parent
+
+    meta = ExportData(
+        config=globalconfig2,
+        name="myname",
+        content="depth",
+        casepath=casepath,
+        fmu_context="case",
+    ).generate_metadata(regsurf)
+
+    share_location = "share/results/maps/myname.gri"
+
+    assert "runpath_relative_path" not in meta["file"]
+    assert meta["file"]["relative_path"] == share_location
+    assert meta["file"]["absolute_path"] == str(casepath / share_location)


### PR DESCRIPTION
Adresses #644 

PR to start adding a `file.runpath_relative_path` field for data exported in a `realization` context. Data exported in a `case` context will not have this field.

This is the first step towards adding a `fmu.object.identifier` (naming up for discussion) that will be an uuid for identifying objects representing the same thing --> both realization and aggregation representations of a specific object.  


## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
