### PR TITLE
ENH: Simple loader for fluid contact surfaces

### DIFF
--- a/docs/src/standard_results/fluid_contact_outlines.md
+++ b/docs/src/standard_results/fluid_contact_outlines.md
@@ -85,3 +85,6 @@ present within the `data.standard_result` key in its associated object metadata.
 The current JSON schema is embedded here.
 
 {{ FluidContactOutlineSchema.literalinclude }}
+
+## Load fluid contact outlines
+The loader interface for fluid contact outlines standard results is still under development and not supported yet.

--- a/docs/src/standard_results/fluid_contact_surfaces.md
+++ b/docs/src/standard_results/fluid_contact_surfaces.md
@@ -57,3 +57,34 @@ The fluid contact surfaces from the `General 2D data` folder will be exported as
 
 This standard result is not presented in a tabular format; therefore, no validation
 schema exists.
+
+## Load fluid contact surfaces
+Use the below loader function, loader object and interface to load and interact with 
+the exported fluid contact surfaces standard results. For more information about the
+purpose of these loader functions, see
+[Load standard results](../standard_results.md#load-standard-results).
+
+### Usage
+```{eval-rst}
+.. autofunction:: fmu.dataio.load.load_standard_results.load_fluid_contact_surfaces
+```
+
+```{eval-rst}
+.. autofunction:: fmu.dataio.load.load_standard_results.FluidContactSurfacesLoader
+```
+
+```{eval-rst}
+.. autofunction:: fmu.dataio.load.load_standard_results.FluidContactSurfacesLoader.list_realizations
+```
+
+```{eval-rst}
+.. autofunction:: fmu.dataio.load.load_standard_results.FluidContactSurfacesLoader.get_realization
+```
+ 
+```{eval-rst}
+.. autofunction:: fmu.dataio.load.load_standard_results.FluidContactSurfacesLoader.get_blobs
+```
+
+```{eval-rst}
+.. autofunction:: fmu.dataio.load.load_standard_results.FluidContactSurfacesLoader.save_realization
+```

--- a/docs/src/standard_results/structure_depth_fault_lines.md
+++ b/docs/src/standard_results/structure_depth_fault_lines.md
@@ -79,3 +79,6 @@ present within the `data.standard_result` key in its associated object metadata.
 The current JSON schema is embedded here.
 
 {{ StructureDepthFaultLinesSchema.literalinclude }}
+
+## Load structure depth fault lines
+The loader interface for structure depth fault lines standard results is still under development and not supported yet.

--- a/docs/src/standard_results/structure_depth_isochores.md
+++ b/docs/src/standard_results/structure_depth_isochores.md
@@ -51,3 +51,6 @@ files to `share/results/maps/structure_depth_isochore/zonename.gri`.
 
 This standard result is not presented in a tabular format; therefore, no validation
 schema exists.
+
+## Load structure depth isochores
+The loader interface for structure depth isochores standard results is still under development and not supported yet.

--- a/src/fmu/dataio/external_interfaces/sumo_explorer_interface.py
+++ b/src/fmu/dataio/external_interfaces/sumo_explorer_interface.py
@@ -55,7 +55,7 @@ class SumoExplorerInterface:
         self, realization_id: int
     ) -> list[tuple[DataFrame | xtgeo.Polygons | xtgeo.RegularSurface, dict]]:
         """
-        Get the standard results data and metadata from Sumo,
+        Get the standard results data objects and metadata from Sumo,
         filtered on the provided realization id. The results are returned
         as a list of tuples containing the data and metadata.
         """

--- a/src/fmu/dataio/external_interfaces/sumo_explorer_interface.py
+++ b/src/fmu/dataio/external_interfaces/sumo_explorer_interface.py
@@ -51,28 +51,7 @@ class SumoExplorerInterface:
             case _:
                 raise ValueError(f"Unknown FMUClass {self._fmu_class}. in provided ")
 
