### PR TITLE
MAINT: Reduce redundant ObjectDataProvider instantiations

### DIFF
--- a/src/fmu/dataio/_metadata.py
+++ b/src/fmu/dataio/_metadata.py
@@ -22,14 +22,11 @@ from ._models.fmu_results.fmu_results import (
     ObjectMetadata,
 )
 from ._models.fmu_results.global_configuration import GlobalConfiguration
-from ._models.fmu_results.standard_result import StandardResult
 from .exceptions import InvalidMetadataError
 from .providers._filedata import FileDataProvider
 from .providers.objectdata._base import UnsetData
-from .providers.objectdata._provider import objectdata_provider_factory
 
 if TYPE_CHECKING:
-    from . import types
     from .dataio import ExportData
     from .providers._fmu import FmuProvider
     from .providers.objectdata._base import ObjectDataProvider
@@ -101,10 +98,9 @@ def _get_meta_display(
 
 
 def generate_export_metadata(
-    obj: types.Inferrable,
+    objdata: ObjectDataProvider,
     dataio: ExportData,
     fmudata: FmuProvider | None = None,
-    standard_result: StandardResult | None = None,
 ) -> ObjectMetadataExport:
     """
     Main function to generate the full metadata
@@ -132,8 +128,6 @@ def generate_export_metadata(
     * meta_display: dict of default display settings (experimental)
 
     """
-
-    objdata = objectdata_provider_factory(obj, dataio, standard_result)
 
     return ObjectMetadataExport(  # type: ignore[call-arg]
         class_=objdata.classname,


### PR DESCRIPTION
PR with some refactoring to avoid initializing the `ObjectDataProvider` more than once per object. 
Essentially this boils down to giving the `ObjectDataProvider` instance as input to the `generate_export_metadata` function instead of the object itself. 

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
