### PR TITLE
ENH, SCHEMA: Add data.uuid to outgoing metadata

### DIFF
--- a/examples/example_metadata/fmu_case.yml
+++ b/examples/example_metadata/fmu_case.yml
@@ -32,7 +32,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-06-11T07:37:46.256673Z'
+- datetime: '2025-06-13T13:20:57.761031Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/polygons_field_outline.yml
+++ b/examples/example_metadata/polygons_field_outline.yml
@@ -42,6 +42,7 @@ data:
   tagname: polygons_field_outline
   undef_is_zero: false
   unit: m
+  uuid: aa8ac31c-4f80-7f64-7e35-9f9f9dba1a99
   vertical_domain: depth
 display:
   name: VOLANTIS GP. Base
@@ -63,7 +64,7 @@ fmu:
     name: iter-0
     uuid: 00000000-0000-0000-0000-000000000000
   entity:
-    uuid: 85a58443-3beb-23f8-c91a-86ff6e247346
+    uuid: 37fac59f-6aaf-3479-4ccb-92ebd2201e6b
   ert:
     experiment:
       id: 00000000-0000-0000-0000-000000000000
@@ -100,7 +101,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-06-11T07:37:51.865324Z'
+- datetime: '2025-06-13T13:21:03.323724Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/polygons_field_region.yml
+++ b/examples/example_metadata/polygons_field_region.yml
@@ -42,6 +42,7 @@ data:
   tagname: polygons_field_region
   undef_is_zero: false
   unit: m
+  uuid: 6ecc777a-4a94-971a-26fb-e145add507c1
   vertical_domain: depth
 display:
   name: VOLANTIS GP. Base
@@ -63,7 +64,7 @@ fmu:
     name: iter-0
     uuid: 00000000-0000-0000-0000-000000000000
   entity:
-    uuid: cdd06e5d-e104-ebbd-1c45-5e25b914522f
+    uuid: e593bd88-d27d-1716-334e-498564b247fe
   ert:
     experiment:
       id: 00000000-0000-0000-0000-000000000000
@@ -100,7 +101,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-06-11T07:37:51.831363Z'
+- datetime: '2025-06-13T13:21:03.288639Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/preprocessed_surface_depth.yml
+++ b/examples/example_metadata/preprocessed_surface_depth.yml
@@ -39,6 +39,7 @@ data:
   tagname: ''
   undef_is_zero: false
   unit: ''
+  uuid: bf9cdfff-2488-78ed-4202-66544c702a75
   vertical_domain: depth
 display:
   name: preprocessedmap
@@ -80,7 +81,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-06-11T07:38:01.668196Z'
+- datetime: '2025-06-13T13:21:11.340461Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/surface_depth.yml
+++ b/examples/example_metadata/surface_depth.yml
@@ -39,6 +39,7 @@ data:
   tagname: ds_extract_geogrid
   undef_is_zero: false
   unit: m
+  uuid: a0ee7fb7-8030-9a84-306f-f317b29a3a85
   vertical_domain: depth
 display:
   name: topvolantis
@@ -60,7 +61,7 @@ fmu:
     name: iter-0
     uuid: 00000000-0000-0000-0000-000000000000
   entity:
-    uuid: 3135c777-e85a-0f80-63d3-837831b31e8a
+    uuid: 6141a238-844c-50ce-057f-3c7ce4f85213
   ert:
     experiment:
       id: 00000000-0000-0000-0000-000000000000
@@ -97,7 +98,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-06-11T07:38:04.314494Z'
+- datetime: '2025-06-13T13:21:13.805924Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/surface_fluid_contact.yml
+++ b/examples/example_metadata/surface_fluid_contact.yml
@@ -42,6 +42,7 @@ data:
   tagname: ''
   undef_is_zero: false
   unit: m
+  uuid: a15a9d09-d972-f3e0-2dc7-8f3813ecc597
   vertical_domain: depth
 display:
   name: surface_fluid_contact
@@ -63,7 +64,7 @@ fmu:
     name: iter-0
     uuid: 00000000-0000-0000-0000-000000000000
   entity:
-    uuid: 4a055a3a-470f-80ee-ed18-9e3c4594f604
+    uuid: cb335861-9e4e-2189-58c1-7ba325da3822
   ert:
     experiment:
       id: 00000000-0000-0000-0000-000000000000
@@ -100,7 +101,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-06-11T07:38:04.383548Z'
+- datetime: '2025-06-13T13:21:13.872675Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/surface_seismic_amplitude.yml
+++ b/examples/example_metadata/surface_seismic_amplitude.yml
@@ -60,6 +60,7 @@ data:
     stratigraphic: true
   undef_is_zero: false
   unit: m
+  uuid: 30bdfa2b-23fe-7c6a-02d4-687162ff1ff5
   vertical_domain: depth
 display:
   name: surface_seismic_amplitude
@@ -81,7 +82,7 @@ fmu:
     name: iter-0
     uuid: 00000000-0000-0000-0000-000000000000
   entity:
-    uuid: 699b770d-bae9-d463-f1f7-a1c7c6f18162
+    uuid: eac23fc1-251d-731b-f5cc-0ad80f3349ba
   ert:
     experiment:
       id: 00000000-0000-0000-0000-000000000000
@@ -118,7 +119,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-06-11T07:38:04.457370Z'
+- datetime: '2025-06-13T13:21:13.946779Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/table_inplace_volumes.yml
+++ b/examples/example_metadata/table_inplace_volumes.yml
@@ -47,6 +47,7 @@ data:
   tagname: volumes
   undef_is_zero: false
   unit: m
+  uuid: 3414de99-38fd-990e-e01b-e5ee0535f4bc
   vertical_domain: depth
 display:
   name: geogrid
@@ -68,7 +69,7 @@ fmu:
     name: iter-0
     uuid: 00000000-0000-0000-0000-000000000000
   entity:
-    uuid: 5cd14e06-93ec-5fa2-ee40-5c0bd34a65b9
+    uuid: 1eb90546-df6b-3333-6a29-6fd3af404a0d
   ert:
     experiment:
       id: 00000000-0000-0000-0000-000000000000
@@ -105,7 +106,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-06-11T07:38:11.089580Z'
+- datetime: '2025-06-13T13:21:19.571376Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/schemas/0.12.0/fmu_results.json
+++ b/schemas/0.12.0/fmu_results.json
@@ -951,6 +951,14 @@
           "title": "Unit",
           "type": "string"
         },
+        "uuid": {
+          "examples": [
+            "15ce3b84-766f-4c93-9050-b154861f9100"
+          ],
+          "format": "uuid",
+          "title": "Uuid",
+          "type": "string"
+        },
         "vertical_domain": {
           "const": "depth",
           "title": "Vertical Domain",
@@ -959,6 +967,7 @@
       },
       "required": [
         "content",
+        "uuid",
         "name",
         "stratigraphic",
         "format",
@@ -1702,6 +1711,14 @@
           "title": "Unit",
           "type": "string"
         },
+        "uuid": {
+          "examples": [
+            "15ce3b84-766f-4c93-9050-b154861f9100"
+          ],
+          "format": "uuid",
+          "title": "Uuid",
+          "type": "string"
+        },
         "vertical_domain": {
           "anyOf": [
             {
@@ -1720,6 +1737,7 @@
       },
       "required": [
         "content",
+        "uuid",
         "name",
         "stratigraphic",
         "format",
@@ -2002,6 +2020,14 @@
           "title": "Unit",
           "type": "string"
         },
+        "uuid": {
+          "examples": [
+            "15ce3b84-766f-4c93-9050-b154861f9100"
+          ],
+          "format": "uuid",
+          "title": "Uuid",
+          "type": "string"
+        },
         "vertical_domain": {
           "anyOf": [
             {
@@ -2020,6 +2046,7 @@
       },
       "required": [
         "content",
+        "uuid",
         "name",
         "stratigraphic",
         "format",
@@ -2302,6 +2329,14 @@
           "title": "Unit",
           "type": "string"
         },
+        "uuid": {
+          "examples": [
+            "15ce3b84-766f-4c93-9050-b154861f9100"
+          ],
+          "format": "uuid",
+          "title": "Uuid",
+          "type": "string"
+        },
         "vertical_domain": {
           "anyOf": [
             {
@@ -2320,6 +2355,7 @@
       },
       "required": [
         "content",
+        "uuid",
         "name",
         "stratigraphic",
         "format",
@@ -2656,6 +2692,14 @@
           "title": "Unit",
           "type": "string"
         },
+        "uuid": {
+          "examples": [
+            "15ce3b84-766f-4c93-9050-b154861f9100"
+          ],
+          "format": "uuid",
+          "title": "Uuid",
+          "type": "string"
+        },
         "vertical_domain": {
           "anyOf": [
             {
@@ -2674,6 +2718,7 @@
       },
       "required": [
         "content",
+        "uuid",
         "name",
         "stratigraphic",
         "format",
@@ -2999,6 +3044,14 @@
           "title": "Unit",
           "type": "string"
         },
+        "uuid": {
+          "examples": [
+            "15ce3b84-766f-4c93-9050-b154861f9100"
+          ],
+          "format": "uuid",
+          "title": "Uuid",
+          "type": "string"
+        },
         "vertical_domain": {
           "anyOf": [
             {
@@ -3017,6 +3070,7 @@
       },
       "required": [
         "content",
+        "uuid",
         "name",
         "stratigraphic",
         "format",
@@ -3339,6 +3393,14 @@
           "title": "Unit",
           "type": "string"
         },
+        "uuid": {
+          "examples": [
+            "15ce3b84-766f-4c93-9050-b154861f9100"
+          ],
+          "format": "uuid",
+          "title": "Uuid",
+          "type": "string"
+        },
         "vertical_domain": {
           "anyOf": [
             {
@@ -3357,6 +3419,7 @@
       },
       "required": [
         "content",
+        "uuid",
         "name",
         "stratigraphic",
         "format",
@@ -3772,6 +3835,14 @@
           "title": "Unit",
           "type": "string"
         },
+        "uuid": {
+          "examples": [
+            "15ce3b84-766f-4c93-9050-b154861f9100"
+          ],
+          "format": "uuid",
+          "title": "Uuid",
+          "type": "string"
+        },
         "vertical_domain": {
           "anyOf": [
             {
@@ -3790,6 +3861,7 @@
       },
       "required": [
         "content",
+        "uuid",
         "name",
         "stratigraphic",
         "format",
@@ -4258,6 +4330,14 @@
           "title": "Unit",
           "type": "string"
         },
+        "uuid": {
+          "examples": [
+            "15ce3b84-766f-4c93-9050-b154861f9100"
+          ],
+          "format": "uuid",
+          "title": "Uuid",
+          "type": "string"
+        },
         "vertical_domain": {
           "anyOf": [
             {
@@ -4276,6 +4356,7 @@
       },
       "required": [
         "content",
+        "uuid",
         "name",
         "stratigraphic",
         "format",
@@ -4599,6 +4680,14 @@
           "title": "Unit",
           "type": "string"
         },
+        "uuid": {
+          "examples": [
+            "15ce3b84-766f-4c93-9050-b154861f9100"
+          ],
+          "format": "uuid",
+          "title": "Uuid",
+          "type": "string"
+        },
         "vertical_domain": {
           "anyOf": [
             {
@@ -4617,6 +4706,7 @@
       },
       "required": [
         "content",
+        "uuid",
         "name",
         "stratigraphic",
         "format",
@@ -4952,6 +5042,14 @@
           "title": "Unit",
           "type": "string"
         },
+        "uuid": {
+          "examples": [
+            "15ce3b84-766f-4c93-9050-b154861f9100"
+          ],
+          "format": "uuid",
+          "title": "Uuid",
+          "type": "string"
+        },
         "vertical_domain": {
           "anyOf": [
             {
@@ -4970,6 +5068,7 @@
       },
       "required": [
         "content",
+        "uuid",
         "name",
         "stratigraphic",
         "format",
@@ -5372,6 +5471,14 @@
           "title": "Unit",
           "type": "string"
         },
+        "uuid": {
+          "examples": [
+            "15ce3b84-766f-4c93-9050-b154861f9100"
+          ],
+          "format": "uuid",
+          "title": "Uuid",
+          "type": "string"
+        },
         "vertical_domain": {
           "anyOf": [
             {
@@ -5390,6 +5497,7 @@
       },
       "required": [
         "content",
+        "uuid",
         "name",
         "stratigraphic",
         "format",
@@ -5672,6 +5780,14 @@
           "title": "Unit",
           "type": "string"
         },
+        "uuid": {
+          "examples": [
+            "15ce3b84-766f-4c93-9050-b154861f9100"
+          ],
+          "format": "uuid",
+          "title": "Uuid",
+          "type": "string"
+        },
         "vertical_domain": {
           "anyOf": [
             {
@@ -5690,6 +5806,7 @@
       },
       "required": [
         "content",
+        "uuid",
         "name",
         "stratigraphic",
         "format",
@@ -5972,6 +6089,14 @@
           "title": "Unit",
           "type": "string"
         },
+        "uuid": {
+          "examples": [
+            "15ce3b84-766f-4c93-9050-b154861f9100"
+          ],
+          "format": "uuid",
+          "title": "Uuid",
+          "type": "string"
+        },
         "vertical_domain": {
           "anyOf": [
             {
@@ -5990,6 +6115,7 @@
       },
       "required": [
         "content",
+        "uuid",
         "name",
         "stratigraphic",
         "format",
@@ -6481,6 +6607,14 @@
           "title": "Unit",
           "type": "string"
         },
+        "uuid": {
+          "examples": [
+            "15ce3b84-766f-4c93-9050-b154861f9100"
+          ],
+          "format": "uuid",
+          "title": "Uuid",
+          "type": "string"
+        },
         "vertical_domain": {
           "anyOf": [
             {
@@ -6499,6 +6633,7 @@
       },
       "required": [
         "content",
+        "uuid",
         "name",
         "stratigraphic",
         "format",
@@ -6781,6 +6916,14 @@
           "title": "Unit",
           "type": "string"
         },
+        "uuid": {
+          "examples": [
+            "15ce3b84-766f-4c93-9050-b154861f9100"
+          ],
+          "format": "uuid",
+          "title": "Uuid",
+          "type": "string"
+        },
         "vertical_domain": {
           "anyOf": [
             {
@@ -6799,6 +6942,7 @@
       },
       "required": [
         "content",
+        "uuid",
         "name",
         "stratigraphic",
         "format",
@@ -7186,6 +7330,14 @@
           "title": "Unit",
           "type": "string"
         },
+        "uuid": {
+          "examples": [
+            "15ce3b84-766f-4c93-9050-b154861f9100"
+          ],
+          "format": "uuid",
+          "title": "Uuid",
+          "type": "string"
+        },
         "vertical_domain": {
           "anyOf": [
             {
@@ -7204,6 +7356,7 @@
       },
       "required": [
         "content",
+        "uuid",
         "name",
         "stratigraphic",
         "format",
@@ -7486,6 +7639,14 @@
           "title": "Unit",
           "type": "string"
         },
+        "uuid": {
+          "examples": [
+            "15ce3b84-766f-4c93-9050-b154861f9100"
+          ],
+          "format": "uuid",
+          "title": "Uuid",
+          "type": "string"
+        },
         "vertical_domain": {
           "anyOf": [
             {
@@ -7504,6 +7665,7 @@
       },
       "required": [
         "content",
+        "uuid",
         "name",
         "stratigraphic",
         "format",
@@ -7877,6 +8039,14 @@
           "title": "Unit",
           "type": "string"
         },
+        "uuid": {
+          "examples": [
+            "15ce3b84-766f-4c93-9050-b154861f9100"
+          ],
+          "format": "uuid",
+          "title": "Uuid",
+          "type": "string"
+        },
         "vertical_domain": {
           "anyOf": [
             {
@@ -7895,6 +8065,7 @@
       },
       "required": [
         "content",
+        "uuid",
         "name",
         "stratigraphic",
         "format",
@@ -8178,6 +8349,14 @@
           "title": "Unit",
           "type": "string"
         },
+        "uuid": {
+          "examples": [
+            "15ce3b84-766f-4c93-9050-b154861f9100"
+          ],
+          "format": "uuid",
+          "title": "Uuid",
+          "type": "string"
+        },
         "vertical_domain": {
           "anyOf": [
             {
@@ -8196,6 +8375,7 @@
       },
       "required": [
         "content",
+        "uuid",
         "name",
         "stratigraphic",
         "format",
@@ -8691,6 +8871,14 @@
           "title": "Unit",
           "type": "string"
         },
+        "uuid": {
+          "examples": [
+            "15ce3b84-766f-4c93-9050-b154861f9100"
+          ],
+          "format": "uuid",
+          "title": "Uuid",
+          "type": "string"
+        },
         "vertical_domain": {
           "anyOf": [
             {
@@ -8709,6 +8897,7 @@
       },
       "required": [
         "content",
+        "uuid",
         "name",
         "stratigraphic",
         "format",
@@ -9141,6 +9330,14 @@
           "title": "Unit",
           "type": "string"
         },
+        "uuid": {
+          "examples": [
+            "15ce3b84-766f-4c93-9050-b154861f9100"
+          ],
+          "format": "uuid",
+          "title": "Uuid",
+          "type": "string"
+        },
         "vertical_domain": {
           "anyOf": [
             {
@@ -9159,6 +9356,7 @@
       },
       "required": [
         "content",
+        "uuid",
         "name",
         "stratigraphic",
         "format",
@@ -9465,6 +9663,14 @@
           "title": "Unit",
           "type": "string"
         },
+        "uuid": {
+          "examples": [
+            "15ce3b84-766f-4c93-9050-b154861f9100"
+          ],
+          "format": "uuid",
+          "title": "Uuid",
+          "type": "string"
+        },
         "vertical_domain": {
           "const": "time",
           "title": "Vertical Domain",
@@ -9473,6 +9679,7 @@
       },
       "required": [
         "content",
+        "uuid",
         "name",
         "stratigraphic",
         "format",
@@ -9756,6 +9963,14 @@
           "title": "Unit",
           "type": "string"
         },
+        "uuid": {
+          "examples": [
+            "15ce3b84-766f-4c93-9050-b154861f9100"
+          ],
+          "format": "uuid",
+          "title": "Uuid",
+          "type": "string"
+        },
         "vertical_domain": {
           "anyOf": [
             {
@@ -9774,6 +9989,7 @@
       },
       "required": [
         "content",
+        "uuid",
         "name",
         "stratigraphic",
         "format",
@@ -10145,6 +10361,14 @@
           "title": "Unit",
           "type": "string"
         },
+        "uuid": {
+          "examples": [
+            "15ce3b84-766f-4c93-9050-b154861f9100"
+          ],
+          "format": "uuid",
+          "title": "Uuid",
+          "type": "string"
+        },
         "vertical_domain": {
           "anyOf": [
             {
@@ -10163,6 +10387,7 @@
       },
       "required": [
         "content",
+        "uuid",
         "name",
         "stratigraphic",
         "format",
@@ -10484,6 +10709,14 @@
           "title": "Unit",
           "type": "string"
         },
+        "uuid": {
+          "examples": [
+            "15ce3b84-766f-4c93-9050-b154861f9100"
+          ],
+          "format": "uuid",
+          "title": "Uuid",
+          "type": "string"
+        },
         "vertical_domain": {
           "anyOf": [
             {
@@ -10502,6 +10735,7 @@
       },
       "required": [
         "content",
+        "uuid",
         "name",
         "stratigraphic",
         "format",
@@ -10806,6 +11040,14 @@
           "title": "Unit",
           "type": "string"
         },
+        "uuid": {
+          "examples": [
+            "15ce3b84-766f-4c93-9050-b154861f9100"
+          ],
+          "format": "uuid",
+          "title": "Uuid",
+          "type": "string"
+        },
         "vertical_domain": {
           "anyOf": [
             {
@@ -10824,6 +11066,7 @@
       },
       "required": [
         "content",
+        "uuid",
         "name",
         "stratigraphic",
         "format",
@@ -11106,6 +11349,14 @@
           "title": "Unit",
           "type": "string"
         },
+        "uuid": {
+          "examples": [
+            "15ce3b84-766f-4c93-9050-b154861f9100"
+          ],
+          "format": "uuid",
+          "title": "Uuid",
+          "type": "string"
+        },
         "vertical_domain": {
           "anyOf": [
             {
@@ -11124,6 +11375,7 @@
       },
       "required": [
         "content",
+        "uuid",
         "name",
         "stratigraphic",
         "format",

--- a/src/fmu/dataio/_models/fmu_results/data.py
+++ b/src/fmu/dataio/_models/fmu_results/data.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import warnings
 from typing import TYPE_CHECKING, Annotated, Any, Literal
+from uuid import UUID
 
 from pydantic import (
     AwareDatetime,
@@ -220,6 +221,9 @@ class Data(BaseModel):
     standard_result: AnyStandardResult | None = Field(default=None)
     """Information about the standard result that these data represent. The presence of
     this field indicates that these data conforms to a specified standard."""
+
+    uuid: UUID = Field(examples=["15ce3b84-766f-4c93-9050-b154861f9100"])
+    """The unique identifier of this data object."""
 
     name: str = Field(examples=["VIKING GP. Top"])
     """This is the identifying name of this data object. For surfaces, this is typically

--- a/src/fmu/dataio/_models/fmu_results/fmu_results.py
+++ b/src/fmu/dataio/_models/fmu_results/fmu_results.py
@@ -51,6 +51,7 @@ class FmuResultsSchema(SchemaBase):
     #### 0.12.0
 
     - `fmu.ert.simulation_mode` now supports `ensemble_information_filter`
+    - `data.uuid` added as required field
 
     #### 0.11.0
 

--- a/src/fmu/dataio/aggregation.py
+++ b/src/fmu/dataio/aggregation.py
@@ -283,6 +283,11 @@ class AggregatedData:
         if bbox := objdata.get_bbox():
             template["data"]["bbox"] = bbox
 
+        # object uuid should be a hash of case uuid + relative_path
+        template["data"]["uuid"] = _utils.uuid_from_string(
+            template["fmu"]["case"]["uuid"] + str(relpath)
+        )
+
         try:
             self._metadata = ObjectMetadataExport.model_validate(template)
         except ValidationError as err:

--- a/src/fmu/dataio/providers/objectdata/_base.py
+++ b/src/fmu/dataio/providers/objectdata/_base.py
@@ -16,7 +16,7 @@ from fmu.dataio._models.fmu_results.global_configuration import (
     GlobalConfiguration,
     StratigraphyElement,
 )
-from fmu.dataio._utils import generate_description, md5sum
+from fmu.dataio._utils import generate_description, md5sum, uuid_from_string
 from fmu.dataio.providers._base import Provider
 from fmu.dataio.providers._filedata import SharePathConstructor
 from fmu.dataio.providers.objectdata._export_models import (
@@ -27,6 +27,8 @@ from fmu.dataio.providers.objectdata._export_models import (
 )
 
 if TYPE_CHECKING:
+    from uuid import UUID
+
     from pydantic import BaseModel
 
     from fmu.dataio._models.fmu_results.data import (
@@ -41,6 +43,7 @@ if TYPE_CHECKING:
     )
     from fmu.dataio._models.fmu_results.specification import AnySpecification
     from fmu.dataio._models.fmu_results.standard_result import StandardResult
+    from fmu.dataio._runcontext import RunContext
     from fmu.dataio.dataio import ExportData
     from fmu.dataio.types import Inferrable
 
@@ -85,6 +88,7 @@ class ObjectDataProvider(Provider):
         self.name = strat_element.name
 
         metadata: dict[str, Any] = {}
+        metadata["uuid"] = self.uuid
         metadata["name"] = self.name
         metadata["stratigraphic"] = strat_element.stratigraphic
         metadata["offset"] = strat_element.offset
@@ -170,6 +174,14 @@ class ObjectDataProvider(Provider):
     @property
     def share_path(self) -> Path:
         return SharePathConstructor(self.dataio, self).get_share_path()
+
+    @property
+    def uuid(self) -> UUID:
+        """The UUID for the object."""
+        return self._get_object_uuid(
+            runcontext=self.dataio._runcontext,
+            share_path=self.share_path,
+        )
 
     def compute_md5(self) -> str:
         """Compute an MD5 sum"""
@@ -310,3 +322,20 @@ class ObjectDataProvider(Provider):
         self.time0, self.time1 = start.value, stop.value if stop else None
 
         return Time(t0=start, t1=stop)
+
+    @staticmethod
+    def _get_object_uuid(runcontext: RunContext, share_path: Path) -> UUID:
+        """Get a UUID for the object. The uuid is made as a hash of the
+        case uuid and the file.relative_path. If no casepath is detected (outside fmu)
+        the uuid is returned as an hash of the absolute path"""
+
+        absolute_path = runcontext.exportroot / share_path
+
+        casepath = runcontext.casepath
+        casemeta = runcontext.casemeta
+
+        if casemeta and casepath:
+            relative_path = absolute_path.relative_to(casepath)
+            return uuid_from_string(f"{casemeta.fmu.case.uuid}{relative_path}")
+
+        return uuid_from_string(f"{absolute_path}")


### PR DESCRIPTION
Towards #710 

PR to start adding `data.uuid` to outgoing metadata. 
This object `uuid` is made as a hash of the `case_uuid` and the `relative_path` which should be similar to how uuid's are given to the objects by sumo (**need to verify this still**).

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [ ] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [ ] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [ ] Checked the boxes in this checklist ✅
