### PR TITLE
SCHEMA, ENH: Add fmu.entity field to outgoing metadata

### DIFF
--- a/examples/example_metadata/fmu_case.yml
+++ b/examples/example_metadata/fmu_case.yml
@@ -32,10 +32,12 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-05-07T18:42:19.716702Z'
+- datetime: '2025-05-15T09:01:05.982464Z'
   event: created
   sysinfo:
     fmu-dataio:
+      version: dummy_version
+    komodo:
       version: dummy_version
     operating_system:
       hostname: dummy_hostname

--- a/examples/example_metadata/polygons_field_outline.yml
+++ b/examples/example_metadata/polygons_field_outline.yml
@@ -62,6 +62,8 @@ fmu:
     id: 0
     name: iter-0
     uuid: 00000000-0000-0000-0000-000000000000
+  entity:
+    uuid: c78cb17e-72d5-bf19-d3a9-03474d45cdc1
   ert:
     experiment:
       id: 00000000-0000-0000-0000-000000000000
@@ -98,10 +100,12 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-05-07T18:42:23.140379Z'
+- datetime: '2025-05-15T09:01:10.610242Z'
   event: created
   sysinfo:
     fmu-dataio:
+      version: dummy_version
+    komodo:
       version: dummy_version
     operating_system:
       hostname: dummy_hostname

--- a/examples/example_metadata/polygons_field_region.yml
+++ b/examples/example_metadata/polygons_field_region.yml
@@ -62,6 +62,8 @@ fmu:
     id: 0
     name: iter-0
     uuid: 00000000-0000-0000-0000-000000000000
+  entity:
+    uuid: 86f1a29f-c8cf-91d8-8be8-a7198c2255d5
   ert:
     experiment:
       id: 00000000-0000-0000-0000-000000000000
@@ -98,10 +100,12 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-05-07T18:42:23.115695Z'
+- datetime: '2025-05-15T09:01:10.583615Z'
   event: created
   sysinfo:
     fmu-dataio:
+      version: dummy_version
+    komodo:
       version: dummy_version
     operating_system:
       hostname: dummy_hostname

--- a/examples/example_metadata/preprocessed_surface_depth.yml
+++ b/examples/example_metadata/preprocessed_surface_depth.yml
@@ -80,10 +80,12 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-05-07T18:42:27.997499Z'
+- datetime: '2025-05-15T09:01:16.275225Z'
   event: created
   sysinfo:
     fmu-dataio:
+      version: dummy_version
+    komodo:
       version: dummy_version
     operating_system:
       hostname: dummy_hostname

--- a/examples/example_metadata/surface_depth.yml
+++ b/examples/example_metadata/surface_depth.yml
@@ -59,6 +59,8 @@ fmu:
     id: 0
     name: iter-0
     uuid: 00000000-0000-0000-0000-000000000000
+  entity:
+    uuid: f253e398-6d02-eadb-3cf4-64132e0152f6
   ert:
     experiment:
       id: 00000000-0000-0000-0000-000000000000
@@ -95,10 +97,12 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-05-07T18:42:29.593855Z'
+- datetime: '2025-05-15T09:01:18.071338Z'
   event: created
   sysinfo:
     fmu-dataio:
+      version: dummy_version
+    komodo:
       version: dummy_version
     operating_system:
       hostname: dummy_hostname

--- a/examples/example_metadata/surface_fluid_contact.yml
+++ b/examples/example_metadata/surface_fluid_contact.yml
@@ -62,6 +62,8 @@ fmu:
     id: 0
     name: iter-0
     uuid: 00000000-0000-0000-0000-000000000000
+  entity:
+    uuid: 143bf0a4-d8be-82a3-8d76-0cdbce138667
   ert:
     experiment:
       id: 00000000-0000-0000-0000-000000000000
@@ -98,10 +100,12 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-05-07T18:42:29.649618Z'
+- datetime: '2025-05-15T09:01:18.125884Z'
   event: created
   sysinfo:
     fmu-dataio:
+      version: dummy_version
+    komodo:
       version: dummy_version
     operating_system:
       hostname: dummy_hostname

--- a/examples/example_metadata/surface_seismic_amplitude.yml
+++ b/examples/example_metadata/surface_seismic_amplitude.yml
@@ -80,6 +80,8 @@ fmu:
     id: 0
     name: iter-0
     uuid: 00000000-0000-0000-0000-000000000000
+  entity:
+    uuid: ee9d2260-6aa6-b008-6605-0ec85e4b9beb
   ert:
     experiment:
       id: 00000000-0000-0000-0000-000000000000
@@ -116,10 +118,12 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-05-07T18:42:29.705339Z'
+- datetime: '2025-05-15T09:01:18.180809Z'
   event: created
   sysinfo:
     fmu-dataio:
