### PR TITLE
ENH: Add simple export for structure_time_surfaces

### DIFF
--- a/docs/src/standard_results/structure_time_surfaces.md
+++ b/docs/src/standard_results/structure_time_surfaces.md
@@ -1,0 +1,47 @@
+# Structure time surfaces
+
+This exports the modelled structural time surfaces from within RMS.
+These surfaces serve as the input for depth conversion in RMS and form the basis for generating
+the structural framework in depth. Typically, they are extracted from a structural model in time domain.
+
+:::{note} 
+It is only possible to export **one single set** of time surface predictions per 
+model workflow.
+:::
+
+:::{table} Current
+:widths: auto
+:align: left
+
+| Field | Value |
+| --- | --- |
+| Version | NA |
+| Output | `share/results/maps/structure_time_surface/surfacename.gri` |
+| Security classification | 🟡 Internal |
+:::
+
+## Requirements
+
+- RMS
+- time surfaces stored in a horizon folder within RMS
+
+The surfaces must be located within a horizon folder in RMS and be in domain `time`.
+This export function will automatically export all non-empty horizons from the provided folder.
+
+
+## Usage
+
+```{eval-rst}
+.. autofunction:: fmu.dataio.export.rms.structure_time_surfaces.export_structure_time_surfaces
+```
+
+## Result
+
+The surfaces from the horizon folder will be exported as 'irap_binary'
+files to `share/results/maps/structure_time_surface/surfacename.gri`.
+
+
+## Standard result schema
+
+This standard result is not presented in a tabular format; therefore, no validation
+schema exists.

--- a/src/fmu/dataio/export/rms/__init__.py
+++ b/src/fmu/dataio/export/rms/__init__.py
@@ -5,10 +5,12 @@ from .inplace_volumes import export_inplace_volumes, export_rms_volumetrics
 from .structure_depth_fault_lines import export_structure_depth_fault_lines
 from .structure_depth_isochores import export_structure_depth_isochores
 from .structure_depth_surfaces import export_structure_depth_surfaces
