### PR TITLE
MAINT: Remove redundant obj as input argument to FileDataProvider

### DIFF
--- a/src/fmu/dataio/_metadata.py
+++ b/src/fmu/dataio/_metadata.py
@@ -61,7 +61,6 @@ class CaseMetadataExport(CaseMetadata, populate_by_name=True):
 
 def _get_meta_filedata(
     dataio: ExportData,
-    obj: types.Inferrable,
     objdata: ObjectDataProvider,
     fmudata: FmuProvider | None,
 ) -> fields.File:
@@ -70,7 +69,6 @@ def _get_meta_filedata(
         dataio=dataio,
         objdata=objdata,
         runpath=fmudata.get_runpath() if fmudata else None,
-        obj=obj,
     ).get_metadata()
 
 
@@ -147,7 +145,7 @@ def generate_export_metadata(
         ),
         access=_get_meta_access(dataio),
         data=objdata.get_metadata(),
-        file=_get_meta_filedata(dataio, obj, objdata, fmudata),
+        file=_get_meta_filedata(dataio, objdata, fmudata),
         tracklog=fields.Tracklog.initialize(),
         display=_get_meta_display(dataio, objdata),
         preprocessed=dataio.preprocessed,

--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -833,7 +833,6 @@ class ExportData:
         filemeta = FileDataProvider(
             dataio=self,
             objdata=objdata,
-            obj=obj,
             runpath=fmudata.get_runpath() if fmudata else None,
         ).get_metadata()
 

--- a/src/fmu/dataio/providers/_filedata.py
+++ b/src/fmu/dataio/providers/_filedata.py
@@ -22,7 +22,7 @@ from ._base import Provider
 logger: Final = null_logger(__name__)
 
 if TYPE_CHECKING:
-    from fmu.dataio import ExportData, types
+    from fmu.dataio import ExportData
 
     from .objectdata._provider import ObjectDataProvider
 
@@ -47,7 +47,6 @@ class FileDataProvider(Provider):
     # input
     dataio: ExportData
     objdata: ObjectDataProvider
-    obj: types.Inferrable
     runpath: Path | None = None
 
     @property

--- a/tests/test_units/test_filedataprovider_class.py
+++ b/tests/test_units/test_filedataprovider_class.py
@@ -112,7 +112,7 @@ def test_get_filestem(
     edataobj1.parent = parentname
     edataobj1.name = ""
 
-    fdata = FileDataProvider(edataobj1, objdata, regsurf)
+    fdata = FileDataProvider(edataobj1, objdata)
 
     stem = fdata._get_filestem()
     assert stem == expected
@@ -160,7 +160,7 @@ def test_get_filestem_shall_fail(
     edataobj1.parent = parentname
     edataobj1.name = ""
 
-    fdata = FileDataProvider(edataobj1, objdata, regsurf)
+    fdata = FileDataProvider(edataobj1, objdata)
 
     with pytest.raises(ValueError) as msg:
         _ = fdata._get_filestem()
@@ -175,7 +175,7 @@ def test_get_share_folders(regsurf, globalconfig2):
     objdata = objectdata_provider_factory(regsurf, edataobj1)
     objdata.name = "some"
 
-    fdata = FileDataProvider(edataobj1, objdata, regsurf)
+    fdata = FileDataProvider(edataobj1, objdata)
     share_folders = fdata._get_share_folders()
     assert isinstance(share_folders, Path)
     assert share_folders == Path(f"share/results/{ExportFolder.maps.value}")
@@ -197,7 +197,7 @@ def test_get_share_folders_with_subfolder(regsurf, globalconfig2):
     objdata = objectdata_provider_factory(regsurf, edataobj1)
     objdata.name = "some"
 
-    fdata = FileDataProvider(edataobj1, objdata, regsurf)
+    fdata = FileDataProvider(edataobj1, objdata)
     share_folders = fdata._get_share_folders()
     assert share_folders == Path("share/results/maps/sub")
 
@@ -229,7 +229,7 @@ def test_filedata_provider(regsurf, tmp_path, globalconfig2):
     objdata.time0 = datetime.strptime(t1, "%Y%m%d")
     objdata.time1 = datetime.strptime(t2, "%Y%m%d")
 
-    fdata = FileDataProvider(cfg, objdata, regsurf)
+    fdata = FileDataProvider(cfg, objdata)
     filemeta = fdata.get_metadata()
 
     assert isinstance(filemeta, fields.File)
@@ -250,6 +250,6 @@ def test_filedata_has_nonascii_letters(regsurf, tmp_path, globalconfig2):
     objdata = objectdata_provider_factory(regsurf, edataobj1)
     objdata.name = "anynõme"
 
-    fdata = FileDataProvider(edataobj1, objdata, regsurf)
+    fdata = FileDataProvider(edataobj1, objdata)
     with pytest.raises(ValueError, match="Path has non-ascii elements"):
         fdata.get_metadata()


### PR DESCRIPTION
After #1057 we no longer use the data object inside the `FileDataProvider,` hence the `obj` argument is redundant and is removed in this PR 🧹

Modified some existing tests, new ones not necessary

## Checklist

- [x] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
