### PR TITLE
BUG, TST: get xmax instead of xmin in bbox (#1175)

### DIFF
--- a/src/fmu/dataio/providers/objectdata/_faultroom.py
+++ b/src/fmu/dataio/providers/objectdata/_faultroom.py
@@ -63,7 +63,7 @@ class FaultRoomSurfaceProvider(ObjectDataProvider):
         logger.info("Get bbox for FaultRoomSurface")
         return BoundingBox3D(
             xmin=float(self.obj.bbox["xmin"]),
-            xmax=float(self.obj.bbox["xmin"]),
+            xmax=float(self.obj.bbox["xmax"]),
             ymin=float(self.obj.bbox["ymin"]),
             ymax=float(self.obj.bbox["ymax"]),
             zmin=float(self.obj.bbox["zmin"]),

--- a/tests/test_units/test_objectdataprovider_class.py
+++ b/tests/test_units/test_objectdataprovider_class.py
@@ -1,6 +1,7 @@
 """Test the _ObjectData class from the _objectdata.py module"""
 
 import os
+from io import BytesIO
 from pathlib import Path
 
 import pytest
@@ -54,9 +55,25 @@ def test_objectdata_faultroom_fault_juxtaposition_get_stratigraphy_differ(
     Fault juxtaposition is a list of formations on the footwall and hangingwall sides.
     Ensure that each name is converted to the names given in the stratigraphic column
     in the global config.
+    Also perform a few other tests to verify API and functionality.
     """
     objdata = objectdata_provider_factory(faultroom_object, edataobj2)
     assert isinstance(objdata, FaultRoomSurfaceProvider)
+
+    assert objdata.extension == ".json"
+    assert objdata.layout == "faultroom_triangulated"
+
+    bbox = objdata.get_bbox()
+    assert bbox.xmin == 1.1
+    assert bbox.zmax == 2.3
+
+    encoding = "utf-8"
+    buffer = BytesIO()
+    objdata.export_to_file(buffer)
+    buffer.seek(0)
+    # Check the first bytes of the buffer
+    expected = """{\n    "metadata": {\n        "horizons":"""
+    assert buffer.read(len(expected)).decode(encoding=encoding) == expected
 
     frss = objdata.get_spec()
     assert isinstance(frss, FaultRoomSurfaceSpecification)


### PR DESCRIPTION
Resolves #1175 

Retrieve `xmax` instead of `xmin` in `FaultRoomSurfaceProvider.get_bbox()`
Added a few tests

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
