### PR TITLE
TST: Remove skip_inside_rmsvenv mark

### DIFF
--- a/ci/testrmsenv.sh
+++ b/ci/testrmsenv.sh
@@ -39,6 +39,6 @@ install_test_dependencies () {
 run_pytest () {
     echo "Running fmu-dataio tests with pytest..."
     pushd $CI_TEST_ROOT
-    pytest ./tests -n 4 -vv -m "not skip_inside_rmsvenv" --ignore=tests/test_ert_integration
+    pytest ./tests -n 4 -vv --ignore=tests/test_ert_integration
     popd
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,9 +89,6 @@ write_to = "src/fmu/dataio/version.py"
 [tool.pytest.ini_options]
 minversion = "6.0"
 testpaths = "tests"
-markers = [
-    "skip_inside_rmsvenv: tests that should be skipped if inside rmsvenv",
-]
 
 [tool.coverage.run]
 omit = [

--- a/src/fmu/dataio/export/rms/inplace_volumes.py
+++ b/src/fmu/dataio/export/rms/inplace_volumes.py
@@ -283,7 +283,7 @@ class _ExportVolumetricsRMS(SimpleExportRMSBase):
         table = self._add_missing_columns_to_table(table)
         return self._set_table_column_order(table)
 
-    def _is_column_missing_in_table(self, column: str) -> bool:
+    def _is_column_missing_in_table(self, column: str) -> bool | np.bool:
         """Check if a column is present in the final dataframe and has values"""
         return column not in self._dataframe or self._dataframe[column].isna().all()
 

--- a/tests/test_units/test_dataio.py
+++ b/tests/test_units/test_dataio.py
@@ -67,7 +67,6 @@ def test_missing_or_wrong_config_exports_with_warning(monkeypatch, tmp_path, reg
         read_metadata(out)
 
 
-@pytest.mark.skip_inside_rmsvenv
 def test_wrong_config_exports_correctly_ouside_fmu(
     monkeypatch, tmp_path, globalconfig1, regsurf
 ):
@@ -113,7 +112,6 @@ def test_wrong_config_exports_correctly_ouside_fmu(
     assert objpath_cfg_invalid == objpath_cfg_valid
 
 
-@pytest.mark.skip_inside_rmsvenv
 def test_wrong_config_exports_correctly_in_fmu(
     monkeypatch, fmurun_w_casemetadata, globalconfig1, regsurf
 ):
@@ -262,7 +260,6 @@ def test_update_check_settings_shall_fail(globalconfig1):
         some._update_check_settings(newsettings)
 
 
-@pytest.mark.skip_inside_rmsvenv
 @pytest.mark.parametrize(
     "key, value, expected_msg",
     [

--- a/tests/test_units/test_filedataprovider_class.py
+++ b/tests/test_units/test_filedataprovider_class.py
@@ -202,7 +202,6 @@ def test_get_share_folders_with_subfolder(regsurf, globalconfig2):
     assert str(fmeta.absolute_path.parent).endswith("share/results/maps/sub")
 
 
-@pytest.mark.skip_inside_rmsvenv
 def test_filedata_provider(regsurf, tmp_path, globalconfig2):
     """Testing the derive_filedata function."""
 

--- a/tests/test_units/test_fmuprovider_class.py
+++ b/tests/test_units/test_fmuprovider_class.py
@@ -407,7 +407,6 @@ def test_fmuprovider_workflow_reference(fmurun_w_casemetadata, globalconfig2):
         FmuProvider(model=GLOBAL_CONFIG_MODEL, workflow=123.4).get_metadata()
 
 
-@pytest.mark.skip_inside_rmsvenv
 def test_ert_simulation_modes_one_to_one() -> None:
     """Ensure dataio known modes match those defined by Ert.
 

--- a/tests/test_units/test_table.py
+++ b/tests/test_units/test_table.py
@@ -52,7 +52,6 @@ def assert_correct_table_index(dict_input, answer):
     assert_list_and_answer(index, answer, index)
 
 
-@pytest.mark.skip_inside_rmsvenv
 def test_inplace_volume_index(mock_volumes, globalconfig2, monkeypatch, tmp_path):
     """Test volumetric data
 
@@ -70,7 +69,6 @@ def test_inplace_volume_index(mock_volumes, globalconfig2, monkeypatch, tmp_path
     assert_correct_table_index(path, answer)
 
 
-@pytest.mark.skip_inside_rmsvenv
 def test_relperm_index(mock_relperm, globalconfig2, monkeypatch, tmp_path):
     """Test that the table index is set correct for relperm data"""
     monkeypatch.chdir(tmp_path)
@@ -80,7 +78,6 @@ def test_relperm_index(mock_relperm, globalconfig2, monkeypatch, tmp_path):
     assert_correct_table_index(path, answer)
 
 
-@pytest.mark.skip_inside_rmsvenv
 def test_derive_summary_index_pandas(
     mock_summary, globalconfig2, monkeypatch, tmp_path
 ):

--- a/tests/test_units/test_utils.py
+++ b/tests/test_units/test_utils.py
@@ -91,7 +91,6 @@ def test_detect_inside_rms_decorator():
     assert utils.get_rms_exec_mode() == RMSExecutionMode.interactive
 
 
-@pytest.mark.skip_inside_rmsvenv
 def test_detect_not_inside_rms():
     # TODO: Refactor tests and move away from outside/inside rms pattern
     assert not utils.detect_inside_rms()


### PR DESCRIPTION
Resolves #1007 

PR to remove the `skip_inside_rmsvenv` `pytest.mark`. 

We no longer need to skip any tests when we have moved away from checking if `rmsapi` is available, and instead use the environment variable from `runrms` to determine if we are inside RMS or not #1246 

Note I did test to run the tests locally inside a `rmsvenv` and with these changes the tests run fine both inside and outside.


## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