+from .structure_time_surfaces import export_structure_time_surfaces
 
 __all__ = [
     "export_structure_depth_fault_lines",
     "export_structure_depth_surfaces",
+    "export_structure_time_surfaces",
     "export_structure_depth_isochores",
     "export_inplace_volumes",
     "export_rms_volumetrics",

--- a/src/fmu/dataio/export/rms/structure_time_surfaces.py
+++ b/src/fmu/dataio/export/rms/structure_time_surfaces.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Final
+
+import fmu.dataio as dio
+from fmu.dataio._logging import null_logger
+from fmu.dataio._models.fmu_results import standard_result
+from fmu.dataio._models.fmu_results.enums import (
+    Classification,
+    Content,
+    DomainReference,
+    StandardResultName,
+    VerticalDomain,
+)
+from fmu.dataio.export._decorators import experimental
+from fmu.dataio.export._export_result import ExportResult, ExportResultItem
+from fmu.dataio.export.rms._base import SimpleExportRMSBase
+from fmu.dataio.export.rms._utils import (
+    get_horizons_in_folder,
+    get_rms_project_units,
+    validate_name_in_stratigraphy,
+)
+
+if TYPE_CHECKING:
+    import xtgeo
+
+_logger: Final = null_logger(__name__)
+
+
+class _ExportStructureTimeSurfaces(SimpleExportRMSBase):
+    def __init__(self, project: Any, horizon_folder: str) -> None:
+        super().__init__()
+
+        _logger.debug("Process data, establish state prior to export.")
+        self._surfaces = get_horizons_in_folder(project, horizon_folder)
+        self._unit = "m" if get_rms_project_units(project) == "metric" else "ft"
+        _logger.debug("Process data... DONE")
+
+    @property
+    def _standard_result(self) -> standard_result.StructureTimeSurfaceStandardResult:
+        """Standard result type for the exported data."""
+        return standard_result.StructureTimeSurfaceStandardResult(
+            name=StandardResultName.structure_time_surface
+        )
+
+    @property
+    def _content(self) -> Content:
+        """Get content for the exported data."""
+        return Content.time
+
+    @property
+    def _classification(self) -> Classification:
+        """Get default classification."""
+        return Classification.internal
+
+    @property
+    def _rep_include(self) -> bool:
+        """rep_include status"""
+        return True
+
+    def _export_surface(self, surf: xtgeo.RegularSurface) -> ExportResultItem:
+        edata = dio.ExportData(
+            config=self._config,
+            content=self._content,
+            unit=self._unit,
+            vertical_domain=VerticalDomain.time.value,
+            domain_reference=DomainReference.msl.value,
+            subfolder=self._subfolder,
+            is_prediction=True,
+            name=surf.name,
+            classification=self._classification,
+            rep_include=self._rep_include,
+        )
+
+        absolute_export_path = edata._export_with_standard_result(
+            surf, standard_result=self._standard_result
+        )
+        _logger.debug("Surface exported to: %s", absolute_export_path)
+
+        return ExportResultItem(
+            absolute_path=Path(absolute_export_path),
+        )
+
+    def _export_data_as_standard_result(self) -> ExportResult:
+        """Do the actual surface export using dataio setup."""
+        return ExportResult(
+            items=[self._export_surface(surf) for surf in self._surfaces]
+        )
+
+    def _validate_data_pre_export(self) -> None:
+        """Surface validations."""
+        # TODO: Add check that the surfaces are consistent, i.e. a stratigraphic
+        # deeper surface should never have shallower values than the one above
+        for surf in self._surfaces:
+            validate_name_in_stratigraphy(surf.name, self._config)
+
+
+@experimental
+def export_structure_time_surfaces(
+    project: Any,
+    horizon_folder: str,
+) -> ExportResult:
+    """Simplified interface when exporting modelled time surfaces from RMS.
+
+    Args:
+        project: The 'magic' project variable in RMS.
+        horizon_folder: Name of horizon folder in RMS.
+    Note:
+        This function is experimental and may change in future versions.
+
+    Examples:
+        Example usage in an RMS script::
+
+            from fmu.dataio.export.rms import export_structure_time_surfaces
+
+            export_results = export_structure_time_surfaces(project, "TS_extracted")
+
+            for result in export_results.items:
+                print(f"Output surfaces to {result.absolute_path}")
+
+    """
+    return _ExportStructureTimeSurfaces(project, horizon_folder).export()

--- a/tests/test_export_rms/test_export_structure_time_surfaces.py
+++ b/tests/test_export_rms/test_export_structure_time_surfaces.py
@@ -1,0 +1,110 @@
+"""Test the dataio running RMS specific utility function for time surfaces"""
+
+from unittest import mock
+
+import pytest
+
+from fmu import dataio
+from fmu.dataio._logging import null_logger
+from fmu.dataio._models.fmu_results.enums import StandardResultName
+
+logger = null_logger(__name__)
+
+
+@pytest.fixture
+def mock_export_class(
+    mock_project_variable,
+    monkeypatch,
+    rmssetup_with_fmuconfig,
+    xtgeo_surfaces,
+):
+    # needed to find the global config at correct place
+    monkeypatch.chdir(rmssetup_with_fmuconfig)
+
+    from fmu.dataio.export.rms.structure_time_surfaces import (
+        _ExportStructureTimeSurfaces,
+    )
+
+    with mock.patch(
+        "fmu.dataio.export.rms.structure_time_surfaces.get_horizons_in_folder",
+        return_value=xtgeo_surfaces,
+    ):
+        yield _ExportStructureTimeSurfaces(mock_project_variable, "TS_extracted")
+
+
+@pytest.mark.usefixtures("inside_rms_interactive")
+def test_files_exported_with_metadata(mock_export_class, rmssetup_with_fmuconfig):
+    """Test that the standard_result is set correctly in the metadata"""
+
+    mock_export_class.export()
+
+    export_folder = (
+        rmssetup_with_fmuconfig / "../../share/results/maps/structure_time_surface"
+    )
+    assert export_folder.exists()
+
+    assert (export_folder / "topvolantis.gri").exists()
+    assert (export_folder / "toptherys.gri").exists()
+    assert (export_folder / "topvolon.gri").exists()
+
+    assert (export_folder / ".topvolantis.gri.yml").exists()
+    assert (export_folder / ".toptherys.gri.yml").exists()
+    assert (export_folder / ".topvolon.gri.yml").exists()
+
+
+@pytest.mark.usefixtures("inside_rms_interactive")
+def test_standard_result_in_metadata(mock_export_class):
+    """Test that the standard_result is set correctly in the metadata"""
+
+    out = mock_export_class.export()
+    metadata = dataio.read_metadata(out.items[0].absolute_path)
+
+    assert "standard_result" in metadata["data"]
+    assert (
+        metadata["data"]["standard_result"]["name"]
+        == StandardResultName.structure_time_surface
+    )
+
+
+@pytest.mark.usefixtures("inside_rms_interactive")
+def test_public_export_function(mock_project_variable, mock_export_class):
+    """Test that the export function works"""
+
+    from fmu.dataio.export.rms import export_structure_time_surfaces
+
+    out = export_structure_time_surfaces(mock_project_variable, "TS_extract")
+
+    assert len(out.items) == 3
+
+    metadata = dataio.read_metadata(out.items[0].absolute_path)
+
+    assert "time" in metadata["data"]["content"]
+    assert metadata["access"]["classification"] == "internal"
+    assert metadata["data"]["is_prediction"]
+    assert (
+        metadata["data"]["standard_result"]["name"]
+        == StandardResultName.structure_time_surface
+    )
+
+
+@pytest.mark.usefixtures("inside_rms_interactive")
+def test_unknown_name_in_stratigraphy_raises(mock_export_class):
+    """Test that an error is raised if horizon name is missing in the stratigraphy"""
+
+    mock_export_class._surfaces[0].name = "missing"
+
+    with pytest.raises(ValueError, match="not listed"):
+        mock_export_class.export()
+
+
+@pytest.mark.usefixtures("inside_rms_interactive")
+def test_config_missing(mock_project_variable, rmssetup_with_fmuconfig, monkeypatch):
+    """Test that an exception is raised if the config is missing."""
+
+    from fmu.dataio.export.rms import export_structure_time_surfaces
+
+    # move up one directory to trigger not finding the config
+    monkeypatch.chdir(rmssetup_with_fmuconfig.parent)
+
+    with pytest.raises(FileNotFoundError, match="Could not detect"):
+        export_structure_time_surfaces(mock_project_variable, "TS_extract")


### PR DESCRIPTION
Addresses #issue1046

Add a simple export function for exporting the standard result `structure_time_surface` from within RMS. Including Documentation for how to use the export function.

## Checklist

- [x] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [ ] Checked the boxes in this checklist ✅