+      version: dummy_version
+    komodo:
       version: dummy_version
     operating_system:
       hostname: dummy_hostname

--- a/examples/example_metadata/table_inplace_volumes.yml
+++ b/examples/example_metadata/table_inplace_volumes.yml
@@ -52,7 +52,7 @@ display:
   name: geogrid
 file:
   absolute_path: /some/absolute/path/
-  checksum_md5: 173c646133f5a47c9bfbc4432a0a2812
+  checksum_md5: 0cb778f91e6074c471b4bbce1f919165
   relative_path: example_exports/share/results/tables/geogrid--volumes.csv
   runpath_relative_path: share/results/tables/geogrid--volumes.csv
 fmu:
@@ -67,6 +67,8 @@ fmu:
     id: 0
     name: iter-0
     uuid: 00000000-0000-0000-0000-000000000000
+  entity:
+    uuid: efc8479d-e36e-5160-db5a-a47c1642a893
   ert:
     experiment:
       id: 00000000-0000-0000-0000-000000000000
@@ -103,10 +105,12 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-05-07T18:42:33.609572Z'
+- datetime: '2025-05-15T09:01:22.276182Z'
   event: created
   sysinfo:
     fmu-dataio:
+      version: dummy_version
+    komodo:
       version: dummy_version
     operating_system:
       hostname: dummy_hostname

--- a/schemas/0.11.0/fmu_results.json
+++ b/schemas/0.11.0/fmu_results.json
@@ -26,6 +26,7 @@
     "fmu.aggregation.realization_ids",
     "fmu.case",
     "fmu.context.stage",
+    "fmu.entity.uuid",
     "fmu.ensemble.name",
     "fmu.ensemble.uuid",
     "fmu.ert.experiment.id",
@@ -1122,6 +1123,24 @@
       "title": "EnsembleMetadata",
       "type": "object"
     },
