### PR TITLE
MAINT: Use RUNRMS_EXEC_MODE to determine if inside RMS

### DIFF
--- a/src/fmu/dataio/_definitions.py
+++ b/src/fmu/dataio/_definitions.py
@@ -78,3 +78,11 @@ STANDARD_TABLE_INDEX_COLUMNS: Final[dict[Content, StandardTableIndex]] = {
         required=["SATNUM"],
     ),
 }
+
+
+class RMSExecutionMode(StrEnum):
+    """The modes RMS can execute in. These definitions come from
+    `runrms.executor._rms_executor`."""
+
+    interactive = "interactive"
+    batch = "batch"

--- a/src/fmu/dataio/_utils.py
+++ b/src/fmu/dataio/_utils.py
@@ -22,6 +22,7 @@ import yaml
 
 from fmu.config import utilities as ut
 
+from ._definitions import RMSExecutionMode
 from ._logging import null_logger
 from ._readers.faultroom import FaultRoomSurface
 
@@ -41,19 +42,18 @@ def npfloat_to_float(v: Any) -> Any:
 
 
 def detect_inside_rms() -> bool:
-    """Detect if 'truly' inside RMS GUI, where predefined variable project exist.
+    """Detect if inside RMS GUI"""
+    return get_rms_exec_mode() is not None
 
-    However this will be overriden by an environment variable for unit testing
-    when using the Roxar API python, so that unit test outside of RMS behaves
-    properly
+
+def get_rms_exec_mode() -> RMSExecutionMode | None:
     """
