### PR TITLE
ENH: split fmu class

### DIFF
--- a/src/fmu/dataio/_metadata.py
+++ b/src/fmu/dataio/_metadata.py
@@ -16,7 +16,7 @@ from pydantic import Field
 
 from ._logging import null_logger
 from ._models.fmu_results import data, fields
-from ._models.fmu_results.enums import FMUClass
+from ._models.fmu_results.enums import FMUResultsMetadataClass
 from ._models.fmu_results.fmu_results import (
     CaseMetadata,
     ObjectMetadata,
@@ -50,8 +50,8 @@ class ObjectMetadataExport(ObjectMetadata, populate_by_name=True):
 class CaseMetadataExport(CaseMetadata, populate_by_name=True):
     """Adds the optional description field for backward compatibility."""
 
-    class_: Literal[FMUClass.case] = Field(
-        default=FMUClass.case, alias="class", title="metadata_class"
+    class_: Literal[FMUResultsMetadataClass.case] = Field(
+        default=FMUResultsMetadataClass.case, alias="class", title="metadata_class"
     )
     description: list[str] | None = Field(default=None)
 

--- a/src/fmu/dataio/_models/fmu_results/enums.py
+++ b/src/fmu/dataio/_models/fmu_results/enums.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from enum import Enum, IntEnum
+from enum import Enum, IntEnum, StrEnum
 
 
-class StandardResultName(str, Enum):
+class StandardResultName(StrEnum):
     """The standard result name of a given data object."""
 
     field_outline = "field_outline"
@@ -16,7 +16,7 @@ class StandardResultName(str, Enum):
     fluid_contact_outline = "fluid_contact_outline"
 
 
-class Classification(str, Enum):
+class Classification(StrEnum):
     """The security classification for a given data object."""
 
     asset = "asset"
@@ -31,7 +31,7 @@ class AxisOrientation(IntEnum):
     flipped = -1
 
 
-class Content(str, Enum):
+class Content(StrEnum):
     """The content type of a given data object."""
 
     depth = "depth"
@@ -83,13 +83,13 @@ class ErtSimulationMode(str, Enum):
     workflow = "workflow"
 
 
-class FMUClass(str, Enum):
-    """The class of a data object by FMU convention or standards."""
+class MetadataClass(StrEnum):
+    """Base class for objects by FMU convention or standards."""
 
-    case = "case"
-    realization = "realization"
-    iteration = "iteration"
-    ensemble = "ensemble"
+
+class ObjectMetadataClass(MetadataClass):
+    """The class of a data object (typically originating from an RMS model)."""
+
     surface = "surface"
     triangulated_surface = "triangulated_surface"
     table = "table"
@@ -102,7 +102,16 @@ class FMUClass(str, Enum):
     dictionary = "dictionary"
 
 
-class Layout(str, Enum):
+class FMUResultsMetadataClass(MetadataClass):
+    """The class of an FMU results object."""
+
+    case = "case"
+    realization = "realization"
+    iteration = "iteration"
+    ensemble = "ensemble"
+
+
+class Layout(StrEnum):
     """The layout of a given data object."""
 
     regular = "regular"
@@ -123,18 +132,18 @@ class FMUContext(str, Enum):
     realization = "realization"
 
 
-class VerticalDomain(str, Enum):
+class VerticalDomain(StrEnum):
     depth = "depth"
     time = "time"
 
 
-class DomainReference(str, Enum):
+class DomainReference(StrEnum):
     msl = "msl"
     sb = "sb"
     rkb = "rkb"
 
 
-class TrackLogEventType(str, Enum):
+class TrackLogEventType(StrEnum):
     """The type of event being logged"""
 
     created = "created"
@@ -142,7 +151,7 @@ class TrackLogEventType(str, Enum):
     merged = "merged"
 
 
-class FluidContactType(str, Enum):
+class FluidContactType(StrEnum):
     """The type of fluid contact."""
 
     fgl = "fgl"
@@ -161,7 +170,7 @@ class FluidContactType(str, Enum):
     """Oil-water contact."""
 
 
-class FileFormat(str, Enum):
+class FileFormat(StrEnum):
     """The format of a given data object."""
 
     parquet = "parquet"

--- a/src/fmu/dataio/_models/fmu_results/fmu_results.py
+++ b/src/fmu/dataio/_models/fmu_results/fmu_results.py
@@ -20,7 +20,7 @@ from fmu.dataio._models._schema_base import (
 from fmu.dataio.types import VersionStr
 
 from .data import AnyData
-from .enums import FMUClass
+from .enums import FMUResultsMetadataClass, MetadataClass, ObjectMetadataClass
 from .fields import (
     FMU,
     Access,
@@ -192,7 +192,7 @@ class FmuResultsSchema(SchemaBase):
 class MetadataBase(BaseModel):
     """Base model for all root metadata models generated."""
 
-    class_: FMUClass = Field(alias="class", title="metadata_class")
+    class_: MetadataClass = Field(alias="class", title="metadata_class")
     """The class of this metadata object. Functions as the discriminating field."""
 
     masterdata: Masterdata
@@ -224,7 +224,9 @@ class CaseMetadata(MetadataBase):
     corresponding to /scratch/<asset>/<user>/<my case name>/.
     """
 
-    class_: Literal[FMUClass.case] = Field(alias="class", title="metadata_class")
+    class_: Literal[FMUResultsMetadataClass.case] = Field(
+        alias="class", title="metadata_class"
+    )
     """The class of this metadata object. In this case, always an FMU case."""
 
     fmu: FMUBase
@@ -239,7 +241,9 @@ class CaseMetadata(MetadataBase):
 class IterationMetadata(MetadataBase):
     """Deprecated and replaced by :class:`EnsembleMetadata`."""
 
-    class_: Literal[FMUClass.iteration] = Field(alias="class", title="metadata_class")
+    class_: Literal[FMUResultsMetadataClass.iteration] = Field(
+        alias="class", title="metadata_class"
+    )
     """The class of this metadata object. In this case, always an FMU iteration."""
 
     fmu: FMUIteration
@@ -257,7 +261,9 @@ class EnsembleMetadata(MetadataBase):
     An object representing a single Ensemble of a specific case.
     """
 
-    class_: Literal[FMUClass.ensemble] = Field(alias="class", title="metadata_class")
+    class_: Literal[FMUResultsMetadataClass.ensemble] = Field(
+        alias="class", title="metadata_class"
+    )
     """The class of this metadata object. In this case, always an FMU ensemble."""
 
     fmu: FMUEnsemble
@@ -275,7 +281,9 @@ class RealizationMetadata(MetadataBase):
     An object representing a single Realization of a specific Ensemble.
     """
 
-    class_: Literal[FMUClass.realization] = Field(alias="class", title="metadata_class")
+    class_: Literal[FMUResultsMetadataClass.realization] = Field(
+        alias="class", title="metadata_class"
+    )
     """The class of this metadata object. In this case, always an FMU realization."""
 
     fmu: FMURealization
@@ -291,16 +299,16 @@ class ObjectMetadata(MetadataBase):
     """The FMU metadata model for a given data object."""
 
     class_: Literal[
-        FMUClass.surface,
-        FMUClass.triangulated_surface,
-        FMUClass.table,
-        FMUClass.cpgrid,
-        FMUClass.cpgrid_property,
-        FMUClass.polygons,
-        FMUClass.cube,
-        FMUClass.well,
-        FMUClass.points,
-        FMUClass.dictionary,
+        ObjectMetadataClass.surface,
+        ObjectMetadataClass.triangulated_surface,
+        ObjectMetadataClass.table,
+        ObjectMetadataClass.cpgrid,
+        ObjectMetadataClass.cpgrid_property,
+        ObjectMetadataClass.polygons,
+        ObjectMetadataClass.cube,
+        ObjectMetadataClass.well,
+        ObjectMetadataClass.points,
+        ObjectMetadataClass.dictionary,
     ] = Field(
         alias="class",
         title="metadata_class",
@@ -344,7 +352,7 @@ class FmuResults(
     @model_validator(mode="after")
     def _check_class_data_spec(self) -> FmuResults:
         if (
-            self.root.class_ in (FMUClass.table, FMUClass.surface)
+            self.root.class_ in (ObjectMetadataClass.table, ObjectMetadataClass.surface)
             and hasattr(self.root, "data")
             and self.root.data.root.spec is None
         ):

--- a/src/fmu/dataio/external_interfaces/sumo_explorer_interface.py
+++ b/src/fmu/dataio/external_interfaces/sumo_explorer_interface.py
@@ -5,7 +5,7 @@ import pandas as pd
 import xtgeo
 from pandas import DataFrame
 
-from fmu.dataio._models.fmu_results.enums import FMUClass
+from fmu.dataio._models.fmu_results.enums import ObjectMetadataClass
 from fmu.sumo.explorer import Explorer
 from fmu.sumo.explorer.objects import SearchContext
 
@@ -15,12 +15,12 @@ class SumoExplorerInterface:
         self,
         case_id: UUID,
         ensemble_name: str,
-        fmu_class: FMUClass,
+        fmu_class: ObjectMetadataClass,
         standard_result_name: str,
     ) -> None:
         self._case_id: UUID = case_id
         self._ensemble_name: str = ensemble_name
-        self._fmu_class: FMUClass = fmu_class
+        self._fmu_class: ObjectMetadataClass = fmu_class
 
         # TODO: Use sumo prod when ready
         sumo = Explorer(env="dev")
@@ -35,16 +35,16 @@ class SumoExplorerInterface:
         """Get a fmu-dataio formatted data object from the Sumo Explorer object."""
 
         match self._fmu_class:
-            case FMUClass.table:
+            case ObjectMetadataClass.table:
                 return data_object.to_pandas()
 
-            case FMUClass.polygons:
+            case ObjectMetadataClass.polygons:
                 data_frame: DataFrame = pd.read_parquet(
                     data_object.blob, engine="pyarrow"
                 )
                 return xtgeo.Polygons(data_frame)
 
-            case FMUClass.surface:
+            case ObjectMetadataClass.surface:
                 # Dataformat: 'irap_binary'
                 return data_object.to_regular_surface()
 

--- a/src/fmu/dataio/load/load_standard_results.py
+++ b/src/fmu/dataio/load/load_standard_results.py
@@ -7,7 +7,10 @@ import numpy as np
 import xtgeo
 from pandas import DataFrame
 
-from fmu.dataio._models.fmu_results.enums import FMUClass, StandardResultName
+from fmu.dataio._models.fmu_results.enums import (
+    ObjectMetadataClass,
+    StandardResultName,
+)
 from fmu.dataio.export._decorators import experimental
 from fmu.dataio.external_interfaces.schema_validation_interface import (
     SchemaValidationInterface,
@@ -24,7 +27,7 @@ class StandardResultsLoader:
         self,
         case_id: UUID,
         ensemble_name: str,
-        fmu_class: FMUClass,
+        fmu_class: ObjectMetadataClass,
         standard_result_name: str,
     ) -> None:
         self._sumo_interface = SumoExplorerInterface(
@@ -96,7 +99,12 @@ class TabularStandardResultsLoader(StandardResultsLoader):
     def __init__(
         self, case_id: UUID, ensemble_name: str, standard_result_name: str
     ) -> None:
-        super().__init__(case_id, ensemble_name, FMUClass.table, standard_result_name)
+        super().__init__(
+            case_id,
+            ensemble_name,
+            ObjectMetadataClass.table,
+            standard_result_name,
+        )
 
     def get_realization(self, realization_id: int) -> dict[str, DataFrame]:
         return super().get_realization(realization_id)
@@ -137,7 +145,7 @@ class PolygonStandardResultsLoader(StandardResultsLoader):
         self, case_id: UUID, ensemble_name: str, standard_result_name: str
     ) -> None:
         super().__init__(
-            case_id, ensemble_name, FMUClass.polygons, standard_result_name
+            case_id, ensemble_name, ObjectMetadataClass.polygons, standard_result_name
         )
 
     def get_realization(self, realization_id: int) -> dict[str, xtgeo.Polygons]:
@@ -183,7 +191,12 @@ class SurfacesStandardResultsLoader(StandardResultsLoader):
     def __init__(
         self, case_id: UUID, ensemble_name: str, standard_result_name: str
     ) -> None:
-        super().__init__(case_id, ensemble_name, FMUClass.surface, standard_result_name)
+        super().__init__(
+            case_id,
+            ensemble_name,
+            ObjectMetadataClass.surface,
+            standard_result_name,
+        )
 
     def get_realization(self, realization_id: int) -> dict[str, xtgeo.RegularSurface]:
         return super().get_realization(realization_id)

--- a/src/fmu/dataio/providers/objectdata/_base.py
+++ b/src/fmu/dataio/providers/objectdata/_base.py
@@ -34,7 +34,11 @@ if TYPE_CHECKING:
         BoundingBox3D,
         Geometry,
     )
-    from fmu.dataio._models.fmu_results.enums import FileFormat, FMUClass, Layout
+    from fmu.dataio._models.fmu_results.enums import (
+        FileFormat,
+        Layout,
+        MetadataClass,
+    )
     from fmu.dataio._models.fmu_results.specification import AnySpecification
     from fmu.dataio._models.fmu_results.standard_result import StandardResult
     from fmu.dataio.dataio import ExportData
@@ -119,7 +123,7 @@ class ObjectDataProvider(Provider):
 
     @property
     @abstractmethod
-    def classname(self) -> FMUClass:
+    def classname(self) -> MetadataClass:
         raise NotImplementedError
 
     @property

--- a/src/fmu/dataio/providers/objectdata/_faultroom.py
+++ b/src/fmu/dataio/providers/objectdata/_faultroom.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Final
 from fmu.dataio._definitions import ExportFolder, FileExtension
 from fmu.dataio._logging import null_logger
 from fmu.dataio._models.fmu_results.data import BoundingBox3D
-from fmu.dataio._models.fmu_results.enums import FileFormat, FMUClass, Layout
+from fmu.dataio._models.fmu_results.enums import FileFormat, Layout, ObjectMetadataClass
 from fmu.dataio._models.fmu_results.global_configuration import (
     GlobalConfiguration,
 )
@@ -32,8 +32,8 @@ class FaultRoomSurfaceProvider(ObjectDataProvider):
     obj: FaultRoomSurface
 
     @property
-    def classname(self) -> FMUClass:
-        return FMUClass.surface
+    def classname(self) -> ObjectMetadataClass:
+        return ObjectMetadataClass.surface
 
     @property
     def efolder(self) -> str:

--- a/src/fmu/dataio/providers/objectdata/_provider.py
+++ b/src/fmu/dataio/providers/objectdata/_provider.py
@@ -97,7 +97,7 @@ import xtgeo
 
 from fmu.dataio._definitions import ExportFolder, FileExtension
 from fmu.dataio._logging import null_logger
-from fmu.dataio._models.fmu_results.enums import FileFormat, FMUClass, Layout
+from fmu.dataio._models.fmu_results.enums import FileFormat, Layout, ObjectMetadataClass
 from fmu.dataio._readers.faultroom import FaultRoomSurface
 from fmu.dataio._readers.tsurf import TSurfData
 
@@ -193,8 +193,8 @@ class DictionaryDataProvider(ObjectDataProvider):
     obj: dict
 
     @property
-    def classname(self) -> FMUClass:
-        return FMUClass.dictionary
+    def classname(self) -> ObjectMetadataClass:
+        return ObjectMetadataClass.dictionary
 
     @property
     def efolder(self) -> str:

--- a/src/fmu/dataio/providers/objectdata/_tables.py
+++ b/src/fmu/dataio/providers/objectdata/_tables.py
@@ -13,7 +13,12 @@ from fmu.dataio._definitions import (
     FileExtension,
 )
 from fmu.dataio._logging import null_logger
-from fmu.dataio._models.fmu_results.enums import Content, FileFormat, FMUClass, Layout
+from fmu.dataio._models.fmu_results.enums import (
+    Content,
+    FileFormat,
+    Layout,
+    ObjectMetadataClass,
+)
 from fmu.dataio._models.fmu_results.specification import TableSpecification
 from fmu.dataio.exceptions import ConfigurationError
 
@@ -149,8 +154,8 @@ class DataFrameDataProvider(ObjectDataProvider):
     obj: pd.DataFrame
 
     @property
-    def classname(self) -> FMUClass:
-        return FMUClass.table
+    def classname(self) -> ObjectMetadataClass:
+        return ObjectMetadataClass.table
 
     @property
     def efolder(self) -> str:
@@ -218,8 +223,8 @@ class ArrowTableDataProvider(ObjectDataProvider):
     obj: pyarrow.Table
 
     @property
-    def classname(self) -> FMUClass:
-        return FMUClass.table
+    def classname(self) -> ObjectMetadataClass:
+        return ObjectMetadataClass.table
 
     @property
     def efolder(self) -> str:

--- a/src/fmu/dataio/providers/objectdata/_triangulated_surface.py
+++ b/src/fmu/dataio/providers/objectdata/_triangulated_surface.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Final
 from fmu.dataio._definitions import ExportFolder, FileExtension
 from fmu.dataio._logging import null_logger
 from fmu.dataio._models.fmu_results.data import BoundingBox3D
-from fmu.dataio._models.fmu_results.enums import FileFormat, FMUClass, Layout
+from fmu.dataio._models.fmu_results.enums import FileFormat, Layout, ObjectMetadataClass
 from fmu.dataio._models.fmu_results.specification import (
     TriangulatedSurfaceSpecification,
 )
@@ -32,8 +32,8 @@ class TriangulatedSurfaceProvider(ObjectDataProvider):
     obj: TSurfData
 
     @property
-    def classname(self) -> FMUClass:
-        return FMUClass.triangulated_surface
+    def classname(self) -> ObjectMetadataClass:
+        return ObjectMetadataClass.triangulated_surface
 
     @property
     def efolder(self) -> str:

--- a/src/fmu/dataio/providers/objectdata/_xtgeo.py
+++ b/src/fmu/dataio/providers/objectdata/_xtgeo.py
@@ -12,7 +12,7 @@ import pyarrow.parquet as pq
 from fmu.dataio._definitions import ExportFolder, FileExtension
 from fmu.dataio._logging import null_logger
 from fmu.dataio._models.fmu_results.data import BoundingBox2D, BoundingBox3D, Geometry
-from fmu.dataio._models.fmu_results.enums import FileFormat, FMUClass, Layout
+from fmu.dataio._models.fmu_results.enums import FileFormat, Layout, ObjectMetadataClass
 from fmu.dataio._models.fmu_results.specification import (
     CPGridPropertySpecification,
     CPGridSpecification,
@@ -58,8 +58,8 @@ class RegularSurfaceDataProvider(ObjectDataProvider):
     obj: xtgeo.RegularSurface
 
     @property
-    def classname(self) -> FMUClass:
-        return FMUClass.surface
+    def classname(self) -> ObjectMetadataClass:
+        return ObjectMetadataClass.surface
 
     @property
     def efolder(self) -> str:
@@ -148,8 +148,8 @@ class PolygonsDataProvider(ObjectDataProvider):
         super().__post_init__()
 
     @property
-    def classname(self) -> FMUClass:
-        return FMUClass.polygons
+    def classname(self) -> ObjectMetadataClass:
+        return ObjectMetadataClass.polygons
 
     @property
     def efolder(self) -> str:
@@ -264,8 +264,8 @@ class PointsDataProvider(ObjectDataProvider):
         super().__post_init__()
 
     @property
-    def classname(self) -> FMUClass:
-        return FMUClass.points
+    def classname(self) -> ObjectMetadataClass:
+        return ObjectMetadataClass.points
 
     @property
     def efolder(self) -> str:
@@ -371,8 +371,8 @@ class CubeDataProvider(ObjectDataProvider):
     obj: xtgeo.Cube
 
     @property
-    def classname(self) -> FMUClass:
-        return FMUClass.cube
+    def classname(self) -> ObjectMetadataClass:
+        return ObjectMetadataClass.cube
 
     @property
     def efolder(self) -> str:
@@ -459,8 +459,8 @@ class CPGridDataProvider(ObjectDataProvider):
     obj: xtgeo.Grid
 
     @property
-    def classname(self) -> FMUClass:
-        return FMUClass.cpgrid
+    def classname(self) -> ObjectMetadataClass:
+        return ObjectMetadataClass.cpgrid
 
     @property
     def efolder(self) -> str:
@@ -549,8 +549,8 @@ class CPGridPropertyDataProvider(ObjectDataProvider):
     obj: xtgeo.GridProperty
 
     @property
-    def classname(self) -> FMUClass:
-        return FMUClass.cpgrid_property
+    def classname(self) -> ObjectMetadataClass:
+        return ObjectMetadataClass.cpgrid_property
 
     @property
     def efolder(self) -> str:

--- a/tests/test_loaders/test_sumo_interface.py
+++ b/tests/test_loaders/test_sumo_interface.py
@@ -5,7 +5,7 @@ import pandas as pd
 import xtgeo
 from pandas import DataFrame
 
-from fmu.dataio._models.fmu_results.enums import FMUClass, StandardResultName
+from fmu.dataio._models.fmu_results.enums import ObjectMetadataClass, StandardResultName
 from fmu.dataio.external_interfaces.sumo_explorer_interface import SumoExplorerInterface
 from fmu.sumo.explorer import Explorer
 
@@ -42,7 +42,7 @@ def test_get_realization_ids():
         sumo_interface = SumoExplorerInterface(
             "some_case_id",
             ensemble_name,
-            FMUClass.table,
+            ObjectMetadataClass.table,
             StandardResultName.inplace_volumes,
         )
 
@@ -50,7 +50,7 @@ def test_get_realization_ids():
         assert actual_realization_ids == realization_ids_mock
 
 
-def test_get_realalization():
+def test_get_realization():
     ensemble_name = "iter-0"
     realization_id = 0
 
@@ -70,7 +70,7 @@ def test_get_realalization():
         sumo_interface = SumoExplorerInterface(
             "some_case_id",
             ensemble_name,
-            FMUClass.table,
+            ObjectMetadataClass.table,
             StandardResultName.inplace_volumes,
         )
 
@@ -104,7 +104,7 @@ def test_get_realization_with_metadata():
         sumo_interface = SumoExplorerInterface(
             "some_case_id",
             ensemble_name,
-            FMUClass.table,
+            ObjectMetadataClass.table,
             StandardResultName.inplace_volumes,
         )
 
@@ -138,7 +138,7 @@ def test_get_blobs():
         sumo_interface = SumoExplorerInterface(
             "some_case_id",
             ensemble_name,
-            FMUClass.table,
+            ObjectMetadataClass.table,
             StandardResultName.inplace_volumes,
         )
 
@@ -166,7 +166,7 @@ def test_correct_data_format_returned(unregister_pandas_parquet):
         sumo_interface = SumoExplorerInterface(
             "some_case_id",
             ensemble_name,
-            FMUClass.table,
+            ObjectMetadataClass.table,
             StandardResultName.inplace_volumes,
         )
         table_data = sumo_interface.get_realization(realization_id)
@@ -200,7 +200,7 @@ def test_correct_data_format_returned(unregister_pandas_parquet):
         sumo_interface = SumoExplorerInterface(
             "some_case_id",
             ensemble_name,
-            FMUClass.polygons,
+            ObjectMetadataClass.polygons,
             StandardResultName.field_outline,
         )
         polygon_data = sumo_interface.get_realization(realization_id)
@@ -228,7 +228,7 @@ def test_correct_data_format_returned(unregister_pandas_parquet):
         sumo_interface = SumoExplorerInterface(
             "some_case_id",
             ensemble_name,
-            FMUClass.surface,
+            ObjectMetadataClass.surface,
             StandardResultName.structure_depth_surface,
         )
         surface_data = sumo_interface.get_realization(realization_id)


### PR DESCRIPTION
Addresses #1148 

The enum `FMUClass` in `fmu_results` is split in two separate classes of metadata for a) data objects (often originating from RMS) and for b) results from FMU.
Moreover, most of the enums are now based on StrEnum rather than (str, Enum). But two of the enums were not straight-forward to update.

A replacement of the literal in the schema revealed challenges that are not addressed in this PR. Hence the enum for object metadata is still taken as literal when added into the object metadata schema.


## Checklist

- [x] Tests are updated
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
