### PR TITLE
ENH: option to get schema version list as json

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,3 +1,8 @@
+map $arg_json $autoindex {
+    true     @json;
+    default  @html;
+}
+
 server {
        listen 8080;
 
@@ -5,6 +10,16 @@ server {
 
        root /app;
        location /schemas/ {
-                autoindex on;
+              try_files "" $autoindex;
+       }
+
+       location @html {
+              autoindex on;
+              autoindex_format $arg_json;
+       }
+
+       location @json { # return json format if uri includes ?json=true
+              autoindex on;
+              autoindex_format json;
        }
 }


### PR DESCRIPTION
Resolves #issue

Add option to list schema versions in json format by adding `?json=true` to the request uri.

Related to tasks in Sumo where we want to run our tests using all available schema versions.
- https://github.com/equinor/sumo-canary/issues/210
- https://github.com/equinor/sumo-canary/issues/207

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
