### PR TITLE
ENH: Add data class layer to simple loaders

### DIFF
--- a/.github/workflows/ci-fmudataio.yml
+++ b/.github/workflows/ci-fmudataio.yml
@@ -3,8 +3,6 @@ name: Test
 on:
   pull_request:
     branches: [main]
-  push:
-    branches: [main]
   schedule:
     - cron: "0 0 * * *"
 
@@ -16,9 +14,6 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12"]
         os: [ubuntu-latest]
-    permissions:
-      contents: read
-      id-token: write
     steps:
       - uses: actions/checkout@v4
 
@@ -44,22 +39,6 @@ jobs:
           pip install \
             "fmu-sumo-uploader @ git+https://github.com/equinor/fmu-sumo-uploader.git"
 
-      - name: Azure Login
-        if: ${{ github.ref == 'refs/heads/main' }}      
-        uses: Azure/login@v2
-        with:
-          client-id: ${{ secrets.SUMO_TEST_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.SUMO_TEST_SUBSCRIPTION_ID }}
-
-      - name: Get Sumo Explorer access token from Azure
-        if: ${{ github.ref == 'refs/heads/main' }}
-        run: |
-          az --version
-          az account list
-          access_token=$(az account get-access-token --scope api://88d2b022-3539-4dda-9e66-853801334a86/.default --query accessToken --output tsv)
-          echo "SUMO_ACCESS_TOKEN=$access_token" >> "$GITHUB_ENV"
-
       - name: Full test
         run: |
 
@@ -67,12 +46,12 @@ jobs:
           pip install -U pydantic
 
           if [[ "${{ github.event.pull_request.base.ref }}" == "staging" ]]; then
-            pytest -n auto -v --cov --cov-report term-missing --prod --ignore=tests/test_loaders/test_sumo_interface.py
+            pytest -n auto -v --cov --cov-report term-missing --prod
           else
             if [[ -v SUMO_ACCESS_TOKEN ]]; then
               pytest -n auto -v --cov --cov-report term-missing
             else
-              pytest -n auto -v --cov --cov-report term-missing --ignore=tests/test_loaders/test_sumo_interface.py
+              pytest -n auto -v --cov --cov-report term-missing
             fi
           fi
 

--- a/ci/testrmsenv.sh
+++ b/ci/testrmsenv.sh
@@ -39,6 +39,6 @@ install_test_dependencies () {
 run_pytest () {
     echo "Running fmu-dataio tests with pytest..."
     pushd $CI_TEST_ROOT
-    pytest ./tests -n 4 -vv -m "not skip_inside_rmsvenv" --ignore=tests/test_ert_integration --ignore=tests/test_loaders/test_sumo_interface.py
+    pytest ./tests -n 4 -vv -m "not skip_inside_rmsvenv" --ignore=tests/test_ert_integration
     popd
 }

--- a/src/fmu/dataio/external_interfaces/schema_validation_interface.py
+++ b/src/fmu/dataio/external_interfaces/schema_validation_interface.py
@@ -7,7 +7,13 @@ import requests
 class SchemaValidationInterface:
     @staticmethod
     @lru_cache
-    def _get_cached_validator(schema_url: str) -> jsonschema.Draft202012Validator:
+    def _get_validator(schema_url: str) -> jsonschema.Draft202012Validator:
+        """
+        Get the schema validator to use to validate data objects.
+        Use cached validator when present for the requested schema, or
+        create a new validator and add it to the cache.
+        """
+
         response: requests.Response
 
         try:
@@ -23,10 +29,11 @@ class SchemaValidationInterface:
     def validate_against_schema(
         self, schema_url: str, data: object
     ) -> bool | Exception:
-        json_schema_validator = self._get_cached_validator(schema_url)
+        """Validate the provided data object against the provided schema."""
+
+        json_schema_validator = self._get_validator(schema_url)
 
         if not json_schema_validator.is_valid(instance=data):
-            # Run the full validation to raise the validation error
             jsonschema.validate(
                 schema=json_schema_validator.schema,
                 instance=data,

--- a/src/fmu/dataio/external_interfaces/sumo_explorer_interface.py
+++ b/src/fmu/dataio/external_interfaces/sumo_explorer_interface.py
@@ -1,57 +1,104 @@
 from io import BytesIO
 from uuid import UUID
 
+import pandas as pd
+import xtgeo
 from pandas import DataFrame
 
+from fmu.dataio._models.fmu_results.enums import FMUClass
 from fmu.sumo.explorer import Explorer
 from fmu.sumo.explorer.objects import SearchContext
 
 
 class SumoExplorerInterface:
-    _search_context: SearchContext
-
     def __init__(
-        self, case_id: UUID, ensemble_name: str, standard_result_name: str
+        self,
+        case_id: UUID,
+        ensemble_name: str,
+        fmu_class: FMUClass,
+        standard_result_name: str,
     ) -> None:
-        self._case_id = case_id
-        self._ensemble_name = ensemble_name
+        self._case_id: UUID = case_id
+        self._ensemble_name: str = ensemble_name
+        self._fmu_class: FMUClass = fmu_class
 
-        # Using sumo dev for now while this is in POC stage
         # TODO: Use sumo prod when ready
         sumo = Explorer(env="dev")
-
         case = sumo.get_case_by_uuid(self._case_id)
-        self._search_context = case.filter(
+        self._search_context: SearchContext = case.filter(
             iteration=self._ensemble_name, standard_result=standard_result_name
         )
 
-    def get_realization(self, realization_id: int) -> dict[str, DataFrame]:
+    def _get_formatted_data(
+        self, data_object: SearchContext
+    ) -> DataFrame | xtgeo.Polygons | xtgeo.RegularSurface:
+        """Get a fmu-dataio formatted data object from the Sumo Explorer object."""
+
+        match self._fmu_class:
+            case FMUClass.table:
+                return data_object.to_pandas()
+
+            case FMUClass.polygons:
+                dataFrame: DataFrame = pd.read_parquet(
+                    data_object.blob, engine="pyarrow"
+                )
+                return xtgeo.Polygons(dataFrame)
+
+            case FMUClass.surface:
+                # Dataformat: 'irap_binary'
+                return data_object.to_regular_surface()
+            case _:
+                raise ValueError(f"Unknown FMUClass {self._fmu_class}. in provided ")
+
+    def get_realization(
+        self, realization_id: int
+    ) -> dict[str, DataFrame | xtgeo.Polygons | xtgeo.RegularSurface]:
+        """
+        Get the standard results data objects from Sumo,
+        filtered on the provided realization id.
+        The results are returned as key value pairs, with the
+        data name as key and a fmu-dataio formatted data object as value.
+        """
+
         search_context_realization = self._search_context.filter(
             realization=realization_id
         )
 
-        data_frames: dict[str, DataFrame] = {}
+        realization_data: dict[
+            str, DataFrame | xtgeo.Polygons | xtgeo.RegularSurface
+        ] = {}
         for object in search_context_realization:
-            data_frames[object.name] = object.to_pandas()
-
-        return data_frames
+            realization_data[object.name] = self._get_formatted_data(object)
+        return realization_data
 
     def get_realization_with_metadata(
         self, realization_id: int
-    ) -> list[tuple[DataFrame, dict]]:
+    ) -> list[tuple[DataFrame | xtgeo.Polygons | xtgeo.RegularSurface, dict]]:
+        """
+        Get the standard results data and metadata from Sumo,
+        filtered on the provided realization id. The results are returned
+        as a list of tuples containing the data and metadata.
+        """
+
         search_context_realization = self._search_context.filter(
             realization=realization_id
         )
 
-        realization_data: list[tuple[DataFrame, dict]] = []
+        realization_data: list[
+            tuple[DataFrame | xtgeo.Polygons | xtgeo.RegularSurface, dict]
+        ] = []
         for object in search_context_realization:
-            data_frame: DataFrame = object.to_pandas()
-            metadata: dict = object.metadata
-            realization_data.append((data_frame, metadata))
+            realization_data.append((self._get_formatted_data(object), object.metadata))
 
         return realization_data
 
     def get_blob(self, realization_id: int) -> dict[str, BytesIO]:
+        """
+        Get the standard results data blobs from Sumo,
+        filtered on the provided realization id.
+        The results are returned as key value pairs,
+        with the data name as key and the data blob as value.
+        """
         search_context_realization = self._search_context.filter(
             realization=realization_id
         )
@@ -63,4 +110,5 @@ class SumoExplorerInterface:
         return blobs
 
     def get_realization_ids(self) -> list[int]:
+        """Get a list of the standard results realization ids from Sumo."""
         return self._search_context.realizationids

--- a/src/fmu/dataio/external_interfaces/sumo_explorer_interface.py
+++ b/src/fmu/dataio/external_interfaces/sumo_explorer_interface.py
@@ -39,14 +39,15 @@ class SumoExplorerInterface:
                 return data_object.to_pandas()
 
             case FMUClass.polygons:
-                dataFrame: DataFrame = pd.read_parquet(
+                data_frame: DataFrame = pd.read_parquet(
                     data_object.blob, engine="pyarrow"
                 )
-                return xtgeo.Polygons(dataFrame)
+                return xtgeo.Polygons(data_frame)
 
             case FMUClass.surface:
                 # Dataformat: 'irap_binary'
                 return data_object.to_regular_surface()
+
             case _:
                 raise ValueError(f"Unknown FMUClass {self._fmu_class}. in provided ")
 
@@ -92,7 +93,7 @@ class SumoExplorerInterface:
 
         return realization_data
 
-    def get_blob(self, realization_id: int) -> dict[str, BytesIO]:
+    def get_blobs(self, realization_id: int) -> dict[str, BytesIO]:
         """
         Get the standard results data blobs from Sumo,
         filtered on the provided realization id.

--- a/src/fmu/dataio/load/load_standard_results.py
+++ b/src/fmu/dataio/load/load_standard_results.py
@@ -69,23 +69,14 @@ class StandardResultsLoader:
         based on the provided path and metadata.
         """
 
-        file_path = Path(
-            f"{folder_path}/"
-            f"{metadata['fmu']['case']['name']}/"
-            f"{metadata['fmu']['realization']['name']}/"
-            f"{metadata['fmu']['ensemble']['name']}/"
-        )
-
-        file_name = (
-            (
-                f"{metadata['data']['standard_result']['name']}-"
-                f"{metadata['data']['name']}"
-                f".{file_extention}"
-            )
-            .lower()
-            .replace(" ", "")
-        )
+        case_name = metadata["fmu"]["case"]["name"]
+        relative_path = Path(metadata["file"]["relative_path"])
+        relative_folder_path = relative_path.parent
+        file_path = Path(folder_path) / Path(case_name) / relative_folder_path
         file_path.mkdir(parents=True, exist_ok=True)
+
+        file_name = relative_path.name.replace(relative_path.suffix, file_extention)
+
         return file_path / Path(file_name)
 
     @staticmethod
@@ -132,7 +123,7 @@ class TabularStandardResultsLoader(StandardResultsLoader):
                 schema_url=metadata["data"]["standard_result"]["file_schema"]["url"],
             )
 
-            file_path = self._generate_path_for_saving(folder_path, metadata, "csv")
+            file_path = self._generate_path_for_saving(folder_path, metadata, ".csv")
             data_frame.to_csv(file_path, index=False)
             file_paths.append(str(file_path))
 
@@ -179,7 +170,7 @@ class PolygonStandardResultsLoader(StandardResultsLoader):
                 schema_url=metadata["data"]["standard_result"]["file_schema"]["url"],
             )
 
-            file_path = self._generate_path_for_saving(folder_path, metadata, "csv")
+            file_path = self._generate_path_for_saving(folder_path, metadata, ".csv")
             data_frame.to_csv(file_path, index=False)
             file_paths.append(str(file_path))
 
@@ -214,7 +205,7 @@ class SurfacesStandardResultsLoader(StandardResultsLoader):
 
         file_paths: list[str] = []
         for surface, metadata in realization_data:
-            file_path = self._generate_path_for_saving(folder_path, metadata, "gri")
+            file_path = self._generate_path_for_saving(folder_path, metadata, ".gri")
             surface.to_file(file_path, fformat="irap_binary")
             file_paths.append(str(file_path))
 

--- a/src/fmu/dataio/load/load_standard_results.py
+++ b/src/fmu/dataio/load/load_standard_results.py
@@ -53,7 +53,7 @@ class StandardResultsLoader(Generic[T]):
 
         return self._sumo_interface.get_realization(realization_id)
 
-    def get_blob(self, realization_id: int) -> dict[str, BytesIO]:
+    def get_blobs(self, realization_id: int) -> dict[str, BytesIO]:
         """
         Returns a dictionary with the loaded objects blobs, filtered on the
         provided realization id. The `key` is the object name.
@@ -63,7 +63,7 @@ class StandardResultsLoader(Generic[T]):
 
         """
 
-        return self._sumo_interface.get_blob(realization_id)
+        return self._sumo_interface.get_blobs(realization_id)
 
     @staticmethod
     def _generate_path_for_saving(

--- a/src/fmu/dataio/load/load_standard_results.py
+++ b/src/fmu/dataio/load/load_standard_results.py
@@ -4,9 +4,10 @@ from typing import Generic, TypeVar
 from uuid import UUID
 
 import numpy as np
+import xtgeo
 from pandas import DataFrame
 
-from fmu.dataio._models.fmu_results import enums
+from fmu.dataio._models.fmu_results.enums import FMUClass, StandardResultName
 from fmu.dataio.export._decorators import experimental
 from fmu.dataio.external_interfaces.schema_validation_interface import (
     SchemaValidationInterface,
@@ -20,56 +21,30 @@ class StandardResultsLoader(Generic[T]):
     """The generic class for loaded standard results in fmu-dataio."""
 
     def __init__(
-        self, case_id: UUID, ensemble_name: str, standard_result_name: str
+        self,
+        case_id: UUID,
+        ensemble_name: str,
+        fmu_class: FMUClass,
+        standard_result_name: str,
     ) -> None:
         self._sumo_interface = SumoExplorerInterface(
-            case_id, ensemble_name, standard_result_name
+            case_id, ensemble_name, fmu_class, standard_result_name
         )
 
     def list_realizations(self) -> list[int]:
         """Returns a list with the realization ids of the loaded objects."""
+
         return self._sumo_interface.get_realization_ids()
 
     def concatenate_realizations(self) -> T:
         raise NotImplementedError
 
-    def save_realization(self, realization_id: int, folder_path: str) -> list[str]:
-        """
-        Saves the loaded objects, filtered on the provided
-        realization id, as csv files at the provided path.
-
-        Args:
-            realization_id: The id of the realization to filter on.
-            folder_path: The path to where to store the generated csv files.
-
-        """
-
-        realization_data: list[tuple[DataFrame, dict]] = (
-            self._sumo_interface.get_realization_with_metadata(realization_id)
-        )
-
-        file_paths: list[str] = []
-        for data_frame, metadata in realization_data:
-            self._validate_object(
-                data_frame=data_frame,
-                schema_url=metadata["data"]["standard_result"]["file_schema"]["url"],
-            )
-
-            data_name: str = metadata["data"]["name"]
-            standard_result_name: str = metadata["data"]["standard_result"]["name"]
-            file_name = f"{standard_result_name}_{data_name.lower()}.csv"
-            Path(folder_path).mkdir(parents=True, exist_ok=True)
-            file_path = folder_path / Path(file_name)
-
-            data_frame.to_csv(file_path, index=False)
-            file_paths.append(str(file_path))
-
-        return file_paths
-
-    def get_realization(self, realization_id: int) -> dict[str, DataFrame]:
+    def get_realization(
+        self, realization_id: int
+    ) -> dict[str, DataFrame | xtgeo.Polygons | xtgeo.RegularSurface]:
         """
         Returns a dictionary with the loaded objects, filtered on the provided
-        realization id, formatted as data frames. The `key` is the object name.
+        realization id. The `key` is the object name.
 
         Args:
             realization_id: The id of the realization to filter on.
@@ -91,6 +66,34 @@ class StandardResultsLoader(Generic[T]):
         return self._sumo_interface.get_blob(realization_id)
 
     @staticmethod
+    def _generate_path_for_saving(
+        folder_path: str, metadata: dict, file_extention: str
+    ) -> Path:
+        """
+        Generate the path to save the object to,
+        based on the provided path and metadata.
+        """
+
+        file_path = Path(
+            f"{folder_path}/"
+            f"{metadata['fmu']['case']['name']}/"
+            f"{metadata['fmu']['realization']['name']}/"
+            f"{metadata['fmu']['ensemble']['name']}/"
+        )
+
+        file_name = (
+            (
+                f"{metadata['data']['standard_result']['name']}-"
+                f"{metadata['data']['name']}"
+                f".{file_extention}"
+            )
+            .lower()
+            .replace(" ", "")
+        )
+        file_path.mkdir(parents=True, exist_ok=True)
+        return file_path / Path(file_name)
+
+    @staticmethod
     def _validate_object(data_frame: DataFrame, schema_url: str) -> None:
         """Validate the standard result object against its schema"""
 
@@ -101,24 +104,152 @@ class StandardResultsLoader(Generic[T]):
         )
 
 
-class InplaceVolumesLoader(StandardResultsLoader[T]):
+class TabularStandardResultsLoader(StandardResultsLoader[DataFrame]):
+    """Base class for the loaded tabular standard results in fmu-dataio"""
+
+    def __init__(
+        self, case_id: UUID, ensemble_name: str, standard_result_name: str
+    ) -> None:
+        super().__init__(case_id, ensemble_name, FMUClass.table, standard_result_name)
+
+    def save_realization(self, realization_id: int, folder_path: str) -> list[str]:
+        """
+        Saves the loaded tabular objects, filtered on the provided
+        realization id, as csv files at the provided path.
+
+        Args:
+            realization_id: The id of the realization to filter on.
+            folder_path: The path to where to store the generated csv files.
+
+        """
+
+        realization_data: list[tuple[DataFrame, dict]] = (
+            self._sumo_interface.get_realization_with_metadata(realization_id)
+        )
+
+        file_paths: list[str] = []
+        for data_frame, metadata in realization_data:
+            self._validate_object(
+                data_frame=data_frame,
+                schema_url=metadata["data"]["standard_result"]["file_schema"]["url"],
+            )
+
+            file_path = self._generate_path_for_saving(folder_path, metadata, "csv")
+            data_frame.to_csv(file_path, index=False)
+            file_paths.append(str(file_path))
+
+        return file_paths
+
+
+class PolygonStandardResultLoader(StandardResultsLoader[xtgeo.Polygons]):
+    """Base class for the loaded polygon standard results in fmu-dataio"""
+
+    def __init__(
+        self, case_id: UUID, ensemble_name: str, standard_result_name: str
+    ) -> None:
+        super().__init__(
+            case_id, ensemble_name, FMUClass.polygons, standard_result_name
+        )
+
+    def save_realization(self, realization_id: int, folder_path: str) -> list[str]:
+        """
+        Saves the loaded polygon objects, filtered on the provided
+        realization id, as csv files at the provided path.
+
+        Args:
+            realization_id: The id of the realization to filter on.
+            folder_path: The path to where to store the generated csv files.
+
+        """
+
+        realization_data: list[tuple[xtgeo.Polygons, dict]] = (
+            self._sumo_interface.get_realization_with_metadata(realization_id)
+        )
+
+        file_paths: list[str] = []
+        for polygon, metadata in realization_data:
+            # Temporary work-around until xtgeo.Polygons supports storing
+            # csv files directly with Polygons.to_file()
+            # https://github.com/equinor/xtgeo/issues/1333
+            data_frame = polygon.get_dataframe()
+
+            self._validate_object(
+                data_frame=data_frame,
+                schema_url=metadata["data"]["standard_result"]["file_schema"]["url"],
+            )
+
+            file_path = self._generate_path_for_saving(folder_path, metadata, "csv")
+            data_frame.to_csv(file_path, index=False)
+            file_paths.append(str(file_path))
+
+        return file_paths
+
+
+class SurfacesStandardResultLoader(StandardResultsLoader[xtgeo.Surfaces]):
+    """Base class for the loaded surface standard results in fmu-dataio"""
+
+    def __init__(
+        self, case_id: UUID, ensemble_name: str, standard_result_name: str
+    ) -> None:
+        super().__init__(case_id, ensemble_name, FMUClass.surface, standard_result_name)
+
+    def save_realization(self, realization_id: int, folder_path: str) -> list[str]:
+        """
+        Saves the loaded surface objects, filtered on the provided
+        realization id, as irap binary files at the provided path.
+
+        Args:
+            realization_id: The id of the realization to filter on.
+            folder_path: The path to where to store the generated irap binary files.
+
+        """
+
+        realization_data: list[tuple[xtgeo.RegularSurface, dict]] = (
+            self._sumo_interface.get_realization_with_metadata(realization_id)
+        )
+
+        file_paths: list[str] = []
+        for surface, metadata in realization_data:
+            file_path = self._generate_path_for_saving(folder_path, metadata, "gri")
+            surface.to_file(file_path, fformat="irap_binary")
+            file_paths.append(str(file_path))
+
+        return file_paths
+
+
+class InplaceVolumesLoader(TabularStandardResultsLoader):
     """
     Loader object for the Inplace Volumes standard results in fmu-dataio.
-    It offers a set of methods to easily manage and interact
+    Offers a set of methods to easily manage and interact
     with the loaded inplace volumes data.
     """
 
     def __init__(self, case_id: UUID, ensemble_name: str):
-        super().__init__(
-            case_id, ensemble_name, enums.StandardResultName.inplace_volumes
-        )
+        super().__init__(case_id, ensemble_name, StandardResultName.inplace_volumes)
 
 
-class FieldOutlineLoader(StandardResultsLoader[T]):
-    """Class representing a set of Field Outline standard results in fmu-dataio."""
+class FieldOutlinesLoader(PolygonStandardResultLoader):
+    """
+    Loader object for the Field Outline standard results in fmu-dataio.
+    Offers a set of methods to easily manage and interact
+    with the loaded field outlines data.
+    """
 
     def __init__(self, case_id: UUID, ensemble_name: str) -> None:
-        super().__init__(case_id, ensemble_name, enums.StandardResultName.field_outline)
+        super().__init__(case_id, ensemble_name, StandardResultName.field_outline)
+
+
+class StructureDepthSurfacesLoader(SurfacesStandardResultLoader):
+    """
+    Loader object for the Structure Depth Surface standard results in fmu-dataio.
+    Offers a set of methods to easily manage and interact
+    with the loaded structure depth surfaces data.
+    """
+
+    def __init__(self, case_id: UUID, ensemble_name: str) -> None:
+        super().__init__(
+            case_id, ensemble_name, StandardResultName.structure_depth_surface
+        )
 
 
 @experimental
@@ -136,13 +267,13 @@ def load_inplace_volumes(case_id: UUID, ensemble_name: str) -> InplaceVolumesLoa
         This function is experimental and may change in future versions.
 
     Examples:
-        Example usage in an RMS script:
+        Example usage in a script:
 
             from fmu.dataio.load.load_standard_results import load_inplace_volumes
 
             inplace_volumes_loader = load_inplace_volumes(case_id, ensemble_name)
 
-            inplace_volumes_in_realization = inplace_volumes_loader.get_realization(realization_id)
+            realization_data = inplace_volumes_loader.get_realization(realization_id)
 
     """  # noqa: E501 line too long
 
@@ -150,6 +281,59 @@ def load_inplace_volumes(case_id: UUID, ensemble_name: str) -> InplaceVolumesLoa
 
 
 @experimental
-def load_field_outlines(case_id: UUID, ensemble_name: str) -> FieldOutlineLoader:
-    """Simplified interface to load field outline standard results from Sumo."""
-    return FieldOutlineLoader(case_id, ensemble_name)
+def load_field_outlines(case_id: UUID, ensemble_name: str) -> FieldOutlinesLoader:
+    """
+    This function provides a simplified interface for loading field outlines
+    standard results from Sumo. It returns a FieldOutlinesLoader object, which offers
+    a set of methods to easily manage and interact with the loaded field outlines data.
+
+    Args:
+        case_id: The id of the case to load field outlines from.
+        ensemble_name: The name of the ensemble to load field outlines from.
+
+    Note:
+        This function is experimental and may change in future versions.
+
+    Examples:
+        Example usage in a script:
+
+            from fmu.dataio.load.load_standard_results import load_field_outlines
+
+            field_outlines_loader = load_field_outlines(case_id, ensemble_name)
+
+            realization_data = field_outlines_loader.get_realization(realization_id)
+
+    """  # noqa: E501 line too long
+
+    return FieldOutlinesLoader(case_id, ensemble_name)
+
+
+@experimental
+def load_structure_depth_surfaces(
+    case_id: UUID, ensemble_name: str
+) -> StructureDepthSurfacesLoader:
+    """
+    This function provides a simplified interface for loading structure depth surfaces
+    standard results from Sumo. It returns a StructureDepthSurfacesLoader object,
+    which offers a set of methods to easily manage and interact with the
+    loaded structure depth surfaces data.
+
+    Args:
+        case_id: The id of the case to load structure depth surfaces from.
+        ensemble_name: The name of the ensemble to load structure depth surfaces from.
+
+    Note:
+        This function is experimental and may change in future versions.
+
+    Examples:
+        Example usage in a script:
+
+            from fmu.dataio.load.load_standard_results import load_structure_depth_surfaces
+
+            structure_depth_surfaces_loader = load_structure_depth_surfaces(case_id, ensemble_name)
+
+            realization_data = structure_depth_surfaces_loader.get_realization(realization_id)
+
+    """  # noqa: E501 line too long
+
+    return StructureDepthSurfacesLoader(case_id, ensemble_name)

--- a/tests/test_loaders/test_schema_validation_interface.py
+++ b/tests/test_loaders/test_schema_validation_interface.py
@@ -18,7 +18,7 @@ def test_validator_when_valid_metadata(metadata_examples):
     inplace_volumes = metadata_examples["table_inplace_volumes.yml"]
 
     validator = SchemaValidationInterface()
-    validator._get_cached_validator.cache_clear()
+    validator._get_validator.cache_clear()
 
     assert validator.validate_against_schema(
         schema_url=inplace_volumes["$schema"], data=inplace_volumes
@@ -32,7 +32,7 @@ def test_validator_when_invalid_metadata():
     }
 
     validator = SchemaValidationInterface()
-    validator._get_cached_validator.cache_clear()
+    validator._get_validator.cache_clear()
 
     with pytest.raises(ValidationError):
         validator.validate_against_schema(schema_url=metadata["$schema"], data=metadata)
@@ -44,7 +44,7 @@ def test_validator_when_valid_payload():
     )
 
     validator = SchemaValidationInterface()
-    validator._get_cached_validator.cache_clear()
+    validator._get_validator.cache_clear()
 
     assert validator.validate_against_schema(
         schema_url=SCHEMA_URL_INPLACE_VOLUME, data=data_frame
@@ -59,7 +59,7 @@ def test_validator_when_ivalid_payload():
     del data_frame[0]["FLUID"]
 
     validator = SchemaValidationInterface()
-    validator._get_cached_validator.cache_clear()
+    validator._get_validator.cache_clear()
 
     with pytest.raises(ValidationError, match="'FLUID' is a required property"):
         validator.validate_against_schema(
@@ -73,17 +73,17 @@ def test_caching(metadata_examples):
     schema_url_fmu_results = inplace_volumes_metadata["$schema"]
 
     validator = SchemaValidationInterface()
-    validator._get_cached_validator.cache_clear()
+    validator._get_validator.cache_clear()
 
     # Validate against fmu results schema and assert schema is added to cache
     validator.validate_against_schema(schema_url_fmu_results, inplace_volumes_metadata)
-    cache_info = SchemaValidationInterface._get_cached_validator.cache_info()
+    cache_info = SchemaValidationInterface._get_validator.cache_info()
     assert cache_info.misses == 1
     assert cache_info.hits == 0
 
     # Validate against fmu results schema again and assert cached schema is used
     validator.validate_against_schema(schema_url_fmu_results, inplace_volumes_metadata2)
-    cache_info = SchemaValidationInterface._get_cached_validator.cache_info()
+    cache_info = SchemaValidationInterface._get_validator.cache_info()
     assert cache_info.misses == 1
     assert cache_info.hits == 1
 
@@ -94,6 +94,6 @@ def test_caching(metadata_examples):
     validator.validate_against_schema(
         SCHEMA_URL_INPLACE_VOLUME, inplace_volumes_payload
     )
-    cache_info = SchemaValidationInterface._get_cached_validator.cache_info()
+    cache_info = SchemaValidationInterface._get_validator.cache_info()
     assert cache_info.hits == 1
     assert cache_info.misses == 2

--- a/tests/test_loaders/test_standard_result_loaders.py
+++ b/tests/test_loaders/test_standard_result_loaders.py
@@ -1,12 +1,38 @@
+import os
+from io import BytesIO
 from unittest.mock import patch
 
 import pandas as pd
-import pytest
+import xtgeo
+from pandas import DataFrame
 
 import fmu.dataio.load.load_standard_results as load_standard_results
 
 
-def test_inplace_volumes_list_realizations():
+def _generate_metadata_mock(
+    case_name_mock: str,
+    realization_name_mock: str,
+    ensemble_name_mock: str,
+    data_name_mock: str,
+    standard_result_name: str,
+) -> dict:
+    return {
+        "fmu": {
+            "case": {"name": case_name_mock},
+            "realization": {"name": realization_name_mock},
+            "ensemble": {"name": ensemble_name_mock},
+        },
+        "data": {
+            "name": data_name_mock,
+            "standard_result": {
+                "name": standard_result_name,
+                "file_schema": {"url": "http://test.com"},
+            },
+        },
+    }
+
+
+def test_list_realizations():
     realization_ids = [0, 1, 2, 3]
     with (
         patch(
@@ -29,7 +55,42 @@ def test_inplace_volumes_list_realizations():
         assert actual_ids == realization_ids
 
 
-def test_inplace_volumes_get_realization():
+def test_get_blobs(unregister_pandas_parquet):
+    mocked_data_frame = pd.DataFrame(columns=["FLUID", "ZONE", "REGION", "GIIP"])
+
+    buffer = BytesIO()
+    mocked_data_frame.to_parquet(buffer)
+    blob = buffer.getvalue()
+    mocked_blobs_dict = {"test_blob_name": blob}
+
+    with (
+        patch(
+            "fmu.dataio.external_interfaces.sumo_explorer_interface.SumoExplorerInterface.__init__",
+            return_value=None,
+        ) as class_init_mock,
+        patch(
+            "fmu.dataio.external_interfaces.sumo_explorer_interface.SumoExplorerInterface.get_blobs",
+            return_value=mocked_blobs_dict,
+        ) as get_blobs_mock,
+    ):
+        inplace_volumes_loader = load_standard_results.load_inplace_volumes(
+            "test_id", "some_ensemble_name"
+        )
+        assert class_init_mock.assert_called_once
+
+        actual_blobs_dict = inplace_volumes_loader.get_blobs(0)
+        assert get_blobs_mock.assert_called_once
+        assert len(actual_blobs_dict) == len(mocked_blobs_dict)
+
+        blob_name = list(actual_blobs_dict.keys())[0]
+        assert blob_name == "test_blob_name"
+
+        actual_blob = actual_blobs_dict[blob_name]
+        actual_data_frame = pd.read_parquet(BytesIO(actual_blob))
+        pd.testing.assert_frame_equal(actual_data_frame, mocked_data_frame)
+
+
+def test_get_realization():
     columns = ["FLUID", "ZONE", "REGION", "GIIP"]
     mocked_data_frame = pd.DataFrame(columns=columns)
     mocked_realization_dict = {"test_volume": mocked_data_frame}
@@ -44,12 +105,12 @@ def test_inplace_volumes_get_realization():
             return_value=mocked_realization_dict,
         ) as get_realizations_mock,
     ):
-        inplace_volumes = load_standard_results.load_inplace_volumes(
+        inplace_volumes_loader = load_standard_results.load_inplace_volumes(
             "test_id", "some_ensemble_name"
         )
         assert class_init_mock.assert_called_once
 
-        realization_dict = inplace_volumes.get_realization(0)
+        realization_dict = inplace_volumes_loader.get_realization(0)
         assert get_realizations_mock.assert_called_once
         assert len(realization_dict) == len(mocked_realization_dict)
 
@@ -61,21 +122,193 @@ def test_inplace_volumes_get_realization():
             data_frame, mocked_realization_dict["test_volume"]
         )
 
-        assert data_frame.FLUID.name
-        assert data_frame.ZONE.name
-        assert data_frame.REGION.name
-        assert data_frame.GIIP.name
-        with pytest.raises(
-            AttributeError, match="'DataFrame' object has no attribute 'STOIIP'"
-        ):
-            assert data_frame.STOIIP
+
+def test_save_realization_for_tabular(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+
+    columns = ["FLUID", "ZONE", "REGION", "GIIP"]
+    mocked_data_frame = pd.DataFrame(columns=columns)
+
+    case_name_mock = "test_case"
+    realization_name_mock = "realization-0"
+    ensemble_name_mock = "iter-0"
+    data_name_mock = "tabular_object_name"
+    standard_result_name = "inplace_volumes"
+    mocked_metadata = _generate_metadata_mock(
+        case_name_mock,
+        realization_name_mock,
+        ensemble_name_mock,
+        data_name_mock,
+        standard_result_name,
+    )
+
+    mocked_realization_data: list[tuple[DataFrame, dict]] = [
+        (mocked_data_frame, mocked_metadata)
+    ]
+
+    with (
+        patch(
+            "fmu.dataio.external_interfaces.sumo_explorer_interface.SumoExplorerInterface.__init__",
+            return_value=None,
+        ) as class_init_mock,
+        patch(
+            "fmu.dataio.external_interfaces.sumo_explorer_interface.SumoExplorerInterface.get_realization_with_metadata",
+            return_value=mocked_realization_data,
+        ) as get_realization_with_metadata_mock,
+        patch(
+            "fmu.dataio.external_interfaces.schema_validation_interface.SchemaValidationInterface.validate_against_schema",
+            return_value=True,
+        ) as validate_object_mock,
+    ):
+        inplace_volumes_loader = load_standard_results.load_inplace_volumes(
+            "test_id", "some_ensemble_name"
+        )
+        assert class_init_mock.assert_called_once
+
+        actual_file_paths = inplace_volumes_loader.save_realization(0, tmp_path)
+        assert get_realization_with_metadata_mock.assert_called_once
+        assert validate_object_mock.assert_called_once
+
+        expected_file_path = (
+            f"{tmp_path}/"
+            f"{case_name_mock}/"
+            f"{realization_name_mock}/"
+            f"{ensemble_name_mock}/"
+            f"{standard_result_name}-{data_name_mock}.csv"
+        )
+        assert actual_file_paths[0] == expected_file_path
+        assert os.path.exists(expected_file_path)
+
+        with open(expected_file_path) as file:
+            content = file.read()
+            assert "FLUID,ZONE,REGION,GIIP" in content
 
 
-def test_inplace_volumes_save_realization(tmp_path):
-    # TODO
-    assert True
+def test_save_realization_for_ploygons(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+
+    polygon = xtgeo.Polygons()
+
+    case_name_mock = "test_case"
+    realization_name_mock = "realization-0"
+    ensemble_name_mock = "iter-0"
+    data_name_mock = "polygon_object_name"
+    standard_result_name = "field_outlines"
+    mocked_metadata = _generate_metadata_mock(
+        case_name_mock,
+        realization_name_mock,
+        ensemble_name_mock,
+        data_name_mock,
+        standard_result_name,
+    )
+
+    mocked_realization_data: list[tuple[xtgeo.Polygons, dict]] = [
+        (polygon, mocked_metadata)
+    ]
+
+    with (
+        patch(
+            "fmu.dataio.external_interfaces.sumo_explorer_interface.SumoExplorerInterface.__init__",
+            return_value=None,
+        ) as class_init_mock,
+        patch(
+            "fmu.dataio.external_interfaces.sumo_explorer_interface.SumoExplorerInterface.get_realization_with_metadata",
+            return_value=mocked_realization_data,
+        ) as get_realization_with_metadata_mock,
+        patch(
+            "fmu.dataio.external_interfaces.schema_validation_interface.SchemaValidationInterface.validate_against_schema",
+            return_value=True,
+        ) as validate_object_mock,
+    ):
+        field_outlines_loader = load_standard_results.load_field_outlines(
+            "test_id", "some_ensemble_name"
+        )
+        assert class_init_mock.assert_called_once
+
+        actual_file_paths = field_outlines_loader.save_realization(0, tmp_path)
+        assert get_realization_with_metadata_mock.assert_called_once
+        assert validate_object_mock.assert_called_once
+
+        expected_file_path = (
+            f"{tmp_path}/"
+            f"{case_name_mock}/"
+            f"{realization_name_mock}/"
+            f"{ensemble_name_mock}/"
+            f"{standard_result_name}-{data_name_mock}.csv"
+        )
+        assert actual_file_paths[0] == expected_file_path
+        assert os.path.exists(expected_file_path)
+
+        with open(expected_file_path) as file:
+            content = file.read()
+            assert "X_UTME,Y_UTMN,Z_TVDSS" in content
 
 
-def test_inplace_volumes_get_blob():
-    # TODO
-    assert True
+def test_save_realization_for_surfaces(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+
+    surface = xtgeo.RegularSurface(
+        ncol=1,
+        nrow=1,
+        xinc=0.319,
+        yinc=0.211,
+    )
+
+    case_name_mock = "test_case"
+    realization_name_mock = "realization-0"
+    ensemble_name_mock = "iter-0"
+    data_name_mock = "surface_object_name"
+    standard_result_name = "structure_depth_surface"
+    mocked_metadata = _generate_metadata_mock(
+        case_name_mock,
+        realization_name_mock,
+        ensemble_name_mock,
+        data_name_mock,
+        standard_result_name,
+    )
+
+    mocked_realization_data: list[tuple[xtgeo.Polygons, dict]] = [
+        (surface, mocked_metadata)
+    ]
+
+    with (
+        patch(
+            "fmu.dataio.external_interfaces.sumo_explorer_interface.SumoExplorerInterface.__init__",
+            return_value=None,
+        ) as class_init_mock,
+        patch(
+            "fmu.dataio.external_interfaces.sumo_explorer_interface.SumoExplorerInterface.get_realization_with_metadata",
+            return_value=mocked_realization_data,
+        ) as get_realization_with_metadata_mock,
+        patch(
+            "fmu.dataio.external_interfaces.schema_validation_interface.SchemaValidationInterface.validate_against_schema",
+            return_value=True,
+        ) as validate_object_mock,
+    ):
+        structure_depth_surface_loader = (
+            load_standard_results.load_structure_depth_surfaces(
+                "test_id", "some_ensemble_name"
+            )
+        )
+        assert class_init_mock.assert_called_once
+
+        actual_file_paths = structure_depth_surface_loader.save_realization(0, tmp_path)
+        assert get_realization_with_metadata_mock.assert_called_once
+        assert validate_object_mock.assert_not_called
+
+        expected_file_path = (
+            f"{tmp_path}/"
+            f"{case_name_mock}/"
+            f"{realization_name_mock}/"
+            f"{ensemble_name_mock}/"
+            f"{standard_result_name}-{data_name_mock}.gri"
+        )
+
+        assert actual_file_paths[0] == expected_file_path
+        assert os.path.exists(expected_file_path)
+
+        surface_from_file = xtgeo.surface_from_file(
+            expected_file_path, fformat="irap_binary"
+        )
+        assert round(surface_from_file.xinc, 3) == 0.319
+        assert round(surface_from_file.yinc, 3) == 0.211

--- a/tests/test_loaders/test_sumo_interface.py
+++ b/tests/test_loaders/test_sumo_interface.py
@@ -1,182 +1,236 @@
-import os
-from unittest.mock import patch
+from io import BytesIO
+from unittest.mock import MagicMock, patch
 
 import pandas as pd
-import pytest
+import xtgeo
+from pandas import DataFrame
 
+from fmu.dataio._models.fmu_results.enums import FMUClass, StandardResultName
 from fmu.dataio.external_interfaces.sumo_explorer_interface import SumoExplorerInterface
 from fmu.sumo.explorer import Explorer
-from fmu.sumo.explorer.objects import Case
 
 
-@pytest.fixture
-def sumo_test_case() -> Case:
-    sumo_access_token = os.environ.get("SUMO_ACCESS_TOKEN")
-    test_case_id = "3ca4b782-c8e8-4f77-9a75-d6a576751123"
-    sumo_explorer = Explorer(env="dev", token=sumo_access_token)
-    return sumo_explorer.get_case_by_uuid(test_case_id)
+def _generate_sumo_case_mock(sumo_object_mock: MagicMock):
+    summo_search_context_realization_mock = MagicMock()
+    summo_search_context_realization_mock.__iter__.return_value = iter(
+        [sumo_object_mock]
+    )
+
+    sumo_search_context_case_mock = MagicMock()
+    sumo_search_context_case_mock.filter.return_value = (
+        summo_search_context_realization_mock
+    )
+
+    sumo_case_mock = MagicMock()
+    sumo_case_mock.filter.return_value = sumo_search_context_case_mock
+
+    return sumo_case_mock
 
 
-@pytest.mark.skip(
-    reason="Skipping tests while unstability issues are being investigated."
-)
-def test_initialize_inplace_volumes(sumo_test_case):
+def test_get_realization_ids():
     ensemble_name = "iter-0"
+    realization_ids_mock = [0, 16, 48]
+    sumo_case_mock = MagicMock()
+    search_context_mock = MagicMock()
+    search_context_mock.realizationids = realization_ids_mock
+    sumo_case_mock.filter.return_value = search_context_mock
 
     with (
         patch.object(Explorer, "__init__", return_value=None),
-        patch.object(Explorer, "get_case_by_uuid", return_value=sumo_test_case),
+        patch.object(Explorer, "get_case_by_uuid", return_value=sumo_case_mock),
     ):
         sumo_interface = SumoExplorerInterface(
-            "some_case_id", ensemble_name, "inplace_volumes"
+            "some_case_id",
+            ensemble_name,
+            FMUClass.table,
+            StandardResultName.inplace_volumes,
         )
 
-        for table in sumo_interface._search_context:
-            assert (
-                "inplace_volumes" in table.metadata["data"]["standard_result"]["name"]
-            )
-
-        expected_search_context = sumo_test_case.filter(
-            iteration=ensemble_name, standard_result="inplace_volumes"
-        )
-
-        assert sumo_interface._search_context.columns == expected_search_context.columns
-        assert (
-            sumo_interface._search_context.contents == expected_search_context.contents
-        )
-        assert (
-            sumo_interface._search_context.dataformats
-            == expected_search_context.dataformats
-        )
-        assert sumo_interface._search_context.names == expected_search_context.names
+        actual_realization_ids = sumo_interface.get_realization_ids()
+        assert actual_realization_ids == realization_ids_mock
 
 
-@pytest.mark.skip(
-    reason="Skipping tests while unstability issues are being investigated."
-)
-def test_get_realization_ids(sumo_test_case, unregister_pandas_parquet):
-    ensemble_name = "iter-0"
-
-    with (
-        patch.object(Explorer, "__init__", return_value=None),
-        patch.object(Explorer, "get_case_by_uuid", return_value=sumo_test_case),
-    ):
-        sumo_interface = SumoExplorerInterface(
-            "some_case_id", ensemble_name, "inplace_volumes"
-        )
-        realization_ids = sumo_interface.get_realization_ids()
-
-        expected_realization_ids = sumo_test_case.filter(
-            iteration=ensemble_name, standard_result="inplace_volumes"
-        ).realizationids
-
-        assert realization_ids == expected_realization_ids
-
-
-@pytest.mark.skip(
-    reason="Skipping tests while unstability issues are being investigated."
-)
-def test_get_realization(sumo_test_case):
+def test_get_realalization():
     ensemble_name = "iter-0"
     realization_id = 0
 
+    columns_mock = ["FLUID", "ZONE", "REGION", "GIIP"]
+    data_frame_mock = pd.DataFrame(columns=columns_mock)
+
+    sumo_table_object_mock = MagicMock()
+    sumo_table_object_mock.name = "table_object_name"
+    sumo_table_object_mock.to_pandas.return_value = data_frame_mock
+
+    sumo_case_mock = _generate_sumo_case_mock(sumo_table_object_mock)
+
     with (
         patch.object(Explorer, "__init__", return_value=None),
-        patch.object(Explorer, "get_case_by_uuid", return_value=sumo_test_case),
+        patch.object(Explorer, "get_case_by_uuid", return_value=sumo_case_mock),
     ):
         sumo_interface = SumoExplorerInterface(
-            "some_case_id", ensemble_name, "inplace_volumes"
+            "some_case_id",
+            ensemble_name,
+            FMUClass.table,
+            StandardResultName.inplace_volumes,
         )
 
-        expected_data = sumo_test_case.filter(
-            iteration=ensemble_name,
-            standard_result="inplace_volumes",
-            realization=realization_id,
-        )
-
-        expected_first_data_frame = expected_data[0].to_pandas()
-        expected_second_data_frame = expected_data[1].to_pandas()
-        expected_first_name = expected_data[0].name
-        expected_second_name = expected_data[1].name
-
-        actual_data = sumo_interface.get_realization(realization_id)
+        actual_realization = sumo_interface.get_realization(realization_id)
 
         pd.testing.assert_frame_equal(
-            actual_data[expected_first_name],
-            expected_first_data_frame,
-        )
-        pd.testing.assert_frame_equal(
-            actual_data[expected_second_name], expected_second_data_frame
+            actual_realization[sumo_table_object_mock.name],
+            data_frame_mock,
         )
 
-        with pytest.raises(AssertionError, match="DataFrame are different"):
-            pd.testing.assert_frame_equal(
-                expected_first_data_frame, actual_data[expected_second_name]
-            )
 
-
-@pytest.mark.skip(
-    reason="Skipping tests while unstability issues are being investigated."
-)
-def test_get_blob(sumo_test_case):
+def test_get_realization_with_metadata():
     ensemble_name = "iter-0"
     realization_id = 0
 
-    with (
-        patch.object(Explorer, "__init__", return_value=None),
-        patch.object(Explorer, "get_case_by_uuid", return_value=sumo_test_case),
-    ):
-        sumo_interface = SumoExplorerInterface(
-            "some_case_id", ensemble_name, "inplace_volumes"
-        )
+    columns_mock = ["FLUID", "ZONE", "REGION", "GIIP"]
+    data_frame_mock = pd.DataFrame(columns=columns_mock)
+    metadata_mock = {"name": "metadata_name"}
 
-        expected_data = sumo_test_case.filter(
-            iteration=ensemble_name,
-            standard_result="inplace_volumes",
-            realization=realization_id,
-        )
-        expected_first_blob = expected_data[0].blob
-        expected_second_blob = expected_data[1].blob
-        expected_first_name = expected_data[0].name
-        expected_second_name = expected_data[1].name
+    sumo_table_object_mock = MagicMock()
+    sumo_table_object_mock.name = "table_object_name"
+    sumo_table_object_mock.to_pandas.return_value = data_frame_mock
+    sumo_table_object_mock.metadata = metadata_mock
 
-        actual_data = sumo_interface.get_blob(realization_id)
-
-        assert (
-            actual_data[expected_first_name].getvalue()
-            == expected_first_blob.getvalue()
-        )
-        assert (
-            actual_data[expected_second_name].getvalue()
-            == expected_second_blob.getvalue()
-        )
-
-
-@pytest.mark.skip(
-    reason="Skipping tests while unstability issues are being investigated."
-)
-def test_get_realization_with_metadata(sumo_test_case, unregister_pandas_parquet):
-    ensemble_name = "iter-0"
-    realization_id = 0
+    sumo_case_mock = _generate_sumo_case_mock(sumo_table_object_mock)
 
     with (
         patch.object(Explorer, "__init__", return_value=None),
-        patch.object(Explorer, "get_case_by_uuid", return_value=sumo_test_case),
+        patch.object(Explorer, "get_case_by_uuid", return_value=sumo_case_mock),
     ):
         sumo_interface = SumoExplorerInterface(
-            "some_case_id", ensemble_name, "inplace_volumes"
+            "some_case_id",
+            ensemble_name,
+            FMUClass.table,
+            StandardResultName.inplace_volumes,
         )
-
-        expected_data = sumo_test_case.filter(
-            iteration=ensemble_name,
-            standard_result="inplace_volumes",
-            realization=realization_id,
-        )
-
-        expected_first_metadata = expected_data[0].metadata
-        expected_second_metadata = expected_data[1].metadata
 
         actual_data = sumo_interface.get_realization_with_metadata(realization_id)
 
-        assert actual_data[0][1] == expected_first_metadata
-        assert actual_data[1][1] == expected_second_metadata
+        pd.testing.assert_frame_equal(
+            actual_data[0][0],
+            data_frame_mock,
+        )
+
+        assert actual_data[0][1] == metadata_mock
+
+
+def test_get_blobs():
+    ensemble_name = "iter-0"
+    realization_id = 0
+
+    buffer = BytesIO(b"Test blob")
+    mocked_blob = buffer.getvalue()
+
+    sumo_table_object_mock = MagicMock()
+    sumo_table_object_mock.name = "table_object_name"
+    sumo_table_object_mock.blob = mocked_blob
+
+    sumo_case_mock = _generate_sumo_case_mock(sumo_table_object_mock)
+
+    with (
+        patch.object(Explorer, "__init__", return_value=None),
+        patch.object(Explorer, "get_case_by_uuid", return_value=sumo_case_mock),
+    ):
+        sumo_interface = SumoExplorerInterface(
+            "some_case_id",
+            ensemble_name,
+            FMUClass.table,
+            StandardResultName.inplace_volumes,
+        )
+
+        actual_blob_data = sumo_interface.get_blobs(realization_id)
+        assert actual_blob_data[sumo_table_object_mock.name] == mocked_blob
+
+
+def test_correct_data_format_returned(unregister_pandas_parquet):
+    ensemble_name = "iter-0"
+    realization_id = 0
+
+    # Table class
+    data_frame_mock = pd.DataFrame()
+    sumo_table_object_mock = MagicMock()
+    sumo_table_object_mock.name = "table_object_name"
+    sumo_table_object_mock.to_pandas.return_value = data_frame_mock
+    sumo_case_with_table_mock = _generate_sumo_case_mock(sumo_table_object_mock)
+
+    with (
+        patch.object(Explorer, "__init__", return_value=None),
+        patch.object(
+            Explorer, "get_case_by_uuid", return_value=sumo_case_with_table_mock
+        ),
+    ):
+        sumo_interface = SumoExplorerInterface(
+            "some_case_id",
+            ensemble_name,
+            FMUClass.table,
+            StandardResultName.inplace_volumes,
+        )
+        table_data = sumo_interface.get_realization(realization_id)
+        for value in table_data.values():
+            assert isinstance(value, DataFrame)
+
+    # Polygons class
+    mocked_polygon = xtgeo.Polygons(
+        [
+            [1, 22, 3, 0],
+            [6, 25, 4, 0],
+            [8, 27, 6, 0],
+            [1, 22, 3, 0],
+        ]
+    )
+    mocked_data_frame = mocked_polygon.dataframe
+    buffer = BytesIO()
+    mocked_data_frame.to_parquet(buffer)
+    mocked_blob = BytesIO(buffer.getvalue())
+    sumo_polygon_object_mock = MagicMock()
+    sumo_polygon_object_mock.name = "polygon_object_name"
+    sumo_polygon_object_mock.blob = mocked_blob
+    sumo_case_with_polygon_mock = _generate_sumo_case_mock(sumo_polygon_object_mock)
+
+    with (
+        patch.object(Explorer, "__init__", return_value=None),
+        patch.object(
+            Explorer, "get_case_by_uuid", return_value=sumo_case_with_polygon_mock
+        ),
+    ):
+        sumo_interface = SumoExplorerInterface(
+            "some_case_id",
+            ensemble_name,
+            FMUClass.polygons,
+            StandardResultName.field_outline,
+        )
+        polygon_data = sumo_interface.get_realization(realization_id)
+        for value in polygon_data.values():
+            assert isinstance(value, xtgeo.Polygons)
+
+    # Surfaces class
+    mocked_surface = xtgeo.RegularSurface(
+        ncol=1,
+        nrow=1,
+        xinc=0.1,
+        yinc=0.1,
+    )
+    sumo_surface_object_mock = MagicMock()
+    sumo_surface_object_mock.name = "surface_object_name"
+    sumo_surface_object_mock.to_regular_surface.return_value = mocked_surface
+    sumo_case_with_surface_mock = _generate_sumo_case_mock(sumo_surface_object_mock)
+
+    with (
+        patch.object(Explorer, "__init__", return_value=None),
+        patch.object(
+            Explorer, "get_case_by_uuid", return_value=sumo_case_with_surface_mock
+        ),
+    ):
+        sumo_interface = SumoExplorerInterface(
+            "some_case_id",
+            ensemble_name,
+            FMUClass.surface,
+            StandardResultName.structure_depth_surface,
+        )
+        surface_data = sumo_interface.get_realization(realization_id)
+        for value in surface_data.values():
+            assert isinstance(value, xtgeo.RegularSurface)


### PR DESCRIPTION
Resolves #1177 

Added a data class layer to the simple loaders framework. In this way, we have a way to group standard result loaders that share fmu data class (table, polygon, surface etc.) The loader methods that requires custom handling, depending on the data type, can be implemented in this layer. The following data class layers have been added so far:
* `TabularStandardResultsLoader` to handle standard results containing tabular data/tables.
* `PolygonStandardResultLoader` to handle standard results containing polygons.
* `SurfacesStandardResultLoader` handle standard results containing surfaces.

The loader method `save_realization()` has been implemented for each of the data class layers as it requires custom handling for each of the data types. The other loader methods `list_realizations()`, `get_realization()` and `get_blobs()` does not need any custom handling and is therefore implemented in the loader base class `StandardResultsLoader`.

In addition, the Sumo Explorer is now being mocked in the tests, so the CI-setup for sumo authentication has been removed. 

So far, the loading of the following standard results are supported:
* **inplace_volumes** --> `load_inplace_volumes()`
* **field_outlines**  --> `load_field_outlines()`
* **structure_depth_surfaces** --> `load_structure_depth_surfaces()`

## Checklist

- [X] Tests added (if not, comment why)
- [X] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [X] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [X] Docstrings are correct and updated
- [X] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [X] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅
