### PR TITLE
MAINT: Drop NaiveDatetime for tracklog events

### DIFF
--- a/examples/example_metadata/fmu_case.yml
+++ b/examples/example_metadata/fmu_case.yml
@@ -32,7 +32,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-05-05T11:10:30.365157Z'
+- datetime: '2025-05-06T20:30:21.346007Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/polygons_field_outline.yml
+++ b/examples/example_metadata/polygons_field_outline.yml
@@ -97,7 +97,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-05-05T11:10:33.634725Z'
+- datetime: '2025-05-06T20:30:24.722469Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/polygons_field_region.yml
+++ b/examples/example_metadata/polygons_field_region.yml
@@ -97,7 +97,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-05-05T11:10:33.611243Z'
+- datetime: '2025-05-06T20:30:24.698799Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/preprocessed_surface_depth.yml
+++ b/examples/example_metadata/preprocessed_surface_depth.yml
@@ -80,7 +80,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-05-05T11:10:38.129851Z'
+- datetime: '2025-05-06T20:30:29.369227Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/sumo_ensemble.yml
+++ b/examples/example_metadata/sumo_ensemble.yml
@@ -4,11 +4,11 @@ $schema: https://main-fmu-schemas-dev.radix.equinor.com/schemas/0.10.0/fmu_resul
 version: "0.10.0"
 source: fmu
 tracklog:
-  - datetime: 2020-10-28T14:28:02
+  - datetime: 2020-10-28T14:28:02.346007Z
     user:
       id: user
     event: created
-  - datetime: 2020-10-28T14:46:14
+  - datetime: 2020-10-28T14:46:14.346007Z
     user: 
       id: user
     event: updated

--- a/examples/example_metadata/sumo_realization.yml
+++ b/examples/example_metadata/sumo_realization.yml
@@ -4,11 +4,11 @@ $schema: https://main-fmu-schemas-dev.radix.equinor.com/schemas/0.10.0/fmu_resul
 version: "0.10.0"
 source: fmu
 tracklog:
-  - datetime: 2020-10-28T14:28:02
+  - datetime: 2020-10-28T14:28:02.346007Z
     user:
       id: user
     event: created
-  - datetime: 2020-10-28T14:46:14
+  - datetime: 2020-10-28T14:46:14.346007Z
     user: 
       id: user
     event: updated

--- a/examples/example_metadata/surface_depth.yml
+++ b/examples/example_metadata/surface_depth.yml
@@ -94,7 +94,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-05-05T11:10:39.630925Z'
+- datetime: '2025-05-06T20:30:30.929283Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/surface_fluid_contact.yml
+++ b/examples/example_metadata/surface_fluid_contact.yml
@@ -97,7 +97,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-05-05T11:10:39.683189Z'
+- datetime: '2025-05-06T20:30:30.978106Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/surface_seismic_amplitude.yml
+++ b/examples/example_metadata/surface_seismic_amplitude.yml
@@ -115,7 +115,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-05-05T11:10:39.732619Z'
+- datetime: '2025-05-06T20:30:31.030166Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/table_inplace_volumes.yml
+++ b/examples/example_metadata/table_inplace_volumes.yml
@@ -102,7 +102,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-05-05T11:10:43.384028Z'
+- datetime: '2025-05-06T20:30:34.677956Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/schemas/0.11.0/fmu_results.json
+++ b/schemas/0.11.0/fmu_results.json
@@ -9638,7 +9638,7 @@
       "properties": {
         "datetime": {
           "examples": [
-            "2020-10-28T14:28:02"
+            "2020-10-28T14:28:024286Z"
           ],
           "format": "date-time",
           "title": "Datetime",

--- a/src/fmu/dataio/_models/fmu_results/fields.py
+++ b/src/fmu/dataio/_models/fmu_results/fields.py
@@ -17,7 +17,6 @@ from pydantic import (
     BaseModel,
     Field,
     GetJsonSchemaHandler,
-    NaiveDatetime,
     RootModel,
     model_validator,
 )
@@ -493,13 +492,7 @@ class TracklogEvent(BaseModel):
     This data object describes a tracklog event.
     """
 
-    # TODO: Update ex. to inc. timezone
-    # update NaiveDatetime ->  AwareDatetime
-    # On upload, sumo adds timezone if its lacking.
-    # For roundtripping i need an Union here.
-    datetime: NaiveDatetime | AwareDatetime = Field(
-        examples=["2020-10-28T14:28:02"],
-    )
+    datetime: AwareDatetime = Field(examples=["2020-10-28T14:28:024286Z"])
     """A datetime representation recording when the event occurred."""
 
     event: enums.TrackLogEventType

--- a/tests/data/drogon/ertrun1/share/metadata/fmu_case.yml
+++ b/tests/data/drogon/ertrun1/share/metadata/fmu_case.yml
@@ -3,7 +3,7 @@ source: fmu
 version: 0.8.0
 class: case
 tracklog:
-  - datetime: "2021-05-05T09:20:40.475110"
+  - datetime: "2021-05-05T09:20:40.475110Z"
     event: created
     user:
       id: peesv

--- a/tests/data/drogon/ertrun1_no_iter/share/metadata/fmu_case.yml
+++ b/tests/data/drogon/ertrun1_no_iter/share/metadata/fmu_case.yml
@@ -3,7 +3,7 @@ source: fmu
 version: 0.8.0
 class: case
 tracklog:
-  - datetime: "2021-05-05T09:20:40.475110"
+  - datetime: "2021-05-05T09:20:40.475110Z"
     event: created
     user:
       id: peesv


### PR DESCRIPTION
Resolves #1181

PR to drop the `NaiveDatetime` as type for tracklog events. We always populate them with UTC timezone in outgoing metadata. 

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
