### PR TITLE
MAINT: Make share export location an ObjectDataProvider property

### DIFF
--- a/src/fmu/dataio/_definitions.py
+++ b/src/fmu/dataio/_definitions.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from enum import StrEnum
 from typing import Final
 
 from pydantic import BaseModel, model_validator
@@ -11,7 +11,13 @@ from fmu.dataio._models.fmu_results.enums import Content
 from fmu.dataio.export._enums import InplaceVolumes
 
 
-class FileExtension(str, Enum):
+class ShareFolder(StrEnum):
+    PREPROCESSED = "share/preprocessed/"
+    OBSERVATIONS = "share/observations/"
+    RESULTS = "share/results/"
+
+
+class FileExtension(StrEnum):
     gri = ".gri"
     roff = ".roff"
     segy = ".segy"
@@ -22,7 +28,7 @@ class FileExtension(str, Enum):
     json = ".json"
 
 
-class ExportFolder(str, Enum):
+class ExportFolder(StrEnum):
     cubes = "cubes"
     dictionaries = "dictionaries"
     grids = "grids"

--- a/src/fmu/dataio/preprocessed.py
+++ b/src/fmu/dataio/preprocessed.py
@@ -102,7 +102,7 @@ class ExportPreprocessedData:
             raise RuntimeError(
                 f"Exporting files located outside the '{ShareFolder.PREPROCESSED}' "
                 "folder is not supported. Please re-export your objects to disk "
-                "using ExportData(fmu_context='preprocessed')"
+                "using ExportData(preprocessed=True)"
             )
         return objfile
 

--- a/src/fmu/dataio/providers/objectdata/_base.py
+++ b/src/fmu/dataio/providers/objectdata/_base.py
@@ -18,6 +18,7 @@ from fmu.dataio._models.fmu_results.global_configuration import (
 )
 from fmu.dataio._utils import generate_description, md5sum
 from fmu.dataio.providers._base import Provider
+from fmu.dataio.providers._filedata import SharePathConstructor
 from fmu.dataio.providers.objectdata._export_models import (
     UnsetData,
     content_metadata_factory,
@@ -161,6 +162,10 @@ class ObjectDataProvider(Provider):
     @abstractmethod
     def get_spec(self) -> AnySpecification | None:
         raise NotImplementedError
+
+    @property
+    def share_path(self) -> Path:
+        return SharePathConstructor(self.dataio, self).get_share_path()
 
     def compute_md5(self) -> str:
         """Compute an MD5 sum"""


### PR DESCRIPTION
Towards #644 

PR to add the export share path as a property on the `ObjectDataProvider.` This export path, and especially the filename, is very connected to attributes of this provider. 
This is a step towards adding an object identifier field in the metadata which should be located in the `fmu` block in the metadata. This identifier will be reliant on this share path, and this PR enables avoiding having to go into the `FileDataProvider` before the `FmuProvider.` 

This PR is mostly a restructuring of existing code, a lot has just been copied from the `FileDataProvider` into a `SharePathConstructor` which is used to set the `share_path` property on the `ObjectDataProvider.`

Added some new tests, but there is significant amount of tests that checks that the exported paths are correct so it should be covered. 

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
