### PR TITLE
SCHEMA: Add standard_result 'fluid_contact_outline'

### DIFF
--- a/examples/example_metadata/fmu_case.yml
+++ b/examples/example_metadata/fmu_case.yml
@@ -32,7 +32,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-05-15T09:01:05.982464Z'
+- datetime: '2025-05-15T10:08:56.945587Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/polygons_field_outline.yml
+++ b/examples/example_metadata/polygons_field_outline.yml
@@ -63,7 +63,7 @@ fmu:
     name: iter-0
     uuid: 00000000-0000-0000-0000-000000000000
   entity:
-    uuid: c78cb17e-72d5-bf19-d3a9-03474d45cdc1
+    uuid: f41547e0-e99d-c61c-cc84-66b7a62c0c2a
   ert:
     experiment:
       id: 00000000-0000-0000-0000-000000000000
@@ -100,7 +100,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-05-15T09:01:10.610242Z'
+- datetime: '2025-05-15T10:09:00.412551Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/polygons_field_region.yml
+++ b/examples/example_metadata/polygons_field_region.yml
@@ -63,7 +63,7 @@ fmu:
     name: iter-0
     uuid: 00000000-0000-0000-0000-000000000000
   entity:
-    uuid: 86f1a29f-c8cf-91d8-8be8-a7198c2255d5
+    uuid: 2ad14994-3418-c065-af4a-bf0f31aec201
   ert:
     experiment:
       id: 00000000-0000-0000-0000-000000000000
@@ -100,7 +100,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-05-15T09:01:10.583615Z'
+- datetime: '2025-05-15T10:09:00.388083Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/preprocessed_surface_depth.yml
+++ b/examples/example_metadata/preprocessed_surface_depth.yml
@@ -80,7 +80,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-05-15T09:01:16.275225Z'
+- datetime: '2025-05-15T10:09:05.499968Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/surface_depth.yml
+++ b/examples/example_metadata/surface_depth.yml
@@ -60,7 +60,7 @@ fmu:
     name: iter-0
     uuid: 00000000-0000-0000-0000-000000000000
   entity:
-    uuid: f253e398-6d02-eadb-3cf4-64132e0152f6
+    uuid: d07d6470-ffe8-225d-4bce-8f2250d2e6cc
   ert:
     experiment:
       id: 00000000-0000-0000-0000-000000000000
@@ -97,7 +97,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-05-15T09:01:18.071338Z'
+- datetime: '2025-05-15T10:09:07.144934Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/surface_fluid_contact.yml
+++ b/examples/example_metadata/surface_fluid_contact.yml
@@ -63,7 +63,7 @@ fmu:
     name: iter-0
     uuid: 00000000-0000-0000-0000-000000000000
   entity:
-    uuid: 143bf0a4-d8be-82a3-8d76-0cdbce138667
+    uuid: d36a1e94-dc47-92b4-8857-a2a839ecb394
   ert:
     experiment:
       id: 00000000-0000-0000-0000-000000000000
@@ -100,7 +100,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-05-15T09:01:18.125884Z'
+- datetime: '2025-05-15T10:09:07.205511Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/surface_seismic_amplitude.yml
+++ b/examples/example_metadata/surface_seismic_amplitude.yml
@@ -81,7 +81,7 @@ fmu:
     name: iter-0
     uuid: 00000000-0000-0000-0000-000000000000
   entity:
-    uuid: ee9d2260-6aa6-b008-6605-0ec85e4b9beb
+    uuid: efd9f409-5a7c-1fdc-cb67-6c67d519bd86
   ert:
     experiment:
       id: 00000000-0000-0000-0000-000000000000
@@ -118,7 +118,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-05-15T09:01:18.180809Z'
+- datetime: '2025-05-15T10:09:07.266856Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/table_inplace_volumes.yml
+++ b/examples/example_metadata/table_inplace_volumes.yml
@@ -68,7 +68,7 @@ fmu:
     name: iter-0
     uuid: 00000000-0000-0000-0000-000000000000
   entity:
-    uuid: efc8479d-e36e-5160-db5a-a47c1642a893
+    uuid: 5bf16fd9-17cd-9674-2dfb-980338479ada
   ert:
     experiment:
       id: 00000000-0000-0000-0000-000000000000
@@ -105,7 +105,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-05-15T09:01:22.276182Z'
+- datetime: '2025-05-15T10:09:11.256080Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/schemas/0.11.0/fmu_results.json
+++ b/schemas/0.11.0/fmu_results.json
@@ -232,6 +232,9 @@
         },
         {
           "$ref": "#/$defs/FluidContactSurfaceStandardResult"
+        },
+        {
+          "$ref": "#/$defs/FluidContactOutlineStandardResult"
         }
       ],
       "title": "AnyStandardResult"
@@ -3770,6 +3773,28 @@
         "fluid_contact"
       ],
       "title": "FluidContactData",
