### PR TITLE
BUG: Require RMS14.2 for simple export inplace_volumes

### DIFF
--- a/docs/src/standard_results/initial_inplace_volumes.md
+++ b/docs/src/standard_results/initial_inplace_volumes.md
@@ -15,7 +15,7 @@ This exports the initial inplace volumes of a single grid from within RMS.
 
 ## Requirements
 
-- RMS
+- RMS (minimum version 14.2)
 - RMS volumetrics job stored to report table
 - Proper grid erosion
 

--- a/src/fmu/dataio/export/rms/inplace_volumes.py
+++ b/src/fmu/dataio/export/rms/inplace_volumes.py
@@ -408,7 +408,7 @@ def export_inplace_volumes(
 
     """  # noqa: E501 line too long
 
-    check_rmsapi_version(minimum_version="1.7")
+    check_rmsapi_version(minimum_version="1.10")
 
     return _ExportVolumetricsRMS(
         project,

--- a/tests/test_export_rms/conftest.py
+++ b/tests/test_export_rms/conftest.py
@@ -195,7 +195,7 @@ VOLJOB_PARAMS = {
 def mock_rmsapi():
     # Create a mock rmsapi module
     mock_rmsapi = MagicMock()
-    mock_rmsapi.__version__ = "1.7"
+    mock_rmsapi.__version__ = "1.10"
     mock_rmsapi.jobs.Job.get_job(...).get_arguments.return_value = VOLJOB_PARAMS
     mock_rmsapi.Surface = MagicMock
     mock_rmsapi.Polylines = MagicMock

--- a/tests/test_export_rms/test_export_inplace_volumes.py
+++ b/tests/test_export_rms/test_export_inplace_volumes.py
@@ -78,7 +78,7 @@ def test_rms_volumetrics_export_class(exportvolumetrics):
     import rmsapi  # type: ignore # noqa
     import rmsapi.jobs as jobs  # type: ignore # noqa
 
-    assert rmsapi.__version__ == "1.7"
+    assert rmsapi.__version__ == "1.10"
     assert "Report" in jobs.Job.get_job("whatever").get_arguments.return_value
 
     # volume table name should be picked up by the mocked object
@@ -501,6 +501,24 @@ def test_validate_table_against_pydantic_model_before_export(
     exportvolumetrics._dataframe = df
     with pytest.raises(ValidationError, match="Input should be a valid number"):
         exportvolumetrics._validate_table()
+
+
+@pytest.mark.usefixtures("inside_rms_interactive")
+def test_rms_volumetrics_export_rmsapi_requirement(
+    mock_project_variable, mocked_rmsapi_modules, exportvolumetrics
+):
+    """Test that an exception is raised if minimum rmsapi version 1.10 is not met"""
+
+    from fmu.dataio.export.rms.inplace_volumes import export_inplace_volumes
+
+    # mock the rmsapi version to be lower than 1.10
+    mocked_rmsapi_modules["rmsapi"].__version__ = "1.9"
+    with pytest.raises(RuntimeError, match="RMS 14.2"):
+        export_inplace_volumes(mock_project_variable, "Geogrid", "geogrid_volume")
+
+    # no error should be raised if the version is 1.10 or higher
+    mocked_rmsapi_modules["rmsapi"].__version__ = "1.10"
+    export_inplace_volumes(mock_project_variable, "Geogrid", "geogrid_volume")
 
 
 @pytest.mark.usefixtures("inside_rms_interactive")


### PR DESCRIPTION
Adresses #1266 

PR to bump the requirement for the `rmsapi` to be minimum `1.10` which corresponds to `RMS` version `14.2.`

Next step is to update the python3.8 version of fmu-dataio (`2.10.1`) with this commit so that users get a meaningful error message when trying to implement this functionality in a project older that 14.2.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
