### PR TITLE
ENH: Add simple_export for 'fluid_contact_outline'

### DIFF
--- a/docs/src/standard_results/fluid_contact_outlines.md
+++ b/docs/src/standard_results/fluid_contact_outlines.md
@@ -1,0 +1,87 @@
+# Initial fluid contact outlines 
+
+This exports modelled initial fluid contact outlines from within RMS.
+
+Each fluid contact outline corresponds to a specific zone or a group of zones 
+that share a common fluid contact. They are polygons representing the outline of
+the hydrocarbon-filled zone above a specific contact.
+
+The fluid contact types supported is 
+- `fwl` (Free water level)
+- `fgl` (Free gas level)
+- `goc` (Gas-oil contact)
+- `gwc` (Gas-water contact)
+- `owc` (Oil-water contact)
+
+
+:::{table} Current
+:widths: auto
+:align: left
+
+| Field | Value |
+| --- | --- |
+| Version | **{{ FluidContactOutlineSchema.VERSION }}** |
+| Output | `share/results/maps/fluid_contact_outline/contactname/zonename.parquet` |
+| Security classification | 🟡 Internal |
+:::
+
+## Requirements
+
+- RMS
+- fluid contact outlines stored in the `General 2D data` folder within RMS.
+- names of outlines defined in the `stratigraphy` block
+
+A folder named `fluid_contact_outlines` must exist in the root of the `General 2D data`
+folder in RMS. This folder should contain at least one subfolder with a valid fluid contact
+name (e.g., `fwl`, see the list above). The export function will automatically process
+and export all outlines found within these subfolders.
+
+:::{note}
+The names of the fluid contact outlines must be defined in the `stratigraphy` block of the
+global configuration to enable mapping against masterdata.
+:::
+
+## Usage
+
+```{eval-rst}
+.. autofunction:: fmu.dataio.export.rms.fluid_contact_outlines.export_fluid_contact_outlines
+```
+
+## Result
+
+The fluid contact outlines from the `General 2D data` folder will be exported as
+to `share/results/maps/fluid_contact_outline/contactname/zonename.parquet`.
+
+This is a tabular file on `.parquet` format. It contains
+the following columns with types validated as indicated.
+
+```{eval-rst}
+.. autopydantic_model:: fmu.dataio._models.standard_result.fluid_contact_outline.FluidContactOutlineResultRow
+   :members:
+   :inherited-members: BaseModel
+   :model-show-config-summary: False
+   :model-show-json: False
+   :model-show-validator-members: False
+   :model-show-validator-summary: False
+   :field-list-validators: False
+```
+
+## Standard result schema
+
+This standard result is made available with a validation schema that can be
+used by consumers. A reference to the URL where this schema is located is
+present within the `data.standard_result` key in its associated object metadata.
+
+| Field | Value |
+| --- | --- |
+| Version | {{ FluidContactOutlineSchema.VERSION }} |
+| Filename | {{ FluidContactOutlineSchema.FILENAME }} |
+| Path | {{ FluidContactOutlineSchema.PATH }} |
+| Prod URL | {{ '[{}]({}) 🔒'.format(FluidContactOutlineSchema.prod_url(), FluidContactOutlineSchema.prod_url()) }}
+| Dev URL | {{ '[{}]({}) 🔒'.format(FluidContactOutlineSchema.dev_url(), FluidContactOutlineSchema.dev_url()) }}
+
+### JSON schema
+
+The current JSON schema is embedded here.
+
+{{ FluidContactOutlineSchema.literalinclude }}

--- a/src/fmu/dataio/export/rms/__init__.py
+++ b/src/fmu/dataio/export/rms/__init__.py
@@ -1,4 +1,5 @@
 from .field_outline import export_field_outline
+from .fluid_contact_outlines import export_fluid_contact_outlines
 from .fluid_contact_surfaces import export_fluid_contact_surfaces
 from .inplace_volumes import export_inplace_volumes, export_rms_volumetrics
 from .structure_depth_fault_lines import export_structure_depth_fault_lines
@@ -13,4 +14,5 @@ __all__ = [
     "export_rms_volumetrics",
     "export_field_outline",
     "export_fluid_contact_surfaces",
+    "export_fluid_contact_outlines",
 ]