+    "Entity": {
+      "description": "The ``fmu.entity`` block identifies data objects representing the same entity\nwithin a case, i.e. both realizations and aggregations of a particular entity\nwill share the same unique identifier.",
+      "properties": {
+        "uuid": {
+          "examples": [
+            "15ce3b84-766f-4c93-9050-b154861f9100"
+          ],
+          "format": "uuid",
+          "title": "Uuid",
+          "type": "string"
+        }
+      },
+      "required": [
+        "uuid"
+      ],
+      "title": "Entity",
+      "type": "object"
+    },
     "Ert": {
       "description": "The ``fmu.ert`` block contains information about the current ert run.",
       "properties": {
@@ -1208,6 +1227,17 @@
           "anyOf": [
             {
               "$ref": "#/$defs/Ensemble"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "entity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Entity"
             },
             {
               "type": "null"

--- a/src/fmu/dataio/_models/fmu_results/fields.py
+++ b/src/fmu/dataio/_models/fmu_results/fields.py
@@ -650,6 +650,17 @@ class FMURealization(FMUBase):
     data object belongs to. See :class:`Realization`."""
 
 
+class Entity(BaseModel):
+    """
+    The ``fmu.entity`` block identifies data objects representing the same entity
+    within a case, i.e. both realizations and aggregations of a particular entity
+    will share the same unique identifier.
+    """
+
+    uuid: UUID = Field(examples=["15ce3b84-766f-4c93-9050-b154861f9100"])
+    """The unique identifier of an object entity within a case."""
+
+
 class FMU(FMUBase):
     """
     The ``fmu`` block contains all attributes specific to FMU. The idea is that the FMU
@@ -679,6 +690,11 @@ class FMU(FMUBase):
     realization: Realization | None = Field(default=None)
     """The ``fmu.realization`` block contains information about the realization this
     data object belongs to. See :class:`Realization`."""
+
+    entity: Entity | None = Field(default=None)
+    """The ``fmu.entity`` block identifies data objects representing the same entity
+    within a case. Note, for objects exported in context ``case`` this field will
+    be empty. See :class:`Ensemble`."""
 
     ert: Ert | None = Field(default=None)
     """The ``fmu.ert`` block contains information about the current ert run

--- a/src/fmu/dataio/_models/fmu_results/fmu_results.py
+++ b/src/fmu/dataio/_models/fmu_results/fmu_results.py
@@ -50,6 +50,7 @@ class FmuResultsSchema(SchemaBase):
     VERSION_CHANGELOG: str = """
     #### 0.11.0
 
+    - `fmu.entity.uuid` added as optional field
     - `file.runpath_relative_path` added as optional field
     - `fmu.ert.experiment.id` is added as contractual field
     - improved validation of grid numbering
@@ -145,6 +146,7 @@ class FmuResultsSchema(SchemaBase):
         "fmu.aggregation.realization_ids",
         "fmu.case",
         "fmu.context.stage",
+        "fmu.entity.uuid",
         "fmu.ensemble.name",
         "fmu.ensemble.uuid",
         "fmu.ert.experiment.id",

--- a/tests/test_ert_integration/conftest.py
+++ b/tests/test_ert_integration/conftest.py
@@ -19,7 +19,7 @@ def base_ert_config() -> str:
         DEFINE <SUMO_ENV>       dev
         DEFINE <SUMO_CASEPATH>  <SCRATCH>/<USER>/<CASE_DIR>
 
-        NUM_REALIZATIONS 5
+        NUM_REALIZATIONS 3
 
         QUEUE_SYSTEM LOCAL
         QUEUE_OPTION LOCAL MAX_RUNNING 5

--- a/tests/test_ert_integration/test_ensemble_experiment_run.py
+++ b/tests/test_ert_integration/test_ensemble_experiment_run.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+from typing import Any
+
+import ert.__main__
+import pytest
+import yaml
+
+from fmu.dataio._models import FmuResults
+from fmu.dataio._models.fmu_results.enums import ErtSimulationMode
+from fmu.dataio._utils import uuid_from_string
+
+from .ert_config_utils import (
+    add_create_case_workflow,
+    add_export_a_surface_forward_model,
+)
+
+
+@pytest.fixture
+def snakeoil_export_surface_experiment(
+    fmu_snakeoil_project: Path, monkeypatch: Any, mocker: Any
+) -> Path:
+    monkeypatch.chdir(fmu_snakeoil_project / "ert/model")
+    add_create_case_workflow("snakeoil.ert")
+    add_export_a_surface_forward_model(fmu_snakeoil_project, "snakeoil.ert")
+
+    mocker.patch(
+        "sys.argv",
+        ["ert", "ensemble_experiment", "snakeoil.ert", "--disable-monitoring"],
+    )
+    ert.__main__.main()
+    return fmu_snakeoil_project
+
+
+def test_export_ensemble_experiment(snakeoil_export_surface_experiment: Path) -> None:
+    """Test that metadata is set correctly in an ensemble_experiment run"""
+    fmu_case_yml = (
+        snakeoil_export_surface_experiment
+        / "scratch/user/snakeoil/share/metadata/fmu_case.yml"
+    )
+    assert fmu_case_yml.exists()
+
+    with open(fmu_case_yml, encoding="utf-8") as f:
+        fmu_case = yaml.safe_load(f)
+
+    case_uuid = fmu_case["fmu"]["case"]["uuid"]
+    share_path = "share/results/maps/all--average_poro.gri"
+
+    # three realizations are present
+    for real_num in range(3):
+        avg_poro = Path(
+            snakeoil_export_surface_experiment
+            / f"scratch/user/snakeoil/realization-{real_num}/iter-0"
+            / "share/results/maps/.all--average_poro.gri.yml"
+        )
+        assert avg_poro.exists()
+
+        with open(avg_poro, encoding="utf-8") as f:
+            avg_poro_metadata = yaml.safe_load(f)
+
+        avg_poro = FmuResults.model_validate(avg_poro_metadata)  # asserts valid
+
+        assert (
+            avg_poro.root.fmu.ert.simulation_mode
+            == ErtSimulationMode.ensemble_experiment
+        )
+        assert avg_poro.root.fmu.ert.experiment.id is not None
+
+        # the three realizations should have equal runpath_relative_path and entity.uuid
+        assert avg_poro.root.file.runpath_relative_path == Path(share_path)
+        assert avg_poro.root.fmu.entity.uuid == uuid_from_string(case_uuid + share_path)

--- a/tests/test_units/test_aggregated_surfaces.py
+++ b/tests/test_units/test_aggregated_surfaces.py
@@ -33,6 +33,8 @@ def test_regsurf_aggregated(fmurun_w_casemetadata, aggr_surfs_mean):
     logger.debug("New metadata:\n%s", utils.prettyprint_dict(newmeta))
     assert newmeta["fmu"]["aggregation"]["id"] == aggregation_uuid
     assert newmeta["fmu"]["context"]["stage"] == "ensemble"
+    # the entity uuid of the aggregated object should match the input objects
+    assert newmeta["fmu"]["entity"]["uuid"] == metas[0]["fmu"]["entity"]["uuid"]
 
 
 def test_regsurf_aggregated_content_seismic(


### PR DESCRIPTION
Resolves #644
Relevant issue  https://github.com/equinor/fmu-results-activities/issues/33 

PR to add a `fmu.entity` block to the schema. This block is intended to be used to identify data objects representing the same entity within a case. For now an `uuid` field has been added, and it will be a `UUID` created from the `case_uuid` and the `runpath_relative_path`. This UUID will be the same for all realizations and aggregations of the same object whithin a specific case.

I made the id based on the case and not the ensemble now as we discussed. If anyone has suddenly gotten strong opinions against it, please speak up 😄  

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