-    def get_realization(
-        self, realization_id: int
-    ) -> dict[str, DataFrame | xtgeo.Polygons | xtgeo.RegularSurface]:
-        """
-        Get the standard results data objects from Sumo,
-        filtered on the provided realization id.
-        The results are returned as key value pairs, with the
-        data name as key and a fmu-dataio formatted data object as value.
-        """
-
-        search_context_realization = self._search_context.filter(
-            realization=realization_id
-        )
-
-        realization_data: dict[
-            str, DataFrame | xtgeo.Polygons | xtgeo.RegularSurface
-        ] = {}
-        for object in search_context_realization:
-            realization_data[object.name] = self._get_formatted_data(object)
-        return realization_data
-
-    def get_realization_with_metadata(
+    def get_objects_with_metadata(
         self, realization_id: int
     ) -> list[tuple[DataFrame | xtgeo.Polygons | xtgeo.RegularSurface, dict]]:
         """
@@ -93,22 +72,19 @@ class SumoExplorerInterface:
 
         return realization_data
 
-    def get_blobs(self, realization_id: int) -> dict[str, BytesIO]:
+    def get_blobs_with_metadata(
+        self, realization_id: int
+    ) -> list[tuple[BytesIO, dict]]:
         """
-        Get the standard results data blobs from Sumo,
-        filtered on the provided realization id.
-        The results are returned as key value pairs,
-        with the data name as key and the data blob as value.
+        Get the standard results data blobs and metadata from Sumo,
+        filtered on the provided realization id. The results are returned
+        as a list of tuples containing the blobs and metadata.
         """
+
         search_context_realization = self._search_context.filter(
             realization=realization_id
         )
-
-        blobs: dict[str, BytesIO] = {}
-        for object in search_context_realization:
-            blobs[object.name] = object.blob
-
-        return blobs
+        return [(object.blob, object.metadata) for object in search_context_realization]
 
     def get_realization_ids(self) -> list[int]:
         """Get a list of the standard results realization ids from Sumo."""

--- a/src/fmu/dataio/load/load_standard_results.py
+++ b/src/fmu/dataio/load/load_standard_results.py
@@ -42,26 +42,40 @@ class StandardResultsLoader:
     def get_realization(self, realization_id: int) -> dict[str, DataFrameOrXtgeoObject]:
         """
         Returns a dictionary with the loaded objects, filtered on the provided
-        realization id. The `key` is the object name.
+        realization id. The `key` is a string based on the object name.
 
         Args:
             realization_id: The id of the realization to filter on.
 
         """
 
-        return self._sumo_interface.get_realization(realization_id)
+        data_dict: dict[str, DataFrameOrXtgeoObject] = {}
+        for object, metadata in self._sumo_interface.get_objects_with_metadata(
+            realization_id
+        ):
+            object_key = self._construct_object_key(metadata)
+            data_dict[object_key] = object
+
+        return data_dict
 
     def get_blobs(self, realization_id: int) -> dict[str, BytesIO]:
         """
         Returns a dictionary with the loaded objects blobs, filtered on the
-        provided realization id. The `key` is the object name.
+        provided realization id. The `key` is a string based on the object name.
 
         Args:
             realization_id: The id of the realization to filter on.
 
         """
 
-        return self._sumo_interface.get_blobs(realization_id)
+        blobs_dict: dict[str, BytesIO] = {}
+        for blob, metadata in self._sumo_interface.get_blobs_with_metadata(
+            realization_id
+        ):
+            object_key = self._construct_object_key(metadata)
+            blobs_dict[object_key] = blob
+
+        return blobs_dict
 
     @staticmethod
     def _generate_path_for_saving(
@@ -81,6 +95,20 @@ class StandardResultsLoader:
         file_name = relative_path.name.replace(relative_path.suffix, file_extention)
 
         return file_path / Path(file_name)
+
+    @staticmethod
+    def _construct_object_key(object_metadata: dict) -> str:
+        """Construct a unique key from the provided object metadata"""
+
+        data_name: str = object_metadata["data"]["name"]
+        object_name = data_name.lower().replace(" ", "-")
+        standard_result_name = object_metadata["data"]["standard_result"]["name"]
+
+        if standard_result_name == StandardResultName.fluid_contact_surface:
+            fluid_contact_type = object_metadata["data"]["fluid_contact"]["contact"]
+            return f"{object_name}_{fluid_contact_type}"
+
+        return object_name
 
     @staticmethod
     def _validate_object(data_frame: DataFrame, schema_url: str) -> None:
@@ -120,12 +148,12 @@ class TabularStandardResultsLoader(StandardResultsLoader):
 
         """
 
-        realization_data: list[tuple[DataFrame, dict]] = (
-            self._sumo_interface.get_realization_with_metadata(realization_id)
+        data_frames_with_metadata: list[tuple[DataFrame, dict]] = (
+            self._sumo_interface.get_objects_with_metadata(realization_id)
         )
 
         file_paths: list[str] = []
-        for data_frame, metadata in realization_data:
+        for data_frame, metadata in data_frames_with_metadata:
             self._validate_object(
                 data_frame=data_frame,
                 schema_url=metadata["data"]["standard_result"]["file_schema"]["url"],
@@ -162,12 +190,12 @@ class PolygonStandardResultsLoader(StandardResultsLoader):
 
         """
 
-        realization_data: list[tuple[xtgeo.Polygons, dict]] = (
-            self._sumo_interface.get_realization_with_metadata(realization_id)
+        plygons_with_metadata: list[tuple[xtgeo.Polygons, dict]] = (
+            self._sumo_interface.get_objects_with_metadata(realization_id)
         )
 
         file_paths: list[str] = []
-        for polygon, metadata in realization_data:
+        for polygon, metadata in plygons_with_metadata:
             # Temporary work-around until xtgeo.Polygons supports storing
             # csv files directly with Polygons.to_file()
             # https://github.com/equinor/xtgeo/issues/1333
@@ -212,12 +240,12 @@ class SurfacesStandardResultsLoader(StandardResultsLoader):
 
         """
 
-        realization_data: list[tuple[xtgeo.RegularSurface, dict]] = (
-            self._sumo_interface.get_realization_with_metadata(realization_id)
+        surfaces_with_metadata: list[tuple[xtgeo.RegularSurface, dict]] = (
+            self._sumo_interface.get_objects_with_metadata(realization_id)
         )
 
         file_paths: list[str] = []
-        for surface, metadata in realization_data:
+        for surface, metadata in surfaces_with_metadata:
             file_path = self._generate_path_for_saving(folder_path, metadata, ".gri")
             surface.to_file(file_path, fformat="irap_binary")
             file_paths.append(str(file_path))
@@ -257,6 +285,19 @@ class StructureDepthSurfacesLoader(SurfacesStandardResultsLoader):
     def __init__(self, case_id: UUID, ensemble_name: str) -> None:
         super().__init__(
             case_id, ensemble_name, StandardResultName.structure_depth_surface
+        )
+
+
+class FluidContactSurfacesLoader(SurfacesStandardResultsLoader):
+    """
+    Loader object for the Fluid Contact Surfaces standard results in fmu-dataio.
+    Offers a set of methods to easily manage and interact
+    with the loaded fluid contact surfaces data.
+    """
+
+    def __init__(self, case_id: UUID, ensemble_name: str) -> None:
+        super().__init__(
+            case_id, ensemble_name, StandardResultName.fluid_contact_surface
         )
 
 
@@ -357,3 +398,38 @@ def load_structure_depth_surfaces(
     """  # noqa: E501 line too long
 
     return StructureDepthSurfacesLoader(case_id, ensemble_name)
+
+
+@experimental
+def load_fluid_contact_surfaces(
+    case_id: UUID, ensemble_name: str
+) -> FluidContactSurfacesLoader:
+    """
+    This function provides a simplified interface for loading fluid contact surfaces
+    standard results from Sumo. It returns a FluidContactSurfacesLoader object,
+    which offers a set of methods to easily manage and interact with the
+    loaded fluid contact surfaces data.
+
+    Args:
+        case_id: The id of the case to load fluid contact surfaces from.
+        ensemble_name: The name of the ensemble to load fluid contact surfaces from.
+
+    Note:
+        This function is experimental and may change in future versions.
+
+    Examples:
+        Example usage in a script::
+
+            from fmu.dataio.load.load_standard_results import load_fluid_contact_surfaces
+
+            fluid_contact_surfaces_loader = load_fluid_contact_surfaces(case_id, ensemble_name)
+
+            # Get all fluid contact surface objects for a given realization
+            objects = fluid_contact_surfaces_loader.get_realization(realization_id)
+
+            # Save the fluid contact surface objects for a given realization
+            object_paths = fluid_contact_surfaces_loader.save_realization(realization_id, folder_path)
+
+    """  # noqa: E501 line too long
+
+    return FluidContactSurfacesLoader(case_id, ensemble_name)

--- a/src/fmu/dataio/load/load_standard_results.py
+++ b/src/fmu/dataio/load/load_standard_results.py
@@ -101,12 +101,12 @@ class StandardResultsLoader:
         """Construct a unique key from the provided object metadata"""
 
         data_name: str = object_metadata["data"]["name"]
-        object_name = data_name.lower().replace(" ", "-")
+        object_name = data_name.lower().replace(" ", "_").replace(".", "")
         standard_result_name = object_metadata["data"]["standard_result"]["name"]
 
         if standard_result_name == StandardResultName.fluid_contact_surface:
             fluid_contact_type = object_metadata["data"]["fluid_contact"]["contact"]
-            return f"{object_name}_{fluid_contact_type}"
+            return f"{object_name}-{fluid_contact_type}"
 
         return object_name
 

--- a/tests/test_loaders/test_standard_result_loaders.py
+++ b/tests/test_loaders/test_standard_result_loaders.py
@@ -358,7 +358,8 @@ def test_construct_object_key():
         )
 
         expected_object_key = (
-            f"{data_name_mock.lower().replace(' ', '-')}_{fluid_contact_type_mock}"
+            f"{data_name_mock.lower().replace(' ', '_').replace('.', '')}-"
+            f"{fluid_contact_type_mock}"
         )
         actual_object_key = fluid_contact_surfaces_loader._construct_object_key(
             mocked_metadata

--- a/tests/test_loaders/test_standard_result_loaders.py
+++ b/tests/test_loaders/test_standard_result_loaders.py
@@ -74,7 +74,7 @@ def test_get_blobs(unregister_pandas_parquet):
 
     data_name_mock = "simgrid"
     mocked_metadata = _generate_metadata_mock(
-        data_name_mock=data_name_mock, standard_result_name="inplace_volumes"
+        data_name=data_name_mock, standard_result_name="inplace_volumes"
     )
 
     mocked_blobs_with_metadata: list[tuple[BytesIO, dict]] = [


### PR DESCRIPTION
Resolves #1244 

Added simple loader interface for the `fluid_contact_surfaces` standard result. This covers:
* A new loader function `load_fluid_contact_surfaces()`
* A new loader object `FluidContactSurfacesLoader`
* Better naming of the data objects returned to the user to ensure uniqueness
* Added and adjusted tests
* Added documentation for fluid contact surfaces

Added a few comments and questions for discussion.

## Checklist

- [X] Tests added (if not, comment why)
- [X] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [X] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [X] Docstrings are correct and updated
- [X] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [X] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅
