### PR TITLE
MAINT: Drop redundant CaseMetadataExport

### DIFF
--- a/src/fmu/dataio/_metadata.py
+++ b/src/fmu/dataio/_metadata.py
@@ -10,15 +10,13 @@ dependencies on the internals.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Final, Literal
+from typing import TYPE_CHECKING, Final
 
 from pydantic import Field
 
 from ._logging import null_logger
 from ._models.fmu_results import data, fields
-from ._models.fmu_results.enums import FMUResultsMetadataClass
 from ._models.fmu_results.fmu_results import (
-    CaseMetadata,
     ObjectMetadata,
 )
 from ._models.fmu_results.global_configuration import GlobalConfiguration
@@ -46,15 +44,6 @@ class ObjectMetadataExport(ObjectMetadata, populate_by_name=True):
     # !! Keep UnsetData first in this union
     data: UnsetData | data.AnyData  # type: ignore
     preprocessed: bool | None = Field(alias="_preprocessed", default=None)
-
-
-class CaseMetadataExport(CaseMetadata, populate_by_name=True):
-    """Adds the optional description field for backward compatibility."""
-
-    class_: Literal[FMUResultsMetadataClass.case] = Field(
-        default=FMUResultsMetadataClass.case, alias="class", title="metadata_class"
-    )
-    description: list[str] | None = Field(default=None)
 
 
 def _get_meta_filedata(

--- a/src/fmu/dataio/_models/fmu_results/fmu_results.py
+++ b/src/fmu/dataio/_models/fmu_results/fmu_results.py
@@ -218,7 +218,7 @@ class MetadataBase(BaseModel):
     """The url of the schema that generated this data."""
 
 
-class CaseMetadata(MetadataBase):
+class CaseMetadata(MetadataBase, populate_by_name=True):
     """The FMU metadata model for an FMU case.
 
     A case represent a set of iterations that belong together, either by being part of

--- a/src/fmu/dataio/_runcontext.py
+++ b/src/fmu/dataio/_runcontext.py
@@ -11,8 +11,8 @@ from typing_extensions import override  # Remove when Python 3.11 dropped
 from fmu.config import utilities as ut
 from fmu.dataio._definitions import ERT_RELATIVE_CASE_METADATA_FILE, RMSExecutionMode
 from fmu.dataio._logging import null_logger
-from fmu.dataio._metadata import CaseMetadataExport
 from fmu.dataio._models.fmu_results.enums import FMUContext
+from fmu.dataio._models.fmu_results.fmu_results import CaseMetadata
 from fmu.dataio._utils import casepath_has_metadata
 
 logger: Final = null_logger(__name__)
@@ -38,7 +38,7 @@ class RunContext:
         self._fmu_context = fmu_context or self.fmu_context_from_env
         self._runpath = get_runpath_from_env()
         self._casepath = self._establish_casepath(casepath_proposed)
-        self._casemeta = self._load_case_meta() if self._casepath else None
+        self._case_metadata = self._load_case_meta() if self._casepath else None
         self._exportroot = self._establish_exportroot()
 
         logger.debug("Runpath is %s", self._runpath)
@@ -81,9 +81,9 @@ class RunContext:
         return self._casepath
 
     @property
-    def casemeta(self) -> CaseMetadataExport | None:
+    def case_metadata(self) -> CaseMetadata | None:
         """The case metadata."""
-        return self._casemeta
+        return self._case_metadata
 
     @property
     def runpath(self) -> Path | None:
@@ -159,12 +159,12 @@ class RunContext:
         )
         return None
 
-    def _load_case_meta(self) -> CaseMetadataExport:
+    def _load_case_meta(self) -> CaseMetadata:
         """Parse and validate the CASE metadata."""
         logger.debug("Loading case metadata file and return pydantic case model")
         assert self.casepath is not None
         case_metafile = self.casepath / ERT_RELATIVE_CASE_METADATA_FILE
-        return CaseMetadataExport.model_validate(
+        return CaseMetadata.model_validate(
             ut.yaml_load(case_metafile, loader="standard")
         )
 

--- a/src/fmu/dataio/providers/_fmu.py
+++ b/src/fmu/dataio/providers/_fmu.py
@@ -40,9 +40,9 @@ from fmu.config import utilities as ut
 from fmu.dataio import _utils
 from fmu.dataio._definitions import ERT_RELATIVE_CASE_METADATA_FILE
 from fmu.dataio._logging import null_logger
-from fmu.dataio._metadata import CaseMetadataExport
 from fmu.dataio._models.fmu_results import fields
 from fmu.dataio._models.fmu_results.enums import ErtSimulationMode, FMUContext
+from fmu.dataio._models.fmu_results.fmu_results import CaseMetadata
 from fmu.dataio._runcontext import FmuEnv
 from fmu.dataio.exceptions import InvalidMetadataError
 
@@ -84,7 +84,7 @@ class FmuProvider(Provider):
 
         self._runpath = runcontext.runpath
         self._casepath = runcontext.casepath
-        self._casemeta = runcontext.casemeta
+        self._casemeta = runcontext.case_metadata
         self._fmu_context = runcontext.fmu_context
         self._real_id = (
             int(real_num) if (real_num := FmuEnv.REALIZATION_NUMBER.value) else 0
@@ -190,7 +190,7 @@ class FmuProvider(Provider):
             return None
 
         try:
-            restart_metadata = CaseMetadataExport.model_validate(
+            restart_metadata = CaseMetadata.model_validate(
                 ut.yaml_load(restart_case_metafile)
             )
             return _utils.uuid_from_string(

--- a/tests/test_units/test_fmuprovider_class.py
+++ b/tests/test_units/test_fmuprovider_class.py
@@ -166,7 +166,6 @@ def test_fmuprovider_prehook_case(tmp_path, globalconfig2, fmurun_prehook):
         config=globalconfig2,
         rootfolder=caseroot,
         casename="MyCaseName",
-        description="Some description",
     )
     exp = icase.export()
 

--- a/tests/test_units/test_initialize_case.py
+++ b/tests/test_units/test_initialize_case.py
@@ -23,7 +23,6 @@ def test_crease_case_metadata_barebone(globalconfig2):
     assert icase.config == globalconfig2
     assert icase.rootfolder == ""
     assert icase.casename == ""
-    assert not icase.description
 
 
 def test_create_case_metadata_post_init(monkeypatch, fmurun, globalconfig2):
@@ -31,12 +30,13 @@ def test_create_case_metadata_post_init(monkeypatch, fmurun, globalconfig2):
     caseroot = fmurun.parent.parent
     logger.info("Active folder is %s", fmurun)
 
-    icase = CreateCaseMetadata(
-        config=globalconfig2,
-        rootfolder=caseroot,
-        casename="mycase",
-        description="Some description",
-    )
+    with pytest.warns(FutureWarning, match="description"):
+        icase = CreateCaseMetadata(
+            config=globalconfig2,
+            rootfolder=caseroot,
+            casename="mycase",
+            description="Some description",
+        )
     logger.info("Casepath is %s", icase._casepath)
 
     assert icase._casepath == caseroot
@@ -143,7 +143,6 @@ def test_create_case_metadata_with_export(monkeypatch, globalconfig2, fmurun):
         config=globalconfig2,
         rootfolder=caseroot,
         casename="MyCaseName",
-        description="Some description",
     )
     fmu_case_yml = Path(icase.export())
     assert fmu_case_yml.exists()
@@ -166,7 +165,6 @@ def test_create_case_metadata_export_with_norsk_alphabet(
         config=globalconfig2,
         rootfolder=caseroot,
         casename="MyCaseName_with_Æ",
-        description="Søme description",
     )
     globalconfig2["masterdata"]["smda"]["field"][0]["identifier"] = "æøå"
 

--- a/tests/test_units/test_run_context.py
+++ b/tests/test_units/test_run_context.py
@@ -50,7 +50,7 @@ def test_runcontext_rms_interactive(monkeypatch):
 
     assert runcontext.runpath is None
     assert runcontext.casepath is None
-    assert runcontext.casemeta is None
+    assert runcontext.case_metadata is None
 
     # exportroot should be up two folders from rms/model
     assert runcontext.exportroot == Path.cwd().parent.parent
@@ -68,7 +68,7 @@ def test_runcontext_rms_batch_inside_fmu(monkeypatch, fmurun_w_casemetadata):
 
     assert runcontext.runpath == fmurun_w_casemetadata
     assert runcontext.casepath == fmurun_w_casemetadata.parent.parent
-    assert runcontext.casemeta.fmu.case.name == "somecasename"
+    assert runcontext.case_metadata.fmu.case.name == "somecasename"
 
     # exportroot should be the runpath
     assert runcontext.exportroot == runcontext.runpath
@@ -86,7 +86,7 @@ def test_runcontext_outside_rms_inside_fmu(monkeypatch, fmurun_w_casemetadata):
 
     assert runcontext.runpath == fmurun_w_casemetadata
     assert runcontext.casepath == fmurun_w_casemetadata.parent.parent
-    assert runcontext.casemeta.fmu.case.name == "somecasename"
+    assert runcontext.case_metadata.fmu.case.name == "somecasename"
 
     # exportroot should be the runpath
     assert runcontext.exportroot == runcontext.runpath
@@ -106,7 +106,7 @@ def test_runcontext_inside_fmu_prehook(monkeypatch, fmurun_prehook):
 
     assert runcontext.runpath is None
     assert runcontext.casepath == fmurun_prehook
-    assert runcontext.casemeta.fmu.case.name == "somecasename"
+    assert runcontext.case_metadata.fmu.case.name == "somecasename"
 
     # exportroot should be the casepath
     assert runcontext.exportroot == runcontext.casepath
@@ -130,7 +130,7 @@ def test_runcontext_inside_fmu_prehook_no_casepath(monkeypatch, fmurun_prehook):
 
     assert runcontext.runpath is None
     assert runcontext.casepath is None
-    assert runcontext.casemeta is None
+    assert runcontext.case_metadata is None
 
     # exportroot should be the casepath
     assert runcontext.exportroot == Path.cwd()
@@ -154,7 +154,7 @@ def test_runcontext_inside_fmu_prehook_invalid_casepath(monkeypatch, fmurun_preh
 
     assert runcontext.runpath is None
     assert runcontext.casepath is None
-    assert runcontext.casemeta is None
+    assert runcontext.case_metadata is None
 
     # exportroot should be the casepath
     assert runcontext.exportroot == Path.cwd()
@@ -172,7 +172,7 @@ def test_runcontext_outside(monkeypatch):
 
     assert runcontext.runpath is None
     assert runcontext.casepath is None
-    assert runcontext.casemeta is None
+    assert runcontext.case_metadata is None
 
     # exportroot should be the current working directory
     assert runcontext.exportroot == Path.cwd()


### PR DESCRIPTION
Resolves #1278

🧹 Drop redundant `CaseMetadataExport` model and use the  `CaseMetadata` instead 

## Checklist

- [x] Tests added (if not, comment why): Existing tests sufficient
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
