### PR TITLE
CI: Fetch sumo explorer token from Azure

### DIFF
--- a/.github/workflows/ci-fmudataio.yml
+++ b/.github/workflows/ci-fmudataio.yml
@@ -14,7 +14,9 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12"]
         os: [ubuntu-latest]
-
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 
@@ -39,6 +41,20 @@ jobs:
         run:
           pip install \
             "fmu-sumo-uploader @ git+https://github.com/equinor/fmu-sumo-uploader.git"
+
+      - name: Azure Login
+        uses: Azure/login@v2
+        with:
+          client-id: ${{ secrets.SUMO_TEST_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.SUMO_TEST_SUBSCRIPTION_ID }}
+
+      - name: Get Sumo Explorer access token from Azure
+        run: |
+          az --version
+          az account list
+          access_token=$(az account get-access-token --scope api://88d2b022-3539-4dda-9e66-853801334a86/.default --query accessToken --output tsv)
+          echo "SUMO_ACCESS_TOKEN=$access_token" >> "$GITHUB_ENV"
 
       - name: Full test
         run: |

--- a/tests/test_export_rms/test_export_inplace_volumes.py
+++ b/tests/test_export_rms/test_export_inplace_volumes.py
@@ -118,6 +118,7 @@ def test_convert_table_from_legacy_to_standard_format(
     voltable_legacy,
     rmssetup_with_fmuconfig,
     monkeypatch,
+    unregister_pandas_parquet,
 ):
     """Test that a voltable with legacy format is converted to
     the expected standard format"""
@@ -142,10 +143,6 @@ def test_convert_table_from_legacy_to_standard_format(
 
     # check that the exported table is equal to the expected
     out = instance._export_data_as_standard_result()
-    # Note that using `read_parquet()` more than once in the same pytest module causes
-    # errors due to an issue in pandas registering a type extension globally on every
-    # invocation. This is probably a pandas bug.
-    # https://github.com/apache/arrow/issues/41857
     exported_table = pd.read_parquet(out.items[0].absolute_path)
 
     pd.testing.assert_frame_equal(voltable_standard, exported_table)

--- a/tests/test_loaders/test_sumo_interface.py
+++ b/tests/test_loaders/test_sumo_interface.py
@@ -48,7 +48,7 @@ def test_initialize_inplace_volumes(sumo_test_case):
         assert sumo_interface._search_context.names == expected_search_context.names
 
 
-def test_get_realization_ids(sumo_test_case):
+def test_get_realization_ids(sumo_test_case, unregister_pandas_parquet):
     ensemble_name = "iter-0"
 
     with (
@@ -140,7 +140,7 @@ def test_get_blob(sumo_test_case):
         )
 
 
-def test_get_realization_with_metadata(sumo_test_case):
+def test_get_realization_with_metadata(sumo_test_case, unregister_pandas_parquet):
     ensemble_name = "iter-0"
     realization_id = 0
 

--- a/tests/test_loaders/test_sumo_interface.py
+++ b/tests/test_loaders/test_sumo_interface.py
@@ -1,3 +1,4 @@
+import os
 from unittest.mock import patch
 
 import pandas as pd
@@ -10,16 +11,12 @@ from fmu.sumo.explorer.objects import Case
 
 @pytest.fixture
 def sumo_test_case() -> Case:
-    # This should be replaced by test_data stored locally.
-    # Fetching directly from Sumo for now
+    sumo_access_token = os.environ.get("SUMO_ACCESS_TOKEN")
     test_case_id = "3ca4b782-c8e8-4f77-9a75-d6a576751123"
-    sumo = Explorer(env="dev")
-    return sumo.get_case_by_uuid(test_case_id)
+    sumo_explorer = Explorer(env="dev", token=sumo_access_token)
+    return sumo_explorer.get_case_by_uuid(test_case_id)
 
 
-@pytest.mark.skip(
-    reason="Authentication towards sumo not working from github workflow yet."
-)
 def test_initialize_inplace_volumes(sumo_test_case):
     ensemble_name = "iter-0"
 
@@ -51,9 +48,6 @@ def test_initialize_inplace_volumes(sumo_test_case):
         assert sumo_interface._search_context.names == expected_search_context.names
 
 
-@pytest.mark.skip(
-    reason="Authentication towards sumo not working from github workflow yet."
-)
 def test_get_realization_ids(sumo_test_case):
     ensemble_name = "iter-0"
 
@@ -73,9 +67,6 @@ def test_get_realization_ids(sumo_test_case):
         assert realization_ids == expected_realization_ids
 
 
-@pytest.mark.skip(
-    reason="Authentication towards sumo not working from github workflow yet."
-)
 def test_get_realization(sumo_test_case):
     ensemble_name = "iter-0"
     realization_id = 0
@@ -88,53 +79,89 @@ def test_get_realization(sumo_test_case):
             "some_case_id", ensemble_name, "inplace_volumes"
         )
 
-        expected_realization_inplace_volumes = sumo_test_case.filter(
+        expected_data = sumo_test_case.filter(
             iteration=ensemble_name,
             standard_result="inplace_volumes",
             realization=realization_id,
         )
 
-        expected_first_data_frame = expected_realization_inplace_volumes[0].to_pandas()
-        expected_second_data_frame = expected_realization_inplace_volumes[1].to_pandas()
+        expected_first_data_frame = expected_data[0].to_pandas()
+        expected_second_data_frame = expected_data[1].to_pandas()
+        expected_first_name = expected_data[0].name
+        expected_second_name = expected_data[1].name
 
-        expected_first_name = expected_realization_inplace_volumes[0].name
-        expected_second_name = expected_realization_inplace_volumes[1].name
-
-        realization_data_frames = sumo_interface.get_realization(realization_id)
+        actual_data = sumo_interface.get_realization(realization_id)
 
         pd.testing.assert_frame_equal(
-            realization_data_frames[expected_first_name],
+            actual_data[expected_first_name],
             expected_first_data_frame,
         )
         pd.testing.assert_frame_equal(
-            realization_data_frames[expected_second_name], expected_second_data_frame
+            actual_data[expected_second_name], expected_second_data_frame
         )
 
         with pytest.raises(AssertionError, match="DataFrame are different"):
             pd.testing.assert_frame_equal(
-                expected_first_data_frame, realization_data_frames[expected_second_name]
+                expected_first_data_frame, actual_data[expected_second_name]
             )
 
 
-@pytest.mark.skip(
-    reason="Authentication towards sumo not working from github workflow yet."
-)
-def test_get_blob():
-    # TODO
-    assert True
+def test_get_blob(sumo_test_case):
+    ensemble_name = "iter-0"
+    realization_id = 0
+
+    with (
+        patch.object(Explorer, "__init__", return_value=None),
+        patch.object(Explorer, "get_case_by_uuid", return_value=sumo_test_case),
+    ):
+        sumo_interface = SumoExplorerInterface(
+            "some_case_id", ensemble_name, "inplace_volumes"
+        )
+
+        expected_data = sumo_test_case.filter(
+            iteration=ensemble_name,
+            standard_result="inplace_volumes",
+            realization=realization_id,
+        )
+        expected_first_blob = expected_data[0].blob
+        expected_second_blob = expected_data[1].blob
+        expected_first_name = expected_data[0].name
+        expected_second_name = expected_data[1].name
+
+        actual_data = sumo_interface.get_blob(realization_id)
+
+        assert (
+            actual_data[expected_first_name].getvalue()
+            == expected_first_blob.getvalue()
+        )
+        assert (
+            actual_data[expected_second_name].getvalue()
+            == expected_second_blob.getvalue()
+        )
 
 
-@pytest.mark.skip(
-    reason="Authentication towards sumo not working from github workflow yet."
-)
-def test_get_realization_with_metadata():
-    # TODO
-    assert True
+def test_get_realization_with_metadata(sumo_test_case):
+    ensemble_name = "iter-0"
+    realization_id = 0
 
+    with (
+        patch.object(Explorer, "__init__", return_value=None),
+        patch.object(Explorer, "get_case_by_uuid", return_value=sumo_test_case),
+    ):
+        sumo_interface = SumoExplorerInterface(
+            "some_case_id", ensemble_name, "inplace_volumes"
+        )
 
-@pytest.mark.skip(
-    reason="Authentication towards sumo not working from github workflow yet."
-)
-def test_get_depth_surface():
-    # TODO
-    assert True
+        expected_data = sumo_test_case.filter(
+            iteration=ensemble_name,
+            standard_result="inplace_volumes",
+            realization=realization_id,
+        )
+
+        expected_first_metadata = expected_data[0].metadata
+        expected_second_metadata = expected_data[1].metadata
+
+        actual_data = sumo_interface.get_realization_with_metadata(realization_id)
+
+        assert actual_data[0][1] == expected_first_metadata
+        assert actual_data[1][1] == expected_second_metadata


### PR DESCRIPTION
Resolves #1179 

Github workflow `ci-fmudataio.yml` now fetches a token from Azure to authenticate towards Sumo. This token is set as an environment variables.

The tests in `test_sumo_explorer.py` now reads this token from the environment variables and uses this to set up the connection to Sumo Explorer. 

In addition to this, some more tests were added.

Update 13.05:
@mferrera added a custom fix to handle an issue in the tests caused by a bug in Pyarrow when using the `read_parquet()` function more than once in a pytest module.  Link to bug: https://github.com/apache/arrow/issues/41857 

## Checklist

- [X] Tests added (if not, comment why)
- [X] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [X] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [X] Docstrings are correct and updated
- [X] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [X] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅
