### PR TITLE
CI: Only run Azure auth for Sumo from main branch

### DIFF
--- a/.github/workflows/ci-fmudataio.yml
+++ b/.github/workflows/ci-fmudataio.yml
@@ -3,6 +3,8 @@ name: Test
 on:
   pull_request:
     branches: [main]
+  push:
+    branches: [main]
   schedule:
     - cron: "0 0 * * *"
 
@@ -43,6 +45,7 @@ jobs:
             "fmu-sumo-uploader @ git+https://github.com/equinor/fmu-sumo-uploader.git"
 
       - name: Azure Login
+        if: ${{ github.ref == 'refs/heads/main' }}      
         uses: Azure/login@v2
         with:
           client-id: ${{ secrets.SUMO_TEST_CLIENT_ID }}
@@ -50,6 +53,7 @@ jobs:
           subscription-id: ${{ secrets.SUMO_TEST_SUBSCRIPTION_ID }}
 
       - name: Get Sumo Explorer access token from Azure
+        if: ${{ github.ref == 'refs/heads/main' }}
         run: |
           az --version
           az account list
@@ -63,9 +67,13 @@ jobs:
           pip install -U pydantic
 
           if [[ "${{ github.event.pull_request.base.ref }}" == "staging" ]]; then
-            pytest -n auto -v --cov --cov-report term-missing --prod
+            pytest -n auto -v --cov --cov-report term-missing --prod --ignore=tests/test_loaders/test_sumo_interface.py
           else
-            pytest -n auto -v --cov --cov-report term-missing
+            if [[ -v SUMO_ACCESS_TOKEN ]]; then
+              pytest -n auto -v --cov --cov-report term-missing
+            else
+              pytest -n auto -v --cov --cov-report term-missing --ignore=tests/test_loaders/test_sumo_interface.py
+            fi
           fi
 
   docker_build:

--- a/ci/testrmsenv.sh
+++ b/ci/testrmsenv.sh
@@ -39,6 +39,6 @@ install_test_dependencies () {
 run_pytest () {
     echo "Running fmu-dataio tests with pytest..."
     pushd $CI_TEST_ROOT
-    pytest ./tests -n 4 -vv -m "not skip_inside_rmsvenv" --ignore=tests/test_ert_integration
+    pytest ./tests -n 4 -vv -m "not skip_inside_rmsvenv" --ignore=tests/test_ert_integration --ignore=tests/test_loaders/test_sumo_interface.py
     popd
 }


### PR DESCRIPTION
Fixes bug introduced by #1179 

When running the github workflow `ci-fmudataio.yml` from a PR where the source branch does does not belong to the base repo equinor/fmu-dataio, the Authentication step towards Azure will fail as only the github runners in repo equinor/fmu-dataio has been given access to Sumos app reg in Azure.

Now, fetching the Sumo token from Azure and running the tests in `test_sumo_interface.py` are only done when running the workflow from main.

NB! With this change we will also run the tests on push/merge to main

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
