### PR TITLE
TST: add TSurf file read test when path is string (#1212)

### DIFF
--- a/tests/test_units/test_reader_tsurf.py
+++ b/tests/test_units/test_reader_tsurf.py
@@ -108,6 +108,14 @@ def test_tsurf_reader_and_writer(tsurf: reader.TSurfData, rootpath: Path) -> Non
         match="Input is empty",
     ):
         reader.read_tsurf_file(filepath)
+
+    # ---------- Filepath as string ----------
+    filepath_str = str(filepath)
+    with pytest.raises(
+        ValueError,
+        match="Input is empty",
+    ):
+        reader.read_tsurf_file(filepath_str)
     filepath.unlink(missing_ok=True)
 
     # ---------- Invalid input ----------


### PR DESCRIPTION
Resolves #1212 

Added test for reading TSurf file when its path is a string (and not e.g. a Path)

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
