### PR TITLE
BUG: Require RMS14.2 for simple export inplace_volumes

### DIFF
--- a/docs/src/standard_results/initial_inplace_volumes.md
+++ b/docs/src/standard_results/initial_inplace_volumes.md
@@ -14,7 +14,7 @@ This exports the initial inplace volumes of a single grid from within RMS.
 
 ## Requirements
 
-- RMS
+- RMS (minimum version 14.2)
 - RMS volumetrics job stored to report table
 - Proper grid erosion
 

--- a/src/fmu/dataio/export/rms/inplace_volumes.py
+++ b/src/fmu/dataio/export/rms/inplace_volumes.py
@@ -374,7 +374,7 @@ def export_inplace_volumes(
 
     """  # noqa: E501 line too long
 
-    check_rmsapi_version(minimum_version="1.7")
+    check_rmsapi_version(minimum_version="1.10")
 
     return _ExportVolumetricsRMS(
         project,

--- a/tests/test_export_rms/conftest.py
+++ b/tests/test_export_rms/conftest.py
@@ -195,7 +195,7 @@ VOLJOB_PARAMS = {
 def mock_rmsapi():
     # Create a mock rmsapi module
     mock_rmsapi = MagicMock()
-    mock_rmsapi.__version__ = "1.7"
+    mock_rmsapi.__version__ = "1.10"
     mock_rmsapi.jobs.Job.get_job(...).get_arguments.return_value = VOLJOB_PARAMS
     yield mock_rmsapi
 


### PR DESCRIPTION
Adresses #1266 

Cherry picked commit #1267 into the 2.10.x branch that is used for RMS 14.1 and below.
This will be used to create a tag to update the version used in the RMS environments.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
