### PR TITLE
ENH: Use sha256 to create hashes for uuid's made from strings

### DIFF
--- a/src/fmu/dataio/_utils.py
+++ b/src/fmu/dataio/_utils.py
@@ -211,7 +211,8 @@ def size(fname: str) -> int:
 
 def uuid_from_string(string: str) -> uuid.UUID:
     """Produce valid and repeteable UUID4 as a hash of given string"""
-    return uuid.UUID(hashlib.md5(string.encode("utf-8")).hexdigest())
+    sha256_hash = hashlib.sha256(string.encode("utf-8")).hexdigest()
+    return uuid.UUID(sha256_hash[:32])
 
 
 def read_parameters_txt(pfile: Path | str) -> types.Parameters:


### PR DESCRIPTION
Resolves #1218 

PR to change to using sha256, instead of md5, to create a hash for an uuid made from a string.
This is implemented in the `uuid_from_string` method wich is used top set the following uuid's:

- `fmu.ensemble.uuid`
- `fmu.realization.uuid`
- `fmu.entity.uuid`
- `fmu.aggregation.uuid` 

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [ ] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [ ] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [ ] Checked the boxes in this checklist ✅
