### PR TITLE
SCHEMA: Add standard_result 'fluid_contact_surface'

### DIFF
--- a/schemas/0.11.0/fmu_results.json
+++ b/schemas/0.11.0/fmu_results.json
@@ -229,6 +229,9 @@
         },
         {
           "$ref": "#/$defs/StructureDepthFaultLinesStandardResult"
+        },
+        {
+          "$ref": "#/$defs/FluidContactSurfaceStandardResult"
         }
       ],
       "title": "AnyStandardResult"
@@ -3767,6 +3770,32 @@
         "fluid_contact"
       ],
       "title": "FluidContactData",
+      "type": "object"
+    },
+    "FluidContactSurfaceStandardResult": {
+      "description": "The ``standard_result`` field contains information about which standard results this\ndata object represent.\nThis class contains metadata for the 'fluid_contact_surface' standard result.",
+      "properties": {
+        "file_schema": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FileSchema"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "name": {
+          "const": "fluid_contact_surface",
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "FluidContactSurfaceStandardResult",
       "type": "object"
     },
     "FluidContactType": {

--- a/src/fmu/dataio/_models/fmu_results/enums.py
+++ b/src/fmu/dataio/_models/fmu_results/enums.py
@@ -12,6 +12,7 @@ class StandardResultName(str, Enum):
     structure_time_surface = "structure_time_surface"
     structure_depth_isochore = "structure_depth_isochore"
     structure_depth_fault_lines = "structure_depth_fault_lines"
+    fluid_contact_surface = "fluid_contact_surface"
 
 
 class Classification(str, Enum):

--- a/src/fmu/dataio/_models/fmu_results/fmu_results.py
+++ b/src/fmu/dataio/_models/fmu_results/fmu_results.py
@@ -50,6 +50,7 @@ class FmuResultsSchema(SchemaBase):
     VERSION_CHANGELOG: str = """
     #### 0.11.0
 
+    - `data.standard_result` now supports `FluidContactSurfaceStandardResult`
     - `fmu.entity.uuid` added as optional field
     - `file.runpath_relative_path` added as optional field
     - `fmu.ert.experiment.id` is added as contractual field

--- a/src/fmu/dataio/_models/fmu_results/standard_result.py
+++ b/src/fmu/dataio/_models/fmu_results/standard_result.py
@@ -132,6 +132,17 @@ class FieldOutlineStandardResult(StandardResult):
     """
 
 
+class FluidContactSurfaceStandardResult(StandardResult):
+    """
+    The ``standard_result`` field contains information about which standard results this
+    data object represent.
+    This class contains metadata for the 'fluid_contact_surface' standard result.
+    """
+
+    name: Literal[enums.StandardResultName.fluid_contact_surface]
+    """The identifying name for the 'fluid_contact_surface' standard result."""
+
+
 class AnyStandardResult(RootModel):
     """
     The ``standard result`` field contains information about which standard result this
@@ -149,6 +160,7 @@ class AnyStandardResult(RootModel):
         | StructureDepthSurfaceStandardResult
         | StructureTimeSurfaceStandardResult
         | StructureDepthIsochoreStandardResult
-        | StructureDepthFaultLinesStandardResult,
+        | StructureDepthFaultLinesStandardResult
+        | FluidContactSurfaceStandardResult,
         Field(discriminator="name"),
     ]


### PR DESCRIPTION
Towards #1207 

Add standard_result 'fluid_contact_surface' to the schema. 
A simple export for it will be created in a subsequent PR.

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