--- a/src/fmu/dataio/export/rms/_utils.py
+++ b/src/fmu/dataio/export/rms/_utils.py
@@ -217,6 +217,28 @@ def get_surfaces_in_general2d_folder(
     return surfaces
 
 
+def get_polygons_in_general2d_folder(
+    project: Any, folder_path: list[str]
+) -> list[xtgeo.Polygons]:
+    """Get all polygons from a General 2D Data folder"""
+    folder_items = get_items_in_general2d_folder(project, folder_path)
+
+    polygons = []
+    for item in folder_items:
+        if isinstance(item, rmsapi.Polylines) and not item.is_empty():
+            polygons.append(
+                xtgeo.polygons_from_roxar(
+                    project, item.name, "/".join(folder_path), stype="general2d_data"
+                )
+            )
+    if not polygons:
+        raise RuntimeError(
+            "No polygons detected in the provided General 2D data "
+            f"folder: '{'/'.join(folder_path)}' "
+        )
+    return polygons
+
+
 def get_faultlines_in_folder(project: Any, horizon_folder: str) -> list[xtgeo.Polygons]:
     """
     Get all non-empty fault lines from a horizon folder stratigraphically ordered.

--- a/src/fmu/dataio/export/rms/fluid_contact_outlines.py
+++ b/src/fmu/dataio/export/rms/fluid_contact_outlines.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Final
+
+import fmu.dataio as dio
+from fmu.dataio._logging import null_logger
+from fmu.dataio._models.fmu_results import standard_result
+from fmu.dataio._models.fmu_results.enums import (
+    Classification,
+    Content,
+    FluidContactType,
+    StandardResultName,
+)
+from fmu.dataio.exceptions import ValidationError
+from fmu.dataio.export._decorators import experimental
+from fmu.dataio.export._export_result import ExportResult, ExportResultItem
+from fmu.dataio.export.rms._base import SimpleExportRMSBase
+from fmu.dataio.export.rms._utils import (
+    get_polygons_in_general2d_folder,
+    get_rms_project_units,
+    list_folder_names_in_general2d_folder,
+    validate_name_in_stratigraphy,
+)
+
+if TYPE_CHECKING:
+    import xtgeo
+
+_logger: Final = null_logger(__name__)
+
+GENERAL2D_FOLDER = "fluid_contact_outlines"
+
+
+class _ExportFluidContactOutlines(SimpleExportRMSBase):
+    def __init__(self, project: Any) -> None:
+        super().__init__()
+
+        _logger.debug("Process data, establish state prior to export.")
+        self.project = project
+        self._contact_outlines = self._get_contact_outlines()
+        self._unit = "m" if get_rms_project_units(project) == "metric" else "ft"
+        _logger.debug("Process data... DONE")
+
+    @property
+    def _standard_result(self) -> standard_result.FluidContactOutlineStandardResult:
+        """Standard result type for the exported data."""
+        return standard_result.FluidContactOutlineStandardResult(
+            name=StandardResultName.fluid_contact_outline
+        )
+
+    @property
+    def _content(self) -> Content:
+        """Get content for the exported data."""
+        return Content.fluid_contact
+
+    @property
+    def _classification(self) -> Classification:
+        """Get default classification."""
+        return Classification.internal
+
+    @property
+    def _rep_include(self) -> bool:
+        """rep_include status"""
+        return True
+
+    def _get_contacts(self) -> list[FluidContactType]:
+        """
+        Get FluidContactTypes from available subfolder names in the main folder.
+        Folders with invalid contact names will be skipped. If no valid contact
+        names are found an error is raised.
+        """
+
+        contact_folders = list_folder_names_in_general2d_folder(
+            self.project, folder_path=[GENERAL2D_FOLDER]
+        )
+        valid_contact_folders = []
+        for contact in contact_folders:
+            try:
+                valid_contact_folders.append(FluidContactType(contact))
+            except ValueError:
+                _logger.info(f"{contact} is not a valid contact name, skipping folder.")
+                continue
+
+        _logger.debug(f"Found valid contact folders {valid_contact_folders}.")
+        return valid_contact_folders
+
+    def _contact_folder_present(self) -> bool:
+        """Check if the main contact folder is present in General 2D data"""
+        return GENERAL2D_FOLDER in self.project.general2d_data.folders
+
+    def _get_contact_outlines(
+        self,
+    ) -> dict[FluidContactType, list[xtgeo.Polygons]]:
+        """
+        Get a dictionary with fluid contact outline polygons per contact folder
+        found in the main folder.
+        """
+
+        if self._contact_folder_present() and (contacts := self._get_contacts()):
+            return {
+                contact: get_polygons_in_general2d_folder(
+                    self.project, folder_path=[GENERAL2D_FOLDER, contact.value]
+                )
+                for contact in contacts
+            }
+        raise ValueError(
+            "Could not detect any fluid contact outlines from RMS. "
+            f"Ensure the folder '{GENERAL2D_FOLDER}' exists in the "
+            "'General 2D data' folder, and that it contains minimum one subfolder "
+            f"with a valid contact name: {list(FluidContactType.__members__)}. The "
+            "contact outlines should be contained inside these subfolders."
+        )
+
+    def _export_contact_outline(
+        self, contact: FluidContactType, pol: xtgeo.Polygons
+    ) -> ExportResultItem:
+        """Export a fluid contact outline as a standard result"""
+        edata = dio.ExportData(
+            config=self._config,
+            content=self._content,
+            content_metadata={"contact": contact, "truncated": False},
+            unit=self._unit,
+            vertical_domain="depth",
+            domain_reference="msl",
+            subfolder=f"{self._subfolder}/{contact.value}",
+            is_prediction=True,
+            name=pol.name,
+            classification=self._classification,
+            rep_include=self._rep_include,
+        )
+
+        edata.polygons_fformat = "parquet"  # type: ignore
+
+        absolute_export_path = edata._export_with_standard_result(
+            pol, standard_result=self._standard_result
+        )
+        _logger.debug("Surface exported to: %s", absolute_export_path)
+
+        return ExportResultItem(
+            absolute_path=Path(absolute_export_path),
+        )
+
+    def _export_data_as_standard_result(self) -> ExportResult:
+        """Do the actual export using dataio setup."""
+        result_items = []
+        for contact, polygons in self._contact_outlines.items():
+            for pol in polygons:
+                result_items.append(self._export_contact_outline(contact, pol))
+        return ExportResult(items=result_items)
+
+    def _validate_data_pre_export(self) -> None:
+        """Data validations."""
+        # TODO: Check that all contacts have positive values
+        for contact, polygons in self._contact_outlines.items():
+            for pol in polygons:
+                try:
+                    validate_name_in_stratigraphy(pol.name, self._config)
+                except ValidationError as err:
+                    raise ValidationError(
+                        f"Error detected for polygon '{pol.name}' in the contact "
+                        f"folder '{contact.value}'. Detailed information:\n{str(err)}"
+                    ) from err
+
+
+@experimental
+def export_fluid_contact_outlines(project: Any) -> ExportResult:
+    """Simplified interface when exporting initial fluid contact outlines from RMS.
+
+    Args:
+        project: The 'magic' project variable in RMS.
+    Note:
+        This function is experimental and may change in future versions.
+
+    Examples:
+        Example usage in an RMS script::
+
+            from fmu.dataio.export.rms import export_fluid_contact_outlines
+
+            export_results = export_fluid_contact_outlines(project)
+
+            for result in export_results.items:
+                print(f"Output polygon to {result.absolute_path}")
+
+    """
+
+    return _ExportFluidContactOutlines(project).export()

--- a/tests/test_export_rms/conftest.py
+++ b/tests/test_export_rms/conftest.py
@@ -198,6 +198,7 @@ def mock_rmsapi():
     mock_rmsapi.__version__ = "1.7"
     mock_rmsapi.jobs.Job.get_job(...).get_arguments.return_value = VOLJOB_PARAMS
     mock_rmsapi.Surface = MagicMock
+    mock_rmsapi.Polylines = MagicMock
     yield mock_rmsapi
 
 
@@ -301,6 +302,24 @@ def xtgeo_fault_lines(fault_line):
 
     base = fault_line.copy()
     base.name = "TopVolon"
+    base.get_dataframe(copy=False)[base.zname] += 200
+
+    yield [top, mid, base]
+
+
+@pytest.fixture
+def xtgeo_zone_polygons(fault_line):
+    """Create a set of polygons with stratigraphic zone names"""
+
+    top = fault_line.copy()
+    top.name = "Valysar"
+
+    mid = fault_line.copy()
+    mid.name = "Therys"
+    mid.get_dataframe(copy=False)[mid.zname] += 100
+
+    base = fault_line.copy()
+    base.name = "Volon"
     base.get_dataframe(copy=False)[base.zname] += 200
 
     yield [top, mid, base]

--- a/tests/test_export_rms/test_export_fluid_contact_outlines.py
+++ b/tests/test_export_rms/test_export_fluid_contact_outlines.py
@@ -1,0 +1,232 @@
+from unittest import mock
+
+import jsonschema
+import numpy as np
+import pyarrow.parquet as pq
+import pytest
+
+from fmu import dataio
+from fmu.dataio._logging import null_logger
+from fmu.dataio._models.fmu_results.enums import FluidContactType, StandardResultName
+from fmu.dataio._models.standard_results.fluid_contact_outline import (
+    FluidContactOutlineResult,
+    FluidContactOutlineSchema,
+)
+from tests.utils import inside_rms
+
+logger = null_logger(__name__)
+
+
+CONTACT_FOLDERS = ["fwl", "goc"]
+
+
+@pytest.fixture
+def mock_export_class(
+    mock_project_variable,
+    monkeypatch,
+    rmssetup_with_fmuconfig,
+    xtgeo_zone_polygons,
+):
+    # needed to find the global config at correct place
+    monkeypatch.chdir(rmssetup_with_fmuconfig)
+
+    from fmu.dataio.export.rms.fluid_contact_outlines import (
+        _ExportFluidContactOutlines,
+    )
+
+    with (
+        mock.patch.object(
+            _ExportFluidContactOutlines, "_contact_folder_present", return_value=True
+        ),
+        mock.patch(
+            "fmu.dataio.export.rms.fluid_contact_outlines.list_folder_names_in_general2d_folder",
+            return_value=CONTACT_FOLDERS,
+        ),
+        mock.patch(
+            "fmu.dataio.export.rms.fluid_contact_outlines.get_polygons_in_general2d_folder",
+            return_value=xtgeo_zone_polygons,
+        ),
+    ):
+        yield _ExportFluidContactOutlines(mock_project_variable)
+
+
+@pytest.mark.parametrize("contact", CONTACT_FOLDERS)
+@inside_rms
+def test_files_exported_with_metadata(
+    mock_export_class, rmssetup_with_fmuconfig, contact
+):
+    """Test that the standard_result is set correctly in the metadata"""
+
+    mock_export_class.export()
+
+    export_folder = (
+        rmssetup_with_fmuconfig
+        / f"../../share/results/polygons/fluid_contact_outline/{contact}"
+    )
+    assert export_folder.exists()
+
+    assert (export_folder / "valysar.parquet").exists()
+    assert (export_folder / "therys.parquet").exists()
+    assert (export_folder / "volon.parquet").exists()
+
+    assert (export_folder / ".valysar.parquet.yml").exists()
+    assert (export_folder / ".therys.parquet.yml").exists()
+    assert (export_folder / ".volon.parquet.yml").exists()
+
+
+@inside_rms
+def test_no_valid_contact_folders_found(mock_export_class):
+    """Test that an error is raised if no valid contact surfaces are found"""
+
+    with (
+        mock.patch(
+            "fmu.dataio.export.rms.fluid_contact_outlines.list_folder_names_in_general2d_folder",
+            return_value=["invalid_folder"],
+        ),
+        pytest.raises(ValueError, match="Could not detect"),
+    ):
+        mock_export_class._get_contact_outlines()
+
+
+@inside_rms
+def test_only_valid_contact_folders_processed(
+    rmssetup_with_fmuconfig, mock_export_class
+):
+    """Test that only folders with valid contact names are processed"""
+
+    with mock.patch(
+        "fmu.dataio.export.rms.fluid_contact_outlines.list_folder_names_in_general2d_folder",
+        return_value=["owc", "fwl", "invalid_folder", "gwc"],
+    ):
+        mock_export_class._contact_outlines = mock_export_class._get_contact_outlines()
+
+        assert set(mock_export_class._get_contacts()) == {
+            FluidContactType.owc,
+            FluidContactType.fwl,
+            FluidContactType.gwc,
+        }
+        mock_export_class.export()
+
+    export_folder = (
+        rmssetup_with_fmuconfig / "../../share/results/polygons/fluid_contact_outline/"
+    )
+    assert export_folder.exists()
+    assert (export_folder / "owc").exists()
+    assert (export_folder / "fwl").exists()
+    assert (export_folder / "gwc").exists()
+    assert not (export_folder / "invalid_folder").exists()
+
+    # test for one of the folders that expected files are present
+    assert {file.name for file in (export_folder / "gwc").glob("*")} == {
+        "valysar.parquet",
+        "therys.parquet",
+        "volon.parquet",
+        ".valysar.parquet.yml",
+        ".therys.parquet.yml",
+        ".volon.parquet.yml",
+    }
+
+
+@inside_rms
+def test_standard_result_in_metadata(mock_export_class):
+    """Test that the standard_result is set correctly in the metadata"""
+
+    out = mock_export_class.export()
+    metadata = dataio.read_metadata(out.items[0].absolute_path)
+
+    assert "standard_result" in metadata["data"]
+    assert (
+        metadata["data"]["standard_result"]["name"]
+        == StandardResultName.fluid_contact_outline
+    )
+    assert (
+        metadata["data"]["standard_result"]["file_schema"]["version"]
+        == FluidContactOutlineSchema.VERSION
+    )
+    assert (
+        metadata["data"]["standard_result"]["file_schema"]["url"]
+        == FluidContactOutlineSchema.url()
+    )
+
+
+@inside_rms
+def test_public_export_function(mock_project_variable, mock_export_class):
+    """Test that the export function works"""
+
+    from fmu.dataio.export.rms import export_fluid_contact_outlines
+
+    out = export_fluid_contact_outlines(mock_project_variable)
+
+    assert len(out.items) == 6  # 3 per contact
+
+    metadata = dataio.read_metadata(out.items[0].absolute_path)
+
+    assert "fluid_contact" in metadata["data"]["content"]
+    assert metadata["data"]["fluid_contact"]["contact"] == "fwl"
+    assert metadata["data"]["fluid_contact"]["truncated"] is False
+
+    assert metadata["access"]["classification"] == "internal"
+    assert metadata["data"]["is_prediction"]
+    assert (
+        metadata["data"]["standard_result"]["name"]
+        == StandardResultName.fluid_contact_outline
+    )
+
+
+@inside_rms
+def test_unknown_name_in_stratigraphy_raises(mock_export_class):
+    """Test that an error is raised if horizon name is missing in the stratigraphy"""
+
+    mock_export_class._contact_outlines["fwl"][0].name = "missing"
+
+    with pytest.raises(ValueError, match="not listed"):
+        mock_export_class.export()
+
+
+@inside_rms
+def test_config_missing(mock_project_variable, rmssetup_with_fmuconfig, monkeypatch):
+    """Test that an exception is raised if the config is missing."""
+
+    from fmu.dataio.export.rms import export_fluid_contact_outlines
+
+    # move up one directory to trigger not finding the config
+    monkeypatch.chdir(rmssetup_with_fmuconfig.parent)
+
+    with pytest.raises(FileNotFoundError, match="Could not detect"):
+        export_fluid_contact_outlines(mock_project_variable)
+
+
+@inside_rms
+def test_payload_validates_against_model(
+    mock_export_class,
+):
+    """Tests that the table exported is validated against the payload result
+    model."""
+
+    out = mock_export_class.export()
+    df = (
+        pq.read_table(out.items[0].absolute_path)
+        .to_pandas()
+        .replace(np.nan, None)
+        .to_dict(orient="records")
+    )
+    FluidContactOutlineResult.model_validate(df)  # Throws if invalid
+
+
+@inside_rms
+def test_payload_validates_against_schema(
+    mock_export_class,
+):
+    """Tests that the table exported is validated against the payload result
+    schema."""
+
+    out = mock_export_class.export()
+    df = (
+        pq.read_table(out.items[0].absolute_path)
+        .to_pandas()
+        .replace(np.nan, None)
+        .to_dict(orient="records")
+    )
+    jsonschema.validate(
+        instance=df, schema=FluidContactOutlineSchema.dump()
+    )  # Throws if invalid


### PR DESCRIPTION
Resolves #1208 

PR to add a simple export for the `fluid_contact_outline` standard_result.
Identical to the newly merged PR #1207 except for the object type and the standard result name.

This simple export requires a folder named `fluid_contact_outlines` in the root of the `General 2D data` folder in RMS. The export function will automatically look for subfolders with valid fluid contact names (members of the `enum.FluidContactType)` inside this `fluid_contact_outlines` folder, and export all polygon outlines found inside these contact folders.

Functionality to help create these contact surfaces is ongoing and will be added to `fmu-tools.` When in place the documentation will be updated with a link.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
