### PR TITLE
ENH, SCHEMA: create triangulated surface provider

### DIFF
--- a/examples/example_metadata/fmu_case.yml
+++ b/examples/example_metadata/fmu_case.yml
@@ -32,12 +32,10 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-05-15T10:08:56.945587Z'
+- datetime: '2025-05-19T12:08:44.337839Z'
   event: created
   sysinfo:
     fmu-dataio:
-      version: dummy_version
-    komodo:
       version: dummy_version
     operating_system:
       hostname: dummy_hostname

--- a/examples/example_metadata/polygons_field_outline.yml
+++ b/examples/example_metadata/polygons_field_outline.yml
@@ -63,7 +63,7 @@ fmu:
     name: iter-0
     uuid: 00000000-0000-0000-0000-000000000000
   entity:
-    uuid: f41547e0-e99d-c61c-cc84-66b7a62c0c2a
+    uuid: 125d596a-1580-10de-00ff-9cdbad9e4287
   ert:
     experiment:
       id: 00000000-0000-0000-0000-000000000000
@@ -100,12 +100,10 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-05-15T10:09:00.412551Z'
+- datetime: '2025-05-19T12:08:46.673774Z'
   event: created
   sysinfo:
     fmu-dataio:
-      version: dummy_version
-    komodo:
       version: dummy_version
     operating_system:
       hostname: dummy_hostname

--- a/examples/example_metadata/polygons_field_region.yml
+++ b/examples/example_metadata/polygons_field_region.yml
@@ -63,7 +63,7 @@ fmu:
     name: iter-0
     uuid: 00000000-0000-0000-0000-000000000000
   entity:
-    uuid: 2ad14994-3418-c065-af4a-bf0f31aec201
+    uuid: d172a63c-7792-018e-e01f-43a0bd0a2447
   ert:
     experiment:
       id: 00000000-0000-0000-0000-000000000000
@@ -100,12 +100,10 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-05-15T10:09:00.388083Z'
+- datetime: '2025-05-19T12:08:46.653232Z'
   event: created
   sysinfo:
     fmu-dataio:
-      version: dummy_version
-    komodo:
       version: dummy_version
     operating_system:
       hostname: dummy_hostname

--- a/examples/example_metadata/preprocessed_surface_depth.yml
+++ b/examples/example_metadata/preprocessed_surface_depth.yml
@@ -80,12 +80,10 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-05-15T10:09:05.499968Z'
+- datetime: '2025-05-19T12:08:49.962747Z'
   event: created
   sysinfo:
     fmu-dataio:
-      version: dummy_version
-    komodo:
       version: dummy_version
     operating_system:
       hostname: dummy_hostname

--- a/examples/example_metadata/surface_depth.yml
+++ b/examples/example_metadata/surface_depth.yml
@@ -60,7 +60,7 @@ fmu:
     name: iter-0
     uuid: 00000000-0000-0000-0000-000000000000
   entity:
-    uuid: d07d6470-ffe8-225d-4bce-8f2250d2e6cc
+    uuid: 4415a4a7-4e88-4fe0-4f85-64274ea50da9
   ert:
     experiment:
       id: 00000000-0000-0000-0000-000000000000
@@ -97,12 +97,10 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-05-15T10:09:07.144934Z'
+- datetime: '2025-05-19T12:08:51.078533Z'
   event: created
   sysinfo:
     fmu-dataio:
-      version: dummy_version
-    komodo:
       version: dummy_version
     operating_system:
       hostname: dummy_hostname

--- a/examples/example_metadata/surface_fluid_contact.yml
+++ b/examples/example_metadata/surface_fluid_contact.yml
@@ -63,7 +63,7 @@ fmu:
     name: iter-0
     uuid: 00000000-0000-0000-0000-000000000000
   entity:
-    uuid: d36a1e94-dc47-92b4-8857-a2a839ecb394
+    uuid: 9f389347-befe-009a-71bf-df274265638c
   ert:
     experiment:
       id: 00000000-0000-0000-0000-000000000000
@@ -100,12 +100,10 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-05-15T10:09:07.205511Z'
+- datetime: '2025-05-19T12:08:51.097902Z'
   event: created
   sysinfo:
     fmu-dataio:
-      version: dummy_version
-    komodo:
       version: dummy_version
     operating_system:
       hostname: dummy_hostname

--- a/examples/example_metadata/surface_seismic_amplitude.yml
+++ b/examples/example_metadata/surface_seismic_amplitude.yml
@@ -81,7 +81,7 @@ fmu:
     name: iter-0
     uuid: 00000000-0000-0000-0000-000000000000
   entity:
-    uuid: efd9f409-5a7c-1fdc-cb67-6c67d519bd86
+    uuid: e917a438-4c05-bf8d-2da8-6e228e3fc291
   ert:
     experiment:
       id: 00000000-0000-0000-0000-000000000000
@@ -118,12 +118,10 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-05-15T10:09:07.266856Z'
+- datetime: '2025-05-19T12:08:51.117926Z'
   event: created
   sysinfo:
     fmu-dataio:
-      version: dummy_version
-    komodo:
       version: dummy_version
     operating_system:
       hostname: dummy_hostname

--- a/examples/example_metadata/table_inplace_volumes.yml
+++ b/examples/example_metadata/table_inplace_volumes.yml
@@ -52,7 +52,7 @@ display:
   name: geogrid
 file:
   absolute_path: /some/absolute/path/
-  checksum_md5: 0cb778f91e6074c471b4bbce1f919165
+  checksum_md5: 173c646133f5a47c9bfbc4432a0a2812
   relative_path: example_exports/share/results/tables/geogrid--volumes.csv
   runpath_relative_path: share/results/tables/geogrid--volumes.csv
 fmu:
@@ -68,7 +68,7 @@ fmu:
     name: iter-0
     uuid: 00000000-0000-0000-0000-000000000000
   entity:
-    uuid: 5bf16fd9-17cd-9674-2dfb-980338479ada
+    uuid: ba39e528-8b9b-233c-bc2f-2d61c62b9383
   ert:
     experiment:
       id: 00000000-0000-0000-0000-000000000000
@@ -105,12 +105,10 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-05-15T10:09:11.256080Z'
+- datetime: '2025-05-19T12:08:53.467511Z'
   event: created
   sysinfo:
     fmu-dataio:
-      version: dummy_version
-    komodo:
       version: dummy_version
     operating_system:
       hostname: dummy_hostname

--- a/schemas/0.11.0/fmu_results.json
+++ b/schemas/0.11.0/fmu_results.json
@@ -845,6 +845,9 @@
               "$ref": "#/$defs/SurfaceSpecification"
             },
             {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
+            },
+            {
               "$ref": "#/$defs/TableSpecification"
             },
             {
@@ -1592,6 +1595,9 @@
               "$ref": "#/$defs/SurfaceSpecification"
             },
             {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
+            },
+            {
               "$ref": "#/$defs/TableSpecification"
             },
             {
@@ -1889,6 +1895,9 @@
               "$ref": "#/$defs/SurfaceSpecification"
             },
             {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
+            },
+            {
               "$ref": "#/$defs/TableSpecification"
             },
             {
@@ -2184,6 +2193,9 @@
             },
             {
               "$ref": "#/$defs/SurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
             },
             {
               "$ref": "#/$defs/TableSpecification"
@@ -2537,6 +2549,9 @@
               "$ref": "#/$defs/SurfaceSpecification"
             },
             {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
+            },
+            {
               "$ref": "#/$defs/TableSpecification"
             },
             {
@@ -2877,6 +2892,9 @@
               "$ref": "#/$defs/SurfaceSpecification"
             },
             {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
+            },
+            {
               "$ref": "#/$defs/TableSpecification"
             },
             {
@@ -3212,6 +3230,9 @@
             },
             {
               "$ref": "#/$defs/SurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
             },
             {
               "$ref": "#/$defs/TableSpecification"
@@ -3642,6 +3663,9 @@
             },
             {
               "$ref": "#/$defs/SurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
             },
             {
               "$ref": "#/$defs/TableSpecification"
@@ -4127,6 +4151,9 @@
               "$ref": "#/$defs/SurfaceSpecification"
             },
             {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
+            },
+            {
               "$ref": "#/$defs/TableSpecification"
             },
             {
@@ -4292,7 +4319,8 @@
         "cornerpoint",
         "table",
         "dictionary",
-        "faultroom_triangulated"
+        "faultroom_triangulated",
+        "triangulated_surface"
       ],
       "title": "Layout",
       "type": "string"
@@ -4462,6 +4490,9 @@
             },
             {
               "$ref": "#/$defs/SurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
             },
             {
               "$ref": "#/$defs/TableSpecification"
@@ -4812,6 +4843,9 @@
             },
             {
               "$ref": "#/$defs/SurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
             },
             {
               "$ref": "#/$defs/TableSpecification"
@@ -5231,6 +5265,9 @@
               "$ref": "#/$defs/SurfaceSpecification"
             },
             {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
+            },
+            {
               "$ref": "#/$defs/TableSpecification"
             },
             {
@@ -5528,6 +5565,9 @@
               "$ref": "#/$defs/SurfaceSpecification"
             },
             {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
+            },
+            {
               "$ref": "#/$defs/TableSpecification"
             },
             {
@@ -5823,6 +5863,9 @@
             },
             {
               "$ref": "#/$defs/SurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
             },
             {
               "$ref": "#/$defs/TableSpecification"
@@ -6331,6 +6374,9 @@
               "$ref": "#/$defs/SurfaceSpecification"
             },
             {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
+            },
+            {
               "$ref": "#/$defs/TableSpecification"
             },
             {
@@ -6626,6 +6672,9 @@
             },
             {
               "$ref": "#/$defs/SurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
             },
             {
               "$ref": "#/$defs/TableSpecification"
@@ -7030,6 +7079,9 @@
               "$ref": "#/$defs/SurfaceSpecification"
             },
             {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
+            },
+            {
               "$ref": "#/$defs/TableSpecification"
             },
             {
@@ -7325,6 +7377,9 @@
             },
             {
               "$ref": "#/$defs/SurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
             },
             {
               "$ref": "#/$defs/TableSpecification"
@@ -7715,6 +7770,9 @@
               "$ref": "#/$defs/SurfaceSpecification"
             },
             {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
+            },
+            {
               "$ref": "#/$defs/TableSpecification"
             },
             {
@@ -8011,6 +8069,9 @@
             },
             {
               "$ref": "#/$defs/SurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
             },
             {
               "$ref": "#/$defs/TableSpecification"
@@ -8523,6 +8584,9 @@
               "$ref": "#/$defs/SurfaceSpecification"
             },
             {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
+            },
+            {
               "$ref": "#/$defs/TableSpecification"
             },
             {
@@ -8970,6 +9034,9 @@
               "$ref": "#/$defs/SurfaceSpecification"
             },
             {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
+            },
+            {
               "$ref": "#/$defs/TableSpecification"
             },
             {
@@ -9291,6 +9358,9 @@
               "$ref": "#/$defs/SurfaceSpecification"
             },
             {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
+            },
+            {
               "$ref": "#/$defs/TableSpecification"
             },
             {
@@ -9577,6 +9647,9 @@
             },
             {
               "$ref": "#/$defs/SurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
             },
             {
               "$ref": "#/$defs/TableSpecification"
@@ -9965,6 +10038,9 @@
               "$ref": "#/$defs/SurfaceSpecification"
             },
             {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
+            },
+            {
               "$ref": "#/$defs/TableSpecification"
             },
             {
@@ -10093,6 +10169,27 @@
         "is_prediction"
       ],
       "title": "TransmissibilitiesData",
