### PR TITLE
SCHEMA: add standard result for structure_time_surface

### DIFF
--- a/examples/example_metadata/fmu_case.yml
+++ b/examples/example_metadata/fmu_case.yml
@@ -32,7 +32,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-05-08T16:24:47.002325Z'
+- datetime: '2025-05-12T07:36:28.510327Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/polygons_field_outline.yml
+++ b/examples/example_metadata/polygons_field_outline.yml
@@ -98,7 +98,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-05-08T16:24:49.615636Z'
+- datetime: '2025-05-12T07:36:31.981876Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/polygons_field_region.yml
+++ b/examples/example_metadata/polygons_field_region.yml
@@ -98,7 +98,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-05-08T16:24:49.572712Z'
+- datetime: '2025-05-12T07:36:31.957233Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/preprocessed_surface_depth.yml
+++ b/examples/example_metadata/preprocessed_surface_depth.yml
@@ -80,7 +80,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-05-08T16:24:53.136936Z'
+- datetime: '2025-05-12T07:36:37.410235Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/surface_depth.yml
+++ b/examples/example_metadata/surface_depth.yml
@@ -95,7 +95,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-05-08T16:24:54.361457Z'
+- datetime: '2025-05-12T07:36:39.334086Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/surface_fluid_contact.yml
+++ b/examples/example_metadata/surface_fluid_contact.yml
@@ -98,7 +98,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-05-08T16:24:54.381892Z'
+- datetime: '2025-05-12T07:36:39.385663Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/surface_seismic_amplitude.yml
+++ b/examples/example_metadata/surface_seismic_amplitude.yml
@@ -116,7 +116,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-05-08T16:24:54.401246Z'
+- datetime: '2025-05-12T07:36:39.438641Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/table_inplace_volumes.yml
+++ b/examples/example_metadata/table_inplace_volumes.yml
@@ -103,7 +103,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-05-08T16:24:57.150773Z'
+- datetime: '2025-05-12T07:36:43.576954Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/schemas/0.11.0/fmu_results.json
+++ b/schemas/0.11.0/fmu_results.json
@@ -221,6 +221,9 @@
           "$ref": "#/$defs/StructureDepthSurfaceStandardResult"
         },
         {
+          "$ref": "#/$defs/StructureTimeSurfaceStandardResult"
+        },
+        {
           "$ref": "#/$defs/StructureDepthIsochoreStandardResult"
         },
         {
@@ -8241,6 +8244,32 @@
         "name"
       ],
       "title": "StructureDepthSurfaceStandardResult",
+      "type": "object"
+    },
+    "StructureTimeSurfaceStandardResult": {
+      "description": "The ``standard_result`` field contains information about which standard results this\ndata object represent.\nThis class contains metadata for the 'structure_time_surface' standard result.",
+      "properties": {
+        "file_schema": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FileSchema"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "name": {
+          "const": "structure_time_surface",
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "StructureTimeSurfaceStandardResult",
       "type": "object"
     },
     "SubcropData": {

--- a/src/fmu/dataio/_models/fmu_results/enums.py
+++ b/src/fmu/dataio/_models/fmu_results/enums.py
@@ -9,6 +9,7 @@ class StandardResultName(str, Enum):
     field_outline = "field_outline"
     inplace_volumes = "inplace_volumes"
     structure_depth_surface = "structure_depth_surface"
+    structure_time_surface = "structure_time_surface"
     structure_depth_isochore = "structure_depth_isochore"
     structure_depth_fault_lines = "structure_depth_fault_lines"
 

--- a/src/fmu/dataio/_models/fmu_results/fmu_results.py
+++ b/src/fmu/dataio/_models/fmu_results/fmu_results.py
@@ -56,6 +56,7 @@ class FmuResultsSchema(SchemaBase):
     - improved validation of grid increments
     - `fmu.ert.simulation_mode` no longer supports `iterative_ensemble_smoother`
     - added `TSurf` to list of supported file formats
+    - `data.standard_result` now supports `StructureTimeSurfaceStandardResult`
 
     #### 0.10.0
 

--- a/src/fmu/dataio/_models/fmu_results/standard_result.py
+++ b/src/fmu/dataio/_models/fmu_results/standard_result.py
@@ -71,6 +71,17 @@ class StructureDepthSurfaceStandardResult(StandardResult):
     """The identifying name for the 'structure_depth_surface' standard result."""
 
 
+class StructureTimeSurfaceStandardResult(StandardResult):
+    """
+    The ``standard_result`` field contains information about which standard results this
+    data object represent.
+    This class contains metadata for the 'structure_time_surface' standard result.
+    """
+
+    name: Literal[enums.StandardResultName.structure_time_surface]
+    """The identifying name for the 'structure_time_surface' standard result."""
+
+
 class StructureDepthIsochoreStandardResult(StandardResult):
     """
     The ``standard_result`` field contains information about which standard results this
@@ -136,6 +147,7 @@ class AnyStandardResult(RootModel):
         FieldOutlineStandardResult
         | InplaceVolumesStandardResult
         | StructureDepthSurfaceStandardResult
+        | StructureTimeSurfaceStandardResult
         | StructureDepthIsochoreStandardResult
         | StructureDepthFaultLinesStandardResult,
         Field(discriminator="name"),


### PR DESCRIPTION
Related to #1046 (similar to #1045 for depth domain)
Add a new standard result: `structure_time_surface`. 
Simple export function for exporting time surfaces (from RMS) will be added in a separate PR.


## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