-    with contextlib.suppress(ModuleNotFoundError):
-        import rmsapi
-
-        logger.info("RMSAPI version is %s", rmsapi.__version__)
-        return True
-    logger.info("Running truly in RMS GUI status: %s", False)
-    return False
+    Get the RMS GUI execution mode from the environment.
+    The RUNRMS_EXEC_MODE variable is set when the RMS GUI is started by runrms,
+    and holds information about the execution mode (interactive or batch).
+    """
+    rms_exec_mode = os.environ.get("RUNRMS_EXEC_MODE")
+    return RMSExecutionMode(rms_exec_mode) if rms_exec_mode else None
 
 
 def dataio_examples() -> bool:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,13 +88,8 @@ def return_to_original_directory():
 
 
 @pytest.fixture
-def set_export_data_inside_rms(monkeypatch):
-    monkeypatch.setattr(ExportData, "_inside_rms", True)
-
-
-@pytest.fixture
-def set_environ_inside_rms(monkeypatch):
-    monkeypatch.setattr("fmu.dataio._utils.detect_inside_rms", lambda: True)
+def inside_rms_interactive(monkeypatch):
+    monkeypatch.setenv("RUNRMS_EXEC_MODE", "interactive")
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_export_rms/test_export_field_outline.py
+++ b/tests/test_export_rms/test_export_field_outline.py
@@ -12,7 +12,6 @@ from fmu.dataio._models.standard_results.field_outline import (
     FieldOutlineResult,
     FieldOutlineSchema,
 )
-from tests.utils import inside_rms
 
 logger = null_logger(__name__)
 
@@ -40,7 +39,7 @@ def mock_export_class(
         yield _ExportFieldOutline(mock_project_variable)
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_files_exported_with_metadata(mock_export_class, rmssetup_with_fmuconfig):
     """Test that the standard_result is set correctly in the metadata"""
 
@@ -54,7 +53,7 @@ def test_files_exported_with_metadata(mock_export_class, rmssetup_with_fmuconfig
     assert (export_folder / "field_outline.parquet").exists()
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_standard_result_in_metadata(mock_export_class):
     """Test that the standard_result is set correctly in the metadata"""
 
@@ -75,7 +74,7 @@ def test_standard_result_in_metadata(mock_export_class):
     )
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_public_export_function(mock_project_variable, mock_export_class):
     """Test that the export function works"""
 
@@ -96,7 +95,7 @@ def test_public_export_function(mock_project_variable, mock_export_class):
     assert metadata["data"]["format"] == "parquet"
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_config_missing(mock_project_variable, rmssetup_with_fmuconfig, monkeypatch):
     """Test that an exception is raised if the config is missing."""
 
@@ -109,7 +108,7 @@ def test_config_missing(mock_project_variable, rmssetup_with_fmuconfig, monkeypa
         export_field_outline(mock_project_variable)
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_payload_validates_against_model(
     mock_export_class,
 ):
@@ -126,7 +125,7 @@ def test_payload_validates_against_model(
     FieldOutlineResult.model_validate(df)  # Throws if invalid
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_payload_validates_against_schema(
     mock_export_class,
 ):

--- a/tests/test_export_rms/test_export_fluid_contact_outlines.py
+++ b/tests/test_export_rms/test_export_fluid_contact_outlines.py
@@ -12,7 +12,6 @@ from fmu.dataio._models.standard_results.fluid_contact_outline import (
     FluidContactOutlineResult,
     FluidContactOutlineSchema,
 )
-from tests.utils import inside_rms
 
 logger = null_logger(__name__)
 
@@ -51,7 +50,7 @@ def mock_export_class(
 
 
 @pytest.mark.parametrize("contact", CONTACT_FOLDERS)
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_files_exported_with_metadata(
     mock_export_class, rmssetup_with_fmuconfig, contact
 ):
@@ -74,7 +73,7 @@ def test_files_exported_with_metadata(
     assert (export_folder / ".volon.parquet.yml").exists()
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_no_valid_contact_folders_found(mock_export_class):
     """Test that an error is raised if no valid contact surfaces are found"""
 
@@ -88,7 +87,7 @@ def test_no_valid_contact_folders_found(mock_export_class):
         mock_export_class._get_contact_outlines()
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_only_valid_contact_folders_processed(
     rmssetup_with_fmuconfig, mock_export_class
 ):
@@ -127,7 +126,7 @@ def test_only_valid_contact_folders_processed(
     }
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_standard_result_in_metadata(mock_export_class):
     """Test that the standard_result is set correctly in the metadata"""
 
@@ -149,7 +148,7 @@ def test_standard_result_in_metadata(mock_export_class):
     )
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_public_export_function(mock_project_variable, mock_export_class):
     """Test that the export function works"""
 
@@ -173,7 +172,7 @@ def test_public_export_function(mock_project_variable, mock_export_class):
     )
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_unknown_name_in_stratigraphy_raises(mock_export_class):
     """Test that an error is raised if horizon name is missing in the stratigraphy"""
 
@@ -183,7 +182,7 @@ def test_unknown_name_in_stratigraphy_raises(mock_export_class):
         mock_export_class.export()
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_config_missing(mock_project_variable, rmssetup_with_fmuconfig, monkeypatch):
     """Test that an exception is raised if the config is missing."""
 
@@ -196,7 +195,7 @@ def test_config_missing(mock_project_variable, rmssetup_with_fmuconfig, monkeypa
         export_fluid_contact_outlines(mock_project_variable)
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_payload_validates_against_model(
     mock_export_class,
 ):
@@ -213,7 +212,7 @@ def test_payload_validates_against_model(
     FluidContactOutlineResult.model_validate(df)  # Throws if invalid
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_payload_validates_against_schema(
     mock_export_class,
 ):

--- a/tests/test_export_rms/test_export_fluid_contact_surfaces.py
+++ b/tests/test_export_rms/test_export_fluid_contact_surfaces.py
@@ -5,7 +5,6 @@ import pytest
 from fmu import dataio
 from fmu.dataio._logging import null_logger
 from fmu.dataio._models.fmu_results.enums import FluidContactType, StandardResultName
-from tests.utils import inside_rms
 
 logger = null_logger(__name__)
 
@@ -44,7 +43,7 @@ def mock_export_class(
 
 
 @pytest.mark.parametrize("contact", CONTACT_FOLDERS)
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_files_exported_with_metadata(
     mock_export_class, rmssetup_with_fmuconfig, contact
 ):
@@ -67,7 +66,7 @@ def test_files_exported_with_metadata(
     assert (export_folder / ".volon.gri.yml").exists()
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_no_valid_contact_folders_found(mock_export_class):
     """Test that an error is raised if no valid contact surfaces are found"""
 
@@ -81,7 +80,7 @@ def test_no_valid_contact_folders_found(mock_export_class):
         mock_export_class._get_contact_surfaces()
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_only_valid_contact_folders_processed(
     rmssetup_with_fmuconfig, mock_export_class
 ):
@@ -120,7 +119,7 @@ def test_only_valid_contact_folders_processed(
     }
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_standard_result_in_metadata(mock_export_class):
     """Test that the standard_result is set correctly in the metadata"""
 
@@ -134,7 +133,7 @@ def test_standard_result_in_metadata(mock_export_class):
     )
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_public_export_function(mock_project_variable, mock_export_class):
     """Test that the export function works"""
 
@@ -158,7 +157,7 @@ def test_public_export_function(mock_project_variable, mock_export_class):
     )
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_unknown_name_in_stratigraphy_raises(mock_export_class):
     """Test that an error is raised if horizon name is missing in the stratigraphy"""
 
@@ -168,7 +167,7 @@ def test_unknown_name_in_stratigraphy_raises(mock_export_class):
         mock_export_class.export()
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_config_missing(mock_project_variable, rmssetup_with_fmuconfig, monkeypatch):
     """Test that an exception is raised if the config is missing."""
 

--- a/tests/test_export_rms/test_export_inplace_volumes.py
+++ b/tests/test_export_rms/test_export_inplace_volumes.py
@@ -19,7 +19,6 @@ from fmu.dataio._models.standard_results.inplace_volumes import (
     InplaceVolumesSchema,
 )
 from fmu.dataio.export import _enums
-from tests.utils import inside_rms
 
 logger = null_logger(__name__)
 
@@ -73,7 +72,7 @@ def exportvolumetrics(
         yield _ExportVolumetricsRMS(mock_project_variable, "Geogrid", "geogrid_vol")
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_rms_volumetrics_export_class(exportvolumetrics):
     """See mocks in local conftest.py"""
 
@@ -94,7 +93,7 @@ def test_rms_volumetrics_export_class(exportvolumetrics):
     assert metadata["access"]["classification"] == "restricted"
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_rms_volumetrics_export_class_table_index(voltable_standard, exportvolumetrics):
     """See mocks in local conftest.py"""
 
@@ -110,7 +109,7 @@ def test_rms_volumetrics_export_class_table_index(voltable_standard, exportvolum
         exportvolumetrics._export_data_as_standard_result()
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_convert_table_from_legacy_to_standard_format(
     mock_project_variable,
     mocked_rmsapi_modules,
@@ -219,7 +218,7 @@ def test_convert_table_from_legacy_to_standard_format(
     )
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_net_column_equal_bulk_if_missing(exportvolumetrics, voltable_standard):
     """Test that the NET column is set equal to BULK if it is missing"""
 
@@ -498,7 +497,7 @@ def test_validate_table_against_pydantic_model_before_export(
         exportvolumetrics._validate_table()
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_rms_volumetrics_export_config_invalid(
     mock_project_variable,
     exportvolumetrics,
@@ -514,7 +513,7 @@ def test_rms_volumetrics_export_config_invalid(
         export_inplace_volumes(mock_project_variable, "Geogrid", "geogrid_volume")
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_rms_volumetrics_export_config_missing(
     mock_project_variable,
     mocked_rmsapi_modules,
@@ -532,7 +531,7 @@ def test_rms_volumetrics_export_config_missing(
         export_inplace_volumes(mock_project_variable, "Geogrid", "geogrid_volume")
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_rms_volumetrics_export_function(
     mock_project_variable,
     mocked_rmsapi_modules,
@@ -571,7 +570,7 @@ def test_rms_volumetrics_export_function(
     assert metadata["data"]["table_index"] == _enums.InplaceVolumes.index_columns()
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_inplace_volumes_payload_validates_against_model(
     exportvolumetrics,
     monkeypatch,
@@ -589,7 +588,7 @@ def test_inplace_volumes_payload_validates_against_model(
     InplaceVolumesResult.model_validate(df)  # Throws if invalid
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_inplace_volumes_payload_validates_against_schema(
     exportvolumetrics,
     monkeypatch,
@@ -609,7 +608,7 @@ def test_inplace_volumes_payload_validates_against_schema(
     )  # Throws if invalid
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_inplace_volumes_export_and_result_columns_are_the_same(
     mocked_rmsapi_modules,
 ) -> None:

--- a/tests/test_export_rms/test_export_structure_depth_fault_lines.py
+++ b/tests/test_export_rms/test_export_structure_depth_fault_lines.py
@@ -14,7 +14,6 @@ from fmu.dataio._models.standard_results.structure_depth_fault_lines import (
     StructureDepthFaultLinesResult,
     StructureDepthFaultLinesSchema,
 )
-from tests.utils import inside_rms
 
 logger = null_logger(__name__)
 
@@ -40,7 +39,7 @@ def mock_export_class(
         yield _ExportStructureDepthFaultLines(mock_project_variable, "DL_extract")
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_files_exported_with_metadata(mock_export_class, rmssetup_with_fmuconfig):
     """Test that the standard_result is set correctly in the metadata"""
 
@@ -61,7 +60,7 @@ def test_files_exported_with_metadata(mock_export_class, rmssetup_with_fmuconfig
     assert (export_folder / ".topvolon.parquet.yml").exists()
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_standard_result_in_metadata(mock_export_class):
     """Test that the standard_result is set correctly in the metadata"""
 
@@ -83,7 +82,7 @@ def test_standard_result_in_metadata(mock_export_class):
     )
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_raise_on_open_fault_lines(mock_export_class):
     """Test that an error is given if a fault line is not closed"""
 
@@ -94,7 +93,7 @@ def test_raise_on_open_fault_lines(mock_export_class):
         mock_export_class.export()
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_public_export_function(mock_project_variable, mock_export_class):
     """Test that the export function works"""
 
@@ -123,7 +122,7 @@ def test_public_export_function(mock_project_variable, mock_export_class):
     assert set(metadata["data"]["table_index"]) == {"POLY_ID", "NAME"}
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_unknown_name_in_stratigraphy_raises(mock_export_class):
     """Test that an error is raised if horizon name is missing in the stratigraphy"""
 
@@ -133,7 +132,7 @@ def test_unknown_name_in_stratigraphy_raises(mock_export_class):
         mock_export_class.export()
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_config_missing(mock_project_variable, rmssetup_with_fmuconfig, monkeypatch):
     """Test that an exception is raised if the config is missing."""
 
@@ -146,7 +145,7 @@ def test_config_missing(mock_project_variable, rmssetup_with_fmuconfig, monkeypa
         export_structure_depth_fault_lines(mock_project_variable, "DS_extract")
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_payload_validates_against_model(
     mock_export_class,
 ):
@@ -163,7 +162,7 @@ def test_payload_validates_against_model(
     StructureDepthFaultLinesResult.model_validate(df)  # Throws if invalid
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_payload_validates_against_schema(
     mock_export_class,
 ):

--- a/tests/test_export_rms/test_export_structure_depth_isochores.py
+++ b/tests/test_export_rms/test_export_structure_depth_isochores.py
@@ -6,7 +6,6 @@ from fmu import dataio
 from fmu.dataio._logging import null_logger
 from fmu.dataio._models.fmu_results.enums import StandardResultName
 from fmu.dataio.exceptions import ValidationError
-from tests.utils import inside_rms
 
 logger = null_logger(__name__)
 
@@ -32,7 +31,7 @@ def mock_export_class(
         yield _ExportStructureDepthIsochores(mock_project_variable, "IS_extracted")
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_files_exported_with_metadata(mock_export_class, rmssetup_with_fmuconfig):
     """Test that the data is exported with metadata"""
 
@@ -52,7 +51,7 @@ def test_files_exported_with_metadata(mock_export_class, rmssetup_with_fmuconfig
     assert (export_folder / ".volon.gri.yml").exists()
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_standard_result_in_metadata(mock_export_class):
     """Test that the standard_result is set correctly in the metadata"""
 
@@ -66,7 +65,7 @@ def test_standard_result_in_metadata(mock_export_class):
     )
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_public_export_function(mock_project_variable, mock_export_class):
     """Test that the export function works"""
 
@@ -87,7 +86,7 @@ def test_public_export_function(mock_project_variable, mock_export_class):
     )
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_unknown_name_in_stratigraphy_raises(mock_export_class):
     """Test that an error is raised if horizon name is missing in the stratigraphy"""
 
@@ -97,7 +96,7 @@ def test_unknown_name_in_stratigraphy_raises(mock_export_class):
         mock_export_class.export()
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_validation_negative_values(
     mock_project_variable, monkeypatch, rmssetup_with_fmuconfig, regsurf
 ):
@@ -119,7 +118,7 @@ def test_validation_negative_values(
             export_structure_depth_isochores(mock_project_variable, "IS_extracted")
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_config_missing(mock_project_variable, rmssetup_with_fmuconfig, monkeypatch):
     """Test that an exception is raised if the config is missing."""
 

--- a/tests/test_export_rms/test_export_structure_depth_surfaces.py
+++ b/tests/test_export_rms/test_export_structure_depth_surfaces.py
@@ -7,7 +7,6 @@ import pytest
 from fmu import dataio
 from fmu.dataio._logging import null_logger
 from fmu.dataio._models.fmu_results.enums import StandardResultName
-from tests.utils import inside_rms
 
 logger = null_logger(__name__)
 
@@ -33,7 +32,7 @@ def mock_export_class(
         yield _ExportStructureDepthSurfaces(mock_project_variable, "geogrid_vol")
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_files_exported_with_metadata(mock_export_class, rmssetup_with_fmuconfig):
     """Test that the standard_result is set correctly in the metadata"""
 
@@ -53,7 +52,7 @@ def test_files_exported_with_metadata(mock_export_class, rmssetup_with_fmuconfig
     assert (export_folder / ".topvolon.gri.yml").exists()
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_standard_result_in_metadata(mock_export_class):
     """Test that the standard_result is set correctly in the metadata"""
 
@@ -67,7 +66,7 @@ def test_standard_result_in_metadata(mock_export_class):
     )
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_public_export_function(mock_project_variable, mock_export_class):
     """Test that the export function works"""
 
@@ -88,7 +87,7 @@ def test_public_export_function(mock_project_variable, mock_export_class):
     )
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_unknown_name_in_stratigraphy_raises(mock_export_class):
     """Test that an error is raised if horizon name is missing in the stratigraphy"""
 
@@ -98,7 +97,7 @@ def test_unknown_name_in_stratigraphy_raises(mock_export_class):
         mock_export_class.export()
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_config_missing(mock_project_variable, rmssetup_with_fmuconfig, monkeypatch):
     """Test that an exception is raised if the config is missing."""
 

--- a/tests/test_units/test_dataio.py
+++ b/tests/test_units/test_dataio.py
@@ -1062,19 +1062,17 @@ def test_metadata_format_deprecated(globalconfig1, regsurf, tmp_path, monkeypatc
     ExportData.meta_format = None  # reset
 
 
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_establish_runpath(tmp_path, globalconfig2):
     """Testing pwd and rootpath from RMS"""
     rmspath = tmp_path / "rms" / "model"
     rmspath.mkdir(parents=True, exist_ok=True)
     os.chdir(rmspath)
 
-    ExportData._inside_rms = True
     edata = ExportData(config=globalconfig2, content="depth")
     edata._establish_rootpath()
 
     assert edata._rootpath == rmspath.parent.parent
-
-    ExportData._inside_rms = False  # reset
 
 
 @pytest.mark.skipif("win" in sys.platform, reason="Windows tests have no /tmp")

--- a/tests/test_units/test_objectdataprovider_class.py
+++ b/tests/test_units/test_objectdataprovider_class.py
@@ -23,7 +23,6 @@ from fmu.dataio.providers.objectdata._triangulated_surface import (
 from fmu.dataio.providers.objectdata._xtgeo import RegularSurfaceDataProvider
 
 from ..conftest import remove_ert_env, set_ert_env_prehook
-from ..utils import inside_rms
 
 # --------------------------------------------------------------------------------------
 # RegularSurface
@@ -187,7 +186,7 @@ def test_regsurf_preprocessed_observation(
     Later, a fmu run will update this (merge metadata)
     """
 
-    @inside_rms
+    @pytest.mark.usefixtures("inside_rms_interactive")
     def _export_data_from_rms(rmssetup, rmsglobalconfig, regsurf):
         """Run an export of a preprocessed surface inside RMS."""
 

--- a/tests/test_units/test_prerealization_surfaces.py
+++ b/tests/test_units/test_prerealization_surfaces.py
@@ -19,7 +19,6 @@ from fmu import dataio
 from fmu.dataio import _utils as utils
 
 from ..conftest import remove_ert_env, set_ert_env_prehook
-from ..utils import inside_rms
 
 logger = logging.getLogger(__name__)
 
@@ -60,7 +59,7 @@ def test_regsurf_preprocessed_observation(
     Later, a fmu run will update this (merge metadata)
     """
 
-    @inside_rms
+    @pytest.mark.usefixtures("inside_rms_interactive")
     def _export_data_from_rms(rmssetup, rmsglobalconfig, regsurf):
         """Run an export of a preprocessed surface inside RMS."""
         logger.info("Active folder is %s", rmssetup)
@@ -168,7 +167,7 @@ def test_regsurf_preprocessed_filename_retained(
     retained when re-exporting preprocessed data.
     """
 
-    @inside_rms
+    @pytest.mark.usefixtures("inside_rms_interactive")
     def _export_data_from_rms(
         rmssetup,
         rmsglobalconfig,
@@ -238,7 +237,7 @@ def test_regsurf_preprocessed_observation_subfolder(
     Alternatively the subfolder can be given another name.
     """
 
-    @inside_rms
+    @pytest.mark.usefixtures("inside_rms_interactive")
     def _export_data_from_rms(rmssetup, rmsglobalconfig, regsurf):
         """Run an export of a preprocessed surface inside RMS."""
         logger.info("Active folder is %s", rmssetup)
@@ -289,7 +288,7 @@ def test_regsurf_preprocessed_observation_subfolder(
     _run_case_fmu(fmurun_prehook, mysurf)
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_preprocessed_with_abs_forcefolder_shall_fail(
     rmssetup, rmsglobalconfig, regsurf
 ):
@@ -311,7 +310,7 @@ def test_preprocessed_with_abs_forcefolder_shall_fail(
         edata.generate_metadata(regsurf)
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_preprocessed_with_rel_forcefolder_ok(rmssetup, rmsglobalconfig, regsurf):
     """Run an export of a preprocessed surface inside RMS, with forcefolder."""
     logger.info("Active folder is %s", rmssetup)
@@ -340,7 +339,7 @@ def test_access_settings_retained(
     The stub metadata is produced when data is made/pre-processed.
     When adding metadata during FMU runtime, the access shall be retained."""
 
-    @inside_rms
+    @pytest.mark.usefixtures("inside_rms_interactive")
     def _export_data_from_rms(rmssetup, rmsglobalconfig, regsurf):
         """Run an export of a preprocessed surface inside RMS."""
         logger.info("Active folder is %s", rmssetup)

--- a/tests/test_units/test_rms_context.py
+++ b/tests/test_units/test_rms_context.py
@@ -21,11 +21,7 @@ from fmu.dataio._readers import faultroom
 from fmu.dataio._utils import prettyprint_dict
 from fmu.dataio.dataio import ValidationError
 
-from ..utils import inside_rms
-
 logger = logging.getLogger(__name__)
-
-logger.info("Inside RMS status %s", dataio.ExportData._inside_rms)
 
 
 @pytest.fixture(scope="module")
@@ -55,7 +51,7 @@ def inside_rms_setup(tmp_path_factory, rootpath):
     os.chdir(rootpath)
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_regsurf_generate_metadata(inside_rms_setup, regsurf):
     """Test generating metadata for a surface pretend inside RMS"""
     logger.info("Active folder is %s", inside_rms_setup["path"])
@@ -66,8 +62,6 @@ def test_regsurf_generate_metadata(inside_rms_setup, regsurf):
         config=inside_rms_setup["config"],
         content="depth",  # read from global config
     )
-    logger.info("Inside RMS status now %s", dataio.ExportData._inside_rms)
-
     edata.generate_metadata(regsurf)
     assert str(edata._pwd) == str(inside_rms_setup["path"])
     assert str(edata._rootpath.resolve()) == str(
@@ -75,7 +69,7 @@ def test_regsurf_generate_metadata(inside_rms_setup, regsurf):
     )
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_regsurf_generate_metadata_change_content(inside_rms_setup, regsurf):
     """As above but change a key in the generate_metadata"""
 
@@ -89,7 +83,7 @@ def test_regsurf_generate_metadata_change_content(inside_rms_setup, regsurf):
     assert meta2["data"]["content"] == "time"
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_regsurf_generate_metadata_change_content_invalid(inside_rms_setup, regsurf):
     """As above but change an invalid name of key in the generate_metadata"""
     edata = dataio.ExportData(
@@ -100,7 +94,7 @@ def test_regsurf_generate_metadata_change_content_invalid(inside_rms_setup, regs
         _ = edata.generate_metadata(regsurf, blablabla="time")
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_regsurf_export_file(inside_rms_setup, regsurf):
     """Export the regular surface to file with correct metadata."""
     logger.info("Active folder is %s", inside_rms_setup["path"])
@@ -114,7 +108,7 @@ def test_regsurf_export_file(inside_rms_setup, regsurf):
     )
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_regsurf_export_file_set_name(inside_rms_setup, regsurf):
     """Export the regular surface to file with correct metadata and name."""
     edata = dataio.ExportData(
@@ -133,7 +127,7 @@ def test_regsurf_export_file_set_name(inside_rms_setup, regsurf):
     assert "TopVolantis" in meta["data"]["alias"]
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_regsurf_metadata_with_timedata(inside_rms_setup, regsurf):
     """Export a regular surface to file with correct metadata and name and timedata."""
 
@@ -164,7 +158,7 @@ def test_regsurf_metadata_with_timedata(inside_rms_setup, regsurf):
     logger.debug(prettyprint_dict(meta1))
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_regsurf_metadata_with_timedata_legacy(inside_rms_setup, regsurf):
     """Export the regular surface to file with correct metadata timedata, legacy ver."""
     dataio.ExportData.legacy_time_format = True
@@ -194,7 +188,7 @@ def test_regsurf_metadata_with_timedata_legacy(inside_rms_setup, regsurf):
     assert meta2["data"]["time"] == meta1["data"]["time"]
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_regsurf_export_file_fmurun(inside_rms_setup, regsurf):
     """Being in RMS and in an active FMU ERT run with case metadata present.
 
@@ -237,7 +231,7 @@ def test_regsurf_export_file_fmurun(inside_rms_setup, regsurf):
 # ======================================================================================
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_polys_export_file_set_name(inside_rms_setup, polygons):
     """Export the polygon to file with correct metadata and name."""
 
@@ -253,7 +247,7 @@ def test_polys_export_file_set_name(inside_rms_setup, polygons):
     )
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_points_export_file_set_name(inside_rms_setup, points):
     """Export the points to file with correct metadata and name."""
     edata = dataio.ExportData(
@@ -271,7 +265,7 @@ def test_points_export_file_set_name(inside_rms_setup, points):
     assert thefile.columns[0] == "X"
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_points_export_file_set_name_xtgeoheaders(inside_rms_setup, points):
     """Export the points to file with correct metadata and name but here xtgeo var."""
 
@@ -300,7 +294,7 @@ def test_points_export_file_set_name_xtgeoheaders(inside_rms_setup, points):
 # ======================================================================================
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_cube_export_file_set_name(inside_rms_setup, cube):
     """Export the cube to file with correct metadata and name."""
 
@@ -316,7 +310,7 @@ def test_cube_export_file_set_name(inside_rms_setup, cube):
     )
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_cube_export_file_set_name_as_observation(inside_rms_setup, cube):
     """Export the cube to file with correct metadata and name, is_observation."""
     edata = dataio.ExportData(
@@ -334,7 +328,7 @@ def test_cube_export_file_set_name_as_observation(inside_rms_setup, cube):
     )
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_cube_export_file_set_name_as_observation_forcefolder(inside_rms_setup, cube):
     """Export the cube to file with correct metadata and name, is_observation.
 
@@ -359,7 +353,7 @@ def test_cube_export_file_set_name_as_observation_forcefolder(inside_rms_setup, 
     )
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_cube_export_as_case(inside_rms_setup, cube):
     """Export the cube to file with correct metadata and name, is_observation.
 
@@ -383,7 +377,7 @@ def test_cube_export_as_case(inside_rms_setup, cube):
     )
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_case_symlink_realization_raises_error(inside_rms_setup):
     """Test that fmu_context="case_symlink_realization" raises error."""
 
@@ -396,7 +390,7 @@ def test_case_symlink_realization_raises_error(inside_rms_setup):
         )
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_cube_export_as_observation_forcefolder_w_added_folder(inside_rms_setup, cube):
     """Export the cube to file with correct metadata and name, is_observation.
 
@@ -421,7 +415,7 @@ def test_cube_export_as_observation_forcefolder_w_added_folder(inside_rms_setup,
     )
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_cube_export_as_observation_forcefolder_w_true_subfolder(
     inside_rms_setup, cube
 ):
@@ -450,7 +444,7 @@ def test_cube_export_as_observation_forcefolder_w_true_subfolder(
     )
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_cube_export_as_observation_forcefolder_w_subfolder_case(
     inside_rms_setup, cube
 ):
@@ -485,7 +479,7 @@ def test_cube_export_as_observation_forcefolder_w_subfolder_case(
 # ======================================================================================
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_grid_export_file_set_name(inside_rms_setup, grid):
     """Export the grid to file with correct metadata and name."""
     edata = dataio.ExportData(
@@ -500,7 +494,7 @@ def test_grid_export_file_set_name(inside_rms_setup, grid):
     )
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_grid_zonation_in_metadata(inside_rms_setup):
     """Export the grid to file with correct metadata and name."""
 
@@ -547,7 +541,7 @@ def test_grid_zonation_in_metadata(inside_rms_setup):
         grid.set_subgrids({"zone1": 1, "zone2": 1})
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_gridproperty_export_file_set_name(inside_rms_setup, gridproperty):
     """Export the gridprop to file with correct metadata and name."""
 
@@ -563,7 +557,7 @@ def test_gridproperty_export_file_set_name(inside_rms_setup, gridproperty):
     )
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_gridproperty_export_with_geometry(inside_rms_setup, grid, gridproperty):
     """Export the the grid and the gridprop(s) with connected geometry."""
 
@@ -622,7 +616,7 @@ def test_gridproperty_export_with_geometry(inside_rms_setup, grid, gridproperty)
     assert "this_is_parent" in output
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_gridproperty_export_with_geometry_and_bad_character(
     inside_rms_setup, grid, gridproperty, monkeypatch
 ):
@@ -664,7 +658,7 @@ def test_gridproperty_export_with_geometry_and_bad_character(
 # ======================================================================================
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_dataframe_export_file_set_name(inside_rms_setup, dataframe):
     """Export the dataframe to file with correct metadata and name."""
 
@@ -683,7 +677,7 @@ def test_dataframe_export_file_set_name(inside_rms_setup, dataframe):
     assert metaout["data"]["spec"]["columns"] == ["COL1", "COL2"]
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_pyarrow_export_file_set_name(inside_rms_setup, arrowtable):
     """Export the arrow to file with correct metadata and name."""
     edata = dataio.ExportData(
@@ -707,7 +701,7 @@ def test_pyarrow_export_file_set_name(inside_rms_setup, arrowtable):
 # ======================================================================================
 
 
-@inside_rms
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_faultroom_export_as_file(rootpath, inside_rms_setup):
     """Export the faultroom surfaces, use input as file"""
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,22 +1,11 @@
 from __future__ import annotations
 
 import datetime
-from functools import wraps
 from pathlib import Path
 from typing import Any, get_args
 
-import pytest
 import yaml
 from pydantic import BaseModel
-
-
-def inside_rms(func):
-    @pytest.mark.usefixtures("set_export_data_inside_rms", "set_environ_inside_rms")
-    @wraps(func)
-    def wrapper(*args, **kwargs):
-        return func(*args, **kwargs)
-
-    return wrapper
 
 
 def _parse_yaml(yaml_path):


### PR DESCRIPTION
Resolves #1246 

PR to start using the `RUNRMS_EXEC_MODE` to determine if we are inside the RMS GUI.
This will enable us to remove the `skip_inside_rmsvenv` pytest.mark #1007 which will be adressed in a separate PR

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
