### PR TITLE
ENH: return TriangulatedSurfaceProvider from provider factory

### DIFF
--- a/src/fmu/dataio/providers/objectdata/_provider.py
+++ b/src/fmu/dataio/providers/objectdata/_provider.py
@@ -98,6 +98,7 @@ import xtgeo
 from fmu.dataio._definitions import ExportFolder, FileExtension
 from fmu.dataio._logging import null_logger
 from fmu.dataio._models.fmu_results.enums import FileFormat, FMUClass, Layout
+from fmu.dataio._readers.tsurf import TSurfData
 from fmu.dataio.readers import FaultRoomSurface
 
 from ._base import (
@@ -105,6 +106,7 @@ from ._base import (
 )
 from ._faultroom import FaultRoomSurfaceProvider
 from ._tables import ArrowTableDataProvider, DataFrameDataProvider
+from ._triangulated_surface import TriangulatedSurfaceProvider
 from ._xtgeo import (
     CPGridDataProvider,
     CPGridPropertyDataProvider,
@@ -168,6 +170,10 @@ def objectdata_provider_factory(
         )
     if isinstance(obj, FaultRoomSurface):
         return FaultRoomSurfaceProvider(
+            obj=obj, dataio=dataio, standard_result=standard_result
+        )
+    if isinstance(obj, TSurfData):
+        return TriangulatedSurfaceProvider(
             obj=obj, dataio=dataio, standard_result=standard_result
         )
     if isinstance(obj, dict):


### PR DESCRIPTION
Resolves #1127 

Returns TriangulatedSurfaceProvider from the object data provider factory.
Added testing of the TriangulatedSurfaceProvider and its specification.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
