### PR TITLE
ENH, DEP: Drop empty columns from table_index

### DIFF
--- a/docs/src/dataio_3_migration.rst
+++ b/docs/src/dataio_3_migration.rst
@@ -87,6 +87,8 @@ Additionally
    now the table_index will remain empty. An exception exists for tables associated with content types
    that have a predefined standard index; then the ``table_index`` will be set to the intersection of
    the table's columns and the standard.
+ - Previously it was possible to set an empty column as a table index, this is no longer allowed.
+
 
 
 Changes to class variables 

--- a/src/fmu/dataio/providers/objectdata/_utils.py
+++ b/src/fmu/dataio/providers/objectdata/_utils.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 import warnings
 from typing import TYPE_CHECKING
 
+import pyarrow as pa
+import pyarrow.compute as pc
+
 if TYPE_CHECKING:
+    import pandas as pd
+
     from fmu.dataio._models.fmu_results.global_configuration import Stratigraphy
 
 
@@ -22,3 +27,21 @@ class Utils:
             "in global config"
         )
         return ""
+
+
+def is_empty_column_pandas(table: pd.DataFrame, column: str) -> bool:
+    """Check if a column in the table is empty (all values are NaN or null)."""
+    return bool(table[column].isna().all())
+
+
+def is_empty_column_pyarrow(table: pa.Table, column: str) -> bool:
+    """Check if a column in the table is empty (all values are NaN or null)."""
+    return pc.all(table[column].is_null()).as_py()
+
+
+def is_empty_column(table: pd.DataFrame | pa.Table, column: str) -> bool:
+    """Check if a column in the table is empty (all values are NaN or null)."""
+
+    if isinstance(table, pa.Table):
+        return is_empty_column_pyarrow(table, column)
+    return is_empty_column_pandas(table, column)

--- a/tests/test_units/test_dataio.py
+++ b/tests/test_units/test_dataio.py
@@ -77,8 +77,6 @@ def test_wrong_config_exports_correctly_ouside_fmu(
     outside an fmu run.
     """
 
-    # TODO: Refactor tests and move away from outside/inside rms pattern
-
     monkeypatch.chdir(tmp_path)
     name = "mysurface"
 
@@ -121,8 +119,6 @@ def test_wrong_config_exports_correctly_in_fmu(
     Test that the export path is correct and equal to exports with valid config,
     inside an fmu run.
     """
-
-    # TODO: Refactor tests and move away from outside/inside rms pattern
 
     monkeypatch.chdir(fmurun_w_casemetadata)
     name = "mysurface"
@@ -278,8 +274,6 @@ def test_update_check_settings_shall_fail(globalconfig1):
 )
 def test_deprecated_keys(globalconfig1, regsurf, key, value, expected_msg):
     """Some keys shall raise a DeprecationWarning or similar."""
-
-    # TODO: Refactor tests and move away from outside/inside rms pattern
 
     # under primary initialisation
     kval = {key: value}

--- a/tests/test_units/test_filedataprovider_class.py
+++ b/tests/test_units/test_filedataprovider_class.py
@@ -205,8 +205,6 @@ def test_get_share_folders_with_subfolder(regsurf, globalconfig2):
 def test_filedata_provider(regsurf, tmp_path, globalconfig2):
     """Testing the derive_filedata function."""
 
-    # TODO: Refactor tests and move away from outside/inside rms pattern
-
     os.chdir(tmp_path)
 
     cfg = ExportData(


### PR DESCRIPTION
Resolves #1263 

PR to start dropping empty columns from the `data.table_index` and to add a deprecation notice saying it will not be allowed in the future. A `table_index` column should only contain valid values and not be empty.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
