### PR TITLE
ENH: Re-populate file.size_bytes

### DIFF
--- a/src/fmu/dataio/_utils.py
+++ b/src/fmu/dataio/_utils.py
@@ -174,16 +174,16 @@ def md5sum_stream(stream: BufferedIOBase) -> str:
     return hash_md5.hexdigest()
 
 
-def compute_md5_from_objdata(objdata: ObjectDataProvider) -> str:
+def compute_md5_and_size_from_objdata(objdata: ObjectDataProvider) -> tuple[str, int]:
     """Compute an MD5 sum for an object."""
     try:
-        return objdata.compute_md5()
+        return objdata.compute_md5_and_size()
     except Exception as e:
         logger.debug(
             f"Exception {e} occured when trying to compute md5 from memory stream "
             f"for an object of type {type(objdata.obj)}. Will use tempfile instead."
         )
-        return objdata.compute_md5_using_temp_file()
+        return objdata.compute_md5_and_size_using_temp_file()
 
 
 def create_symlink(source: str, target: str) -> None:

--- a/src/fmu/dataio/aggregation.py
+++ b/src/fmu/dataio/aggregation.py
@@ -268,11 +268,14 @@ class AggregatedData:
 
         objdata = objectdata_provider_factory(obj=obj, dataio=etemp)
 
+        checksum_md5, size = _utils.compute_md5_and_size_from_objdata(objdata)
+
         template["tracklog"] = [Tracklog.initialize()[0]]
         template["file"] = {
             "relative_path": str(relpath),
             "absolute_path": str(abspath) if abspath else None,
-            "checksum_md5": _utils.compute_md5_from_objdata(objdata),
+            "checksum_md5": checksum_md5,
+            "size_bytes": size,
         }
 
         # data section

--- a/src/fmu/dataio/providers/_filedata.py
+++ b/src/fmu/dataio/providers/_filedata.py
@@ -15,7 +15,7 @@ from fmu.dataio._definitions import ShareFolder
 from fmu.dataio._logging import null_logger
 from fmu.dataio._models.fmu_results import fields
 from fmu.dataio._models.fmu_results.enums import FMUContext
-from fmu.dataio._utils import compute_md5_from_objdata
+from fmu.dataio._utils import compute_md5_and_size_from_objdata
 
 from ._base import Provider
 
@@ -153,6 +153,8 @@ class FileDataProvider(Provider):
         absolute_path = exportroot / share_path
         relative_path = absolute_path.relative_to(casepath or exportroot)
 
+        checksum, size = compute_md5_and_size_from_objdata(self.objdata)
+
         logger.info("Returning metadata pydantic model fields.File")
         return fields.File(
             absolute_path=absolute_path.resolve(),
@@ -162,5 +164,6 @@ class FileDataProvider(Provider):
                 if self.runcontext.fmu_context == FMUContext.realization
                 else None
             ),
-            checksum_md5=compute_md5_from_objdata(self.objdata),
+            checksum_md5=checksum,
+            size_bytes=size,
         )

--- a/src/fmu/dataio/providers/objectdata/_base.py
+++ b/src/fmu/dataio/providers/objectdata/_base.py
@@ -171,19 +171,19 @@ class ObjectDataProvider(Provider):
     def share_path(self) -> Path:
         return SharePathConstructor(self.dataio, self).get_share_path()
 
-    def compute_md5(self) -> str:
-        """Compute an MD5 sum"""
+    def compute_md5_and_size(self) -> tuple[str, int]:
+        """Compute an MD5 sum and the buffer size"""
         memory_stream = BytesIO()
         self.export_to_file(memory_stream)
-        return md5sum(memory_stream)
+        return md5sum(memory_stream), memory_stream.getbuffer().nbytes
 
-    def compute_md5_using_temp_file(self) -> str:
-        """Compute an MD5 sum using a temporary file."""
+    def compute_md5_and_size_using_temp_file(self) -> tuple[str, int]:
+        """Compute an MD5 sum and the file size using a temporary file."""
         with NamedTemporaryFile(buffering=0, suffix=".tmp") as tf:
             logger.info("Compute MD5 sum for tmp file")
             tempfile = Path(tf.name)
             self.export_to_file(tempfile)
-            return md5sum(tempfile)
+            return md5sum(tempfile), tempfile.stat().st_size
 
     def get_metadata(self) -> AnyData | UnsetData:
         assert self._metadata is not None

--- a/tests/test_units/test_objectdataprovider_class.py
+++ b/tests/test_units/test_objectdataprovider_class.py
@@ -236,4 +236,6 @@ def test_objectdata_compute_md5(gridproperty, edataobj1):
     myobj = objectdata_provider_factory(gridproperty, edataobj1)
 
     metadata = edataobj1.generate_metadata(gridproperty)
-    assert metadata["file"]["checksum_md5"] == myobj.compute_md5()
+    checksum, size = myobj.compute_md5_and_size()
+    assert metadata["file"]["checksum_md5"] == checksum
+    assert metadata["file"]["size_bytes"] == size


### PR DESCRIPTION
Resolves #1061

PR to start re-adding `file.size_bytes` into the metadata again. 
This is listed as a contractual field and is information that is nice to know. 

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