+      "type": "object"
+    },
+    "FluidContactOutlineStandardResult": {
+      "description": "The ``standard_result`` field contains information about which standard results this\ndata object represent.\nThis class contains metadata for the 'fluid_contact_outline' standard result.",
+      "properties": {
+        "file_schema": {
+          "$ref": "#/$defs/FileSchema",
+          "default": {
+            "url": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/file_formats/0.1.0/fluid_contact_outline.json",
+            "version": "0.1.0"
+          }
+        },
+        "name": {
+          "const": "fluid_contact_outline",
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "FluidContactOutlineStandardResult",
       "type": "object"
     },
     "FluidContactSurfaceStandardResult": {

--- a/src/fmu/dataio/_models/fmu_results/enums.py
+++ b/src/fmu/dataio/_models/fmu_results/enums.py
@@ -13,6 +13,7 @@ class StandardResultName(str, Enum):
     structure_depth_isochore = "structure_depth_isochore"
     structure_depth_fault_lines = "structure_depth_fault_lines"
     fluid_contact_surface = "fluid_contact_surface"
+    fluid_contact_outline = "fluid_contact_outline"
 
 
 class Classification(str, Enum):

--- a/src/fmu/dataio/_models/fmu_results/standard_result.py
+++ b/src/fmu/dataio/_models/fmu_results/standard_result.py
@@ -11,6 +11,7 @@ from pydantic import (
 
 from fmu.dataio._models.standard_results import (
     FieldOutlineSchema,
+    FluidContactOutlineSchema,
     InplaceVolumesSchema,
     StructureDepthFaultLinesSchema,
 )
@@ -143,6 +144,25 @@ class FluidContactSurfaceStandardResult(StandardResult):
     """The identifying name for the 'fluid_contact_surface' standard result."""
 
 
+class FluidContactOutlineStandardResult(StandardResult):
+    """
+    The ``standard_result`` field contains information about which standard results this
+    data object represent.
+    This class contains metadata for the 'fluid_contact_outline' standard result.
+    """
+
+    name: Literal[enums.StandardResultName.fluid_contact_outline]
+    """The identifying name for the 'fluid_contact_outline' standard result."""
+
+    file_schema: FileSchema = FileSchema(
+        version=FluidContactOutlineSchema.VERSION,
+        url=AnyHttpUrl(FluidContactOutlineSchema.url()),
+    )
+    """
+    The schema identifying the format of the 'fluid_contact_outline' standard result.
+    """
+
+
 class AnyStandardResult(RootModel):
     """
     The ``standard result`` field contains information about which standard result this
@@ -161,6 +181,7 @@ class AnyStandardResult(RootModel):
         | StructureTimeSurfaceStandardResult
         | StructureDepthIsochoreStandardResult
         | StructureDepthFaultLinesStandardResult
-        | FluidContactSurfaceStandardResult,
+        | FluidContactSurfaceStandardResult
+        | FluidContactOutlineStandardResult,
         Field(discriminator="name"),
     ]

--- a/src/fmu/dataio/_models/standard_results/__init__.py
+++ b/src/fmu/dataio/_models/standard_results/__init__.py
@@ -1,4 +1,5 @@
 from .field_outline import FieldOutlineResult, FieldOutlineSchema
+from .fluid_contact_outline import FluidContactOutlineResult, FluidContactOutlineSchema
 from .inplace_volumes import InplaceVolumesResult, InplaceVolumesSchema
 from .structure_depth_fault_lines import (
     StructureDepthFaultLinesResult,
@@ -12,4 +13,6 @@ __all__ = [
     "InplaceVolumesSchema",
     "StructureDepthFaultLinesSchema",
     "StructureDepthFaultLinesResult",
+    "FluidContactOutlineSchema",
+    "FluidContactOutlineResult",
 ]

--- a/src/fmu/dataio/_models/standard_results/fluid_contact_outline.py
+++ b/src/fmu/dataio/_models/standard_results/fluid_contact_outline.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field, RootModel
+
+from fmu.dataio._models._schema_base import FmuSchemas, SchemaBase
+
+if TYPE_CHECKING:
+    from pathlib import Path
+    from typing import Any
+
+    from fmu.dataio.types import VersionStr
+
+
+class FluidContactOutlineResultRow(BaseModel):
+    """Represents the columns of a row in a fluid contact outline export.
+
+    These fields are the current agreed upon standard result. Changes to the fields or
+    their validation should cause the version defined in the standard result schema to
+    increase the version number in a way that corresponds to the schema versioning
+    specification (i.e. they are a patch, minor, or major change)."""
+
+    X_UTME: float
+    """The X coordinate this row represents. Required."""
+
+    Y_UTMN: float
+    """The Y coordinate this row represents. Required."""
+
+    Z_TVDSS: float
+    """The Z coordinate (depth) this row represents. Required."""
+
+    POLY_ID: int = Field(ge=0)
+    """Index column. The id of the polygon which this row represents. Required."""
+
+
+class FluidContactOutlineResult(RootModel):
+    """Represents the resultant fluid contact outline parquet file, which is
+    naturally a list of rows.
+
+    Consumers who retrieve this parquet file must read it into a json-dictionary
+    equivalent format to validate it against the schema."""
+
+    root: list[FluidContactOutlineResultRow]
+
+
+class FluidContactOutlineSchema(SchemaBase):
+    """This class represents the schema that is used to validate the fault lines
+    table being exported. This means that the version, schema filename, and schema
+    location corresponds directly with the values and their validation constraints,
+    documented above."""
+
+    VERSION: VersionStr = "0.1.0"
+    """The version of this schema."""
+
+    VERSION_CHANGELOG: str = """
+    #### 0.1.0
+
+    This is the initial schema version.
+    """
+
+    FILENAME: str = "fluid_contact_outline.json"
+    """The filename this schema is written to."""
+
+    PATH: Path = FmuSchemas.PATH / "file_formats" / VERSION / FILENAME
+    """The local and URL path of this schema."""
+
+    @classmethod
+    def dump(cls) -> dict[str, Any]:
+        return FluidContactOutlineResult.model_json_schema(
+            schema_generator=cls.default_generator()
+        )


### PR DESCRIPTION
Towards https://github.com/equinor/fmu-dataio/issues/1208

Add standard_result 'fluid_contact_outline' to the schema.
A simple export for it will be created in a subsequent PR.

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