+      "type": "object"
+    },
+    "TriangulatedSurfaceSpecification": {
+      "description": "Specifies relevant values describing a triangulated surface.",
+      "properties": {
+        "num_triangles": {
+          "minimum": 0,
+          "title": "Num Triangles",
+          "type": "integer"
+        },
+        "num_vertices": {
+          "minimum": 0,
+          "title": "Num Vertices",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "num_vertices",
+        "num_triangles"
+      ],
+      "title": "TriangulatedSurfaceSpecification",
       "type": "object"
     },
     "User": {
@@ -10278,6 +10375,9 @@
             },
             {
               "$ref": "#/$defs/SurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
             },
             {
               "$ref": "#/$defs/TableSpecification"
@@ -10599,6 +10699,9 @@
               "$ref": "#/$defs/SurfaceSpecification"
             },
             {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
+            },
+            {
               "$ref": "#/$defs/TableSpecification"
             },
             {
@@ -10894,6 +10997,9 @@
             },
             {
               "$ref": "#/$defs/SurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
             },
             {
               "$ref": "#/$defs/TableSpecification"

--- a/src/fmu/dataio/_definitions.py
+++ b/src/fmu/dataio/_definitions.py
@@ -26,6 +26,7 @@ class FileExtension(StrEnum):
     pol = ".pol"
     poi = ".poi"
     json = ".json"
+    tsurf = ".ts"
 
 
 class ExportFolder(StrEnum):

--- a/src/fmu/dataio/_models/fmu_results/enums.py
+++ b/src/fmu/dataio/_models/fmu_results/enums.py
@@ -111,6 +111,7 @@ class Layout(str, Enum):
     table = "table"
     dictionary = "dictionary"
     faultroom_triangulated = "faultroom_triangulated"
+    triangulated_surface = "triangulated_surface"
 
 
 class FMUContext(str, Enum):

--- a/src/fmu/dataio/_models/fmu_results/specification.py
+++ b/src/fmu/dataio/_models/fmu_results/specification.py
@@ -171,6 +171,16 @@ class FaultRoomSurfaceSpecification(BaseModel):
     """A name id of the faultroom usage."""
 
 
+class TriangulatedSurfaceSpecification(BaseModel):
+    """Specifies relevant values describing a triangulated surface."""
+
+    num_vertices: int = Field(ge=0)
+    """The number of vertices."""
+
+    num_triangles: int = Field(ge=0)
+    """The number of triangles."""
+
+
 class CubeSpecification(SurfaceSpecification):
     """Specifies relevant values describing a cube object, i.e. a seismic cube."""
 
@@ -216,5 +226,6 @@ AnySpecification = (
     | CubeSpecification
     | PolygonsSpecification
     | SurfaceSpecification
+    | TriangulatedSurfaceSpecification
     | TableSpecification
 )

--- a/src/fmu/dataio/providers/objectdata/_triangulated_surface.py
+++ b/src/fmu/dataio/providers/objectdata/_triangulated_surface.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Final
+
+from fmu.dataio._definitions import ExportFolder, FileExtension
+from fmu.dataio._logging import null_logger
+from fmu.dataio._models.fmu_results.data import BoundingBox3D
+from fmu.dataio._models.fmu_results.enums import FileFormat, FMUClass, Layout
+from fmu.dataio._models.fmu_results.specification import (
+    TriangulatedSurfaceSpecification,
+)
+from fmu.dataio._readers import tsurf as reader
+
+from ._base import (
+    ObjectDataProvider,
+)
+
+if TYPE_CHECKING:
+    from io import BytesIO
+
+    from fmu.dataio._readers.tsurf import TSurfData
+
+logger: Final = null_logger(__name__)
+
+
+@dataclass
+class TriangulatedSurfaceProvider(ObjectDataProvider):
+    """Provider for triangulated surface data."""
+
+    obj: TSurfData
+
+    @property
+    def classname(self) -> FMUClass:
+        return FMUClass.triangulated_surface
+
+    @property
+    def efolder(self) -> str:
+        return self.dataio.forcefolder or ExportFolder.maps.value
+
+    @property
+    def extension(self) -> str:
+        return FileExtension.tsurf.value
+
+    @property
+    def fmt(self) -> FileFormat:
+        return FileFormat.tsurf
+
+    @property
+    def layout(self) -> Layout:
+        return Layout.triangulated_surface
+
+    @property
+    def table_index(self) -> None:
+        """Return the table index."""
+
+    def get_geometry(self) -> None:
+        """Derive data.geometry for TriangulatedSurface."""
+
+    def get_bbox(self) -> BoundingBox3D:
+        """Derive data.bbox for TriangulatedSurface."""
+        logger.info("Get bounding box for TriangulatedSurface")
+
+        return BoundingBox3D.model_validate(self.obj.bbox())
+
+    def get_spec(self) -> TriangulatedSurfaceSpecification:
+        """Derive data.spec for TriangulatedSurface"""
+        logger.info("Get spec for TriangulatedSurface")
+
+        return TriangulatedSurfaceSpecification(
+            num_vertices=self.obj.num_vertices(),
+            num_triangles=self.obj.num_triangles(),
+        )
+
+    def export_to_file(self, output: Path | BytesIO) -> None:
+        """Export the object to file or memory buffer"""
+
+        reader.write_tsurf_to_file(self.obj, output)


### PR DESCRIPTION
Further towards #1126.

Adds TriangulatedSurfaceProvider as a new provider

## Checklist

- [x] Tests will be added in later PR
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation to be updated when implementing SimpleExport for triangulated surfaces
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
