### PR TITLE
CI: Force update pytest in rmsenv test script

### DIFF
--- a/ci/testrmsenv.sh
+++ b/ci/testrmsenv.sh
@@ -29,8 +29,8 @@ install_test_dependencies () {
     echo "Installing test dependencies..."
     pip install ".[dev]"
     
-    # Reinstall pydantic to force latest version
-    pip install -U pydantic
+    # Reinstall pydantic and pytest to force latest version
+    pip install -U pydantic pytest
 
     echo "Dependencies installed successfully. Listing installed dependencies..."
     pip list


### PR DESCRIPTION
Resolves #1261 

Updated the `testrmsenv.sh` script to force update the pip package `pytest` before running the `fmu-dataio` tests. This script is used when testing the RMS envs.

This update was needed as some of the tests in `fmu-dataio` does not work with the pytest version that comes with the RMS env. 

## Checklist

- [X] Tests added (if not, comment why)
- [X] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [X] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [X] Docstrings are correct and updated
- [X] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [X] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅
