### PR TITLE
ENH: Add simple_export for 'fluid_contact_surface'

### DIFF
--- a/docs/src/standard_results/fluid_contact_surfaces.md
+++ b/docs/src/standard_results/fluid_contact_surfaces.md
@@ -1,0 +1,59 @@
+# Initial fluid contact surfaces 
+
+This exports modelled initial fluid contact surfaces from within RMS.
+
+Each fluid contact surface corresponds to a specific zone or a group of zones 
+that share a common fluid contact. These surfaces typically cover the full spatial
+extent of the zone, and are not restricted to areas above the contact.
+
+The fluid contact types supported is 
+- `fwl` (Free water level)
+- `fgl` (Free gas level)
+- `goc` (Gas-oil contact)
+- `gwc` (Gas-water contact)
+- `owc` (Oil-water contact)
+
+
+:::{table} Current
+:widths: auto
+:align: left
+
+| Field | Value |
+| --- | --- |
+| Version | NA |
+| Output | `share/results/maps/fluid_contact_surface/contactname/surfacename.gri` |
+| Security classification | 🟡 Internal |
+:::
+
+## Requirements
+
+- RMS
+- fluid contact surfaces stored in the `General 2D data` folder within RMS.
+- names of surfaces defined in the `stratigraphy` block
+
+A folder named `fluid_contact_surfaces` must exist in the root of the `General 2D data`
+folder in RMS. This folder should contain at least one subfolder with a valid fluid contact
+name (e.g., `fwl`, see the list above). The export function will automatically process
+and export all surfaces found within these subfolders.
+
+:::{note}
+The names of the fluid contact surfaces must be defined in the `stratigraphy` block of the
+configuration to enable mapping against masterdata.
+:::
+
+## Usage
+
+```{eval-rst}
+.. autofunction:: fmu.dataio.export.rms.fluid_contact_surfaces.export_fluid_contact_surfaces
+```
+
+## Result
+
+The fluid contact surfaces from the `General 2D data` folder will be exported as
+'irap_binary' files to `share/results/maps/fluid_contact_surface/contactname/surfacename.gri`.
+
+
+## Standard result schema
+
+This standard result is not presented in a tabular format; therefore, no validation
+schema exists.

--- a/src/fmu/dataio/export/rms/__init__.py
+++ b/src/fmu/dataio/export/rms/__init__.py
@@ -1,4 +1,5 @@
 from .field_outline import export_field_outline
+from .fluid_contact_surfaces import export_fluid_contact_surfaces
 from .inplace_volumes import export_inplace_volumes, export_rms_volumetrics
 from .structure_depth_fault_lines import export_structure_depth_fault_lines
 from .structure_depth_isochores import export_structure_depth_isochores
@@ -11,4 +12,5 @@ __all__ = [
     "export_inplace_volumes",
     "export_rms_volumetrics",
     "export_field_outline",
+    "export_fluid_contact_surfaces",
 ]

--- a/src/fmu/dataio/export/rms/fluid_contact_surfaces.py
+++ b/src/fmu/dataio/export/rms/fluid_contact_surfaces.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Final
+
+import fmu.dataio as dio
+from fmu.dataio._logging import null_logger
+from fmu.dataio._models.fmu_results import standard_result
+from fmu.dataio._models.fmu_results.enums import (
+    Classification,
+    Content,
+    FluidContactType,
+    StandardResultName,
+)
+from fmu.dataio.exceptions import ValidationError
+from fmu.dataio.export._decorators import experimental
+from fmu.dataio.export._export_result import ExportResult, ExportResultItem
+from fmu.dataio.export.rms._base import SimpleExportRMSBase
+from fmu.dataio.export.rms._utils import (
+    get_rms_project_units,
+    get_surfaces_in_general2d_folder,
+    list_folder_names_in_general2d_folder,
+    validate_name_in_stratigraphy,
+)
+
+if TYPE_CHECKING:
+    import xtgeo
+
+_logger: Final = null_logger(__name__)
+
+GENERAL2D_FOLDER = "fluid_contact_surfaces"
+
+
+class _ExportFluidContactSurfaces(SimpleExportRMSBase):
+    def __init__(self, project: Any) -> None:
+        super().__init__()
+
+        _logger.debug("Process data, establish state prior to export.")
+        self.project = project
+        self._contact_surfaces = self._get_contact_surfaces()
+        self._unit = "m" if get_rms_project_units(project) == "metric" else "ft"
+        _logger.debug("Process data... DONE")
+
+    @property
+    def _standard_result(self) -> standard_result.FluidContactSurfaceStandardResult:
+        """Standard result type for the exported data."""
+        return standard_result.FluidContactSurfaceStandardResult(
+            name=StandardResultName.fluid_contact_surface
+        )
+
+    @property
+    def _content(self) -> Content:
+        """Get content for the exported data."""
+        return Content.fluid_contact
+
+    @property
+    def _classification(self) -> Classification:
+        """Get default classification."""
+        return Classification.internal
+
+    @property
+    def _rep_include(self) -> bool:
+        """rep_include status"""
+        return True
+
+    def _get_contacts(self) -> list[FluidContactType]:
+        """
+        Get FluidContactTypes from available subfolder names in the main folder.
+        Folders with invalid contact names will be skipped. If no valid contact
+        names are found an error is raised.
+        """
+
+        contact_folders = list_folder_names_in_general2d_folder(
+            self.project, folder_path=[GENERAL2D_FOLDER]
+        )
+        valid_contact_folders = []
+        for contact in contact_folders:
+            try:
+                valid_contact_folders.append(FluidContactType(contact))
+            except ValueError:
+                _logger.info(f"{contact} is not a valid contact name, skipping folder.")
+                continue
+
+        _logger.debug(f"Found valid contact folders {valid_contact_folders}.")
+        return valid_contact_folders
+
+    def _contact_folder_present(self) -> bool:
+        """Check if the main contact folder is present in General 2D data"""
+        return GENERAL2D_FOLDER in self.project.general2d_data.folders
+
+    def _get_contact_surfaces(
+        self,
+    ) -> dict[FluidContactType, list[xtgeo.RegularSurface]]:
+        """
+        Get a dictionary with fluid contact surfaces per contact folder
+        found in the main folder.
+        """
+
+        if self._contact_folder_present() and (contacts := self._get_contacts()):
+            return {
+                contact: get_surfaces_in_general2d_folder(
+                    self.project, folder_path=[GENERAL2D_FOLDER, contact.value]
+                )
+                for contact in contacts
+            }
+        raise ValueError(
+            "Could not detect any fluid contact surfaces from RMS. "
+            f"Ensure the folder '{GENERAL2D_FOLDER}' exists in the "
+            "'General 2D data' folder, and that it contains minimum one subfolder "
+            f"with a valid contact name: {list(FluidContactType.__members__)}. The "
+            "contact surfaces should be contained inside these subfolders."
+        )
+
+    def _export_contact_surface(
+        self, contact: FluidContactType, surf: xtgeo.RegularSurface
+    ) -> ExportResultItem:
+        """Export a fluid contact surface as a standard result"""
+        edata = dio.ExportData(
+            config=self._config,
+            content=self._content,
+            content_metadata={"contact": contact, "truncated": False},
+            unit=self._unit,
+            vertical_domain="depth",
+            domain_reference="msl",
+            subfolder=f"{self._subfolder}/{contact.value}",
+            is_prediction=True,
+            name=surf.name,
+            classification=self._classification,
+            rep_include=self._rep_include,
+        )
+
+        absolute_export_path = edata._export_with_standard_result(
+            surf, standard_result=self._standard_result
+        )
+        _logger.debug("Surface exported to: %s", absolute_export_path)
+
+        return ExportResultItem(
+            absolute_path=Path(absolute_export_path),
+        )
+
+    def _export_data_as_standard_result(self) -> ExportResult:
+        """Do the actual export using dataio setup."""
+        result_items = []
+        for contact, surfaces in self._contact_surfaces.items():
+            for surf in surfaces:
+                result_items.append(self._export_contact_surface(contact, surf))
+        return ExportResult(items=result_items)
+
+    def _validate_data_pre_export(self) -> None:
+        """Data validations."""
+        # TODO: Check that all contacts have positive values
+        for contact, surfaces in self._contact_surfaces.items():
+            for surf in surfaces:
+                try:
+                    validate_name_in_stratigraphy(surf.name, self._config)
+                except ValidationError as err:
+                    raise ValidationError(
+                        f"Error detected for surface '{surf.name}' in the contact "
+                        f"folder '{contact.value}'. Detailed information:\n{str(err)}"
+                    ) from err
+
+
+@experimental
+def export_fluid_contact_surfaces(project: Any) -> ExportResult:
+    """Simplified interface when exporting initial fluid contact surfaces from RMS.
+
+    Args:
+        project: The 'magic' project variable in RMS.
+    Note:
+        This function is experimental and may change in future versions.
+
+    Examples:
+        Example usage in an RMS script::
+
+            from fmu.dataio.export.rms import export_fluid_contact_surfaces
+
+            export_results = export_fluid_contact_surfaces(project)
+
+            for result in export_results.items:
+                print(f"Output surfaces to {result.absolute_path}")
+
+    """
+
+    return _ExportFluidContactSurfaces(project).export()

--- a/tests/test_export_rms/conftest.py
+++ b/tests/test_export_rms/conftest.py
@@ -197,6 +197,7 @@ def mock_rmsapi():
     mock_rmsapi = MagicMock()
     mock_rmsapi.__version__ = "1.7"
     mock_rmsapi.jobs.Job.get_job(...).get_arguments.return_value = VOLJOB_PARAMS
+    mock_rmsapi.Surface = MagicMock
     yield mock_rmsapi
 
 
@@ -219,13 +220,35 @@ def mocked_rmsapi_modules(mock_rmsapi, mock_rmsapi_jobs):
         yield mocked_modules
 
 
+class MockGeneral2DFolders:
+    def __init__(self, folders):
+        self.folders = folders
+
+    def __getitem__(self, key):
+        # Handle list-based keys by joining them into a string
+        if isinstance(key, list):
+            key = "/".join(key)
+        return self.folders[key]
+
+
 @pytest.fixture
-def mock_project_variable():
+def mock_general2d_data():
+    general2d_mock = MagicMock()
+    mock_folders = {
+        "MainFolder": MagicMock(),
+        "MainFolder/SubFolder": MagicMock(),
+    }
+    general2d_mock.folders = MockGeneral2DFolders(mock_folders)
+    return general2d_mock
+
+
+@pytest.fixture
+def mock_project_variable(mock_general2d_data):
     # A mock_project variable for the RMS 'project' (potentially extend for later use)
     mock_project = MagicMock()
     mock_project.horizons.representations = ["DS_final"]
     mock_project.zones.representations = ["IS_final"]
-
+    mock_project.general2d_data = mock_general2d_data
     yield mock_project
 
 

--- a/tests/test_export_rms/test_export_fluid_contact_surfaces.py
+++ b/tests/test_export_rms/test_export_fluid_contact_surfaces.py
@@ -1,0 +1,181 @@
+from unittest import mock
+
+import pytest
+
+from fmu import dataio
+from fmu.dataio._logging import null_logger
+from fmu.dataio._models.fmu_results.enums import FluidContactType, StandardResultName
+from tests.utils import inside_rms
+
+logger = null_logger(__name__)
+
+
+CONTACT_FOLDERS = ["fwl", "goc"]
+
+
+@pytest.fixture
+def mock_export_class(
+    mock_project_variable,
+    monkeypatch,
+    rmssetup_with_fmuconfig,
+    xtgeo_zones,
+):
+    # needed to find the global config at correct place
+    monkeypatch.chdir(rmssetup_with_fmuconfig)
+
+    from fmu.dataio.export.rms.fluid_contact_surfaces import (
+        _ExportFluidContactSurfaces,
+    )
+
+    with (
+        mock.patch.object(
+            _ExportFluidContactSurfaces, "_contact_folder_present", return_value=True
+        ),
+        mock.patch(
+            "fmu.dataio.export.rms.fluid_contact_surfaces.list_folder_names_in_general2d_folder",
+            return_value=CONTACT_FOLDERS,
+        ),
+        mock.patch(
+            "fmu.dataio.export.rms.fluid_contact_surfaces.get_surfaces_in_general2d_folder",
+            return_value=xtgeo_zones,
+        ),
+    ):
+        yield _ExportFluidContactSurfaces(mock_project_variable)
+
+
+@pytest.mark.parametrize("contact", CONTACT_FOLDERS)
+@inside_rms
+def test_files_exported_with_metadata(
+    mock_export_class, rmssetup_with_fmuconfig, contact
+):
+    """Test that the standard_result is set correctly in the metadata"""
+
+    mock_export_class.export()
+
+    export_folder = (
+        rmssetup_with_fmuconfig
+        / f"../../share/results/maps/fluid_contact_surface/{contact}"
+    )
+    assert export_folder.exists()
+
+    assert (export_folder / "valysar.gri").exists()
+    assert (export_folder / "therys.gri").exists()
+    assert (export_folder / "volon.gri").exists()
+
+    assert (export_folder / ".valysar.gri.yml").exists()
+    assert (export_folder / ".therys.gri.yml").exists()
+    assert (export_folder / ".volon.gri.yml").exists()
+
+
+@inside_rms
+def test_no_valid_contact_folders_found(mock_export_class):
+    """Test that an error is raised if no valid contact surfaces are found"""
+
+    with (
+        mock.patch(
+            "fmu.dataio.export.rms.fluid_contact_surfaces.list_folder_names_in_general2d_folder",
+            return_value=["invalid_folder"],
+        ),
+        pytest.raises(ValueError, match="Could not detect"),
+    ):
+        mock_export_class._get_contact_surfaces()
+
+
+@inside_rms
+def test_only_valid_contact_folders_processed(
+    rmssetup_with_fmuconfig, mock_export_class
+):
+    """Test that only folders with valid contact names are processed"""
+
+    with mock.patch(
+        "fmu.dataio.export.rms.fluid_contact_surfaces.list_folder_names_in_general2d_folder",
+        return_value=["owc", "fwl", "invalid_folder", "gwc"],
+    ):
+        mock_export_class._contact_surfaces = mock_export_class._get_contact_surfaces()
+
+        assert set(mock_export_class._get_contacts()) == {
+            FluidContactType.owc,
+            FluidContactType.fwl,
+            FluidContactType.gwc,
+        }
+        mock_export_class.export()
+
+    export_folder = (
+        rmssetup_with_fmuconfig / "../../share/results/maps/fluid_contact_surface/"
+    )
+    assert export_folder.exists()
+    assert (export_folder / "owc").exists()
+    assert (export_folder / "fwl").exists()
+    assert (export_folder / "gwc").exists()
+    assert not (export_folder / "invalid_folder").exists()
+
+    # test for one of the folders that expected files are present
+    assert {file.name for file in (export_folder / "gwc").glob("*")} == {
+        "valysar.gri",
+        "therys.gri",
+        "volon.gri",
+        ".valysar.gri.yml",
+        ".therys.gri.yml",
+        ".volon.gri.yml",
+    }
+
+
+@inside_rms
+def test_standard_result_in_metadata(mock_export_class):
+    """Test that the standard_result is set correctly in the metadata"""
+
+    out = mock_export_class.export()
+    metadata = dataio.read_metadata(out.items[0].absolute_path)
+
+    assert "standard_result" in metadata["data"]
+    assert (
+        metadata["data"]["standard_result"]["name"]
+        == StandardResultName.fluid_contact_surface
+    )
+
+
+@inside_rms
+def test_public_export_function(mock_project_variable, mock_export_class):
+    """Test that the export function works"""
+
+    from fmu.dataio.export.rms import export_fluid_contact_surfaces
+
+    out = export_fluid_contact_surfaces(mock_project_variable)
+
+    assert len(out.items) == 6  # 3 per contact
+
+    metadata = dataio.read_metadata(out.items[0].absolute_path)
+
+    assert "fluid_contact" in metadata["data"]["content"]
+    assert metadata["data"]["fluid_contact"]["contact"] == "fwl"
+    assert metadata["data"]["fluid_contact"]["truncated"] is False
+
+    assert metadata["access"]["classification"] == "internal"
+    assert metadata["data"]["is_prediction"]
+    assert (
+        metadata["data"]["standard_result"]["name"]
+        == StandardResultName.fluid_contact_surface
+    )
+
+
+@inside_rms
+def test_unknown_name_in_stratigraphy_raises(mock_export_class):
+    """Test that an error is raised if horizon name is missing in the stratigraphy"""
+
+    mock_export_class._contact_surfaces["fwl"][0].name = "missing"
+
+    with pytest.raises(ValueError, match="not listed"):
+        mock_export_class.export()
+
+
+@inside_rms
+def test_config_missing(mock_project_variable, rmssetup_with_fmuconfig, monkeypatch):
+    """Test that an exception is raised if the config is missing."""
+
+    from fmu.dataio.export.rms import export_fluid_contact_surfaces
+
+    # move up one directory to trigger not finding the config
+    monkeypatch.chdir(rmssetup_with_fmuconfig.parent)
+
+    with pytest.raises(FileNotFoundError, match="Could not detect"):
+        export_fluid_contact_surfaces(mock_project_variable)


### PR DESCRIPTION
Resolves #1207 

PR to add a simple export for the `fluid_contact_surface` standard_result.

This simple export requires a folder named `fluid_contact_surfaces` in the root of the `General 2D data` folder in RMS. The export function will automatically look for subfolders with valid fluid contact names (members of the `enum.FluidContactType`) inside this  `fluid_contact_surfaces` folder, and export all surfaces found inside these contact folders.

Functionality to help create these contact surfaces is ongoing and will be added to `fmu-tools`. When in place the documentation will be updated with a link.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
