### PR TITLE
CI: Drop custom pydantic handling

### DIFF
--- a/.github/workflows/ci-fmudataio.yml
+++ b/.github/workflows/ci-fmudataio.yml
@@ -42,9 +42,6 @@ jobs:
       - name: Full test
         run: |
 
-          # Reinstall pydantic to force latest version
-          pip install -U pydantic
-
           if [[ "${{ github.event.pull_request.base.ref }}" == "staging" ]]; then
             pytest -n auto -v --cov --cov-report term-missing --prod
           else

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -27,7 +27,4 @@ jobs:
       - name: Mypy
         run: |
 
-          # Reinstall pydantic to force latest version
-          pip install -U pydantic
-
           mypy .

--- a/ci/testrmsenv.sh
+++ b/ci/testrmsenv.sh
@@ -28,9 +28,6 @@ copy_test_files () {
 install_test_dependencies () {
     echo "Installing test dependencies..."
     pip install ".[dev]"
-    
-    # Reinstall pydantic and pytest to force latest version
-    pip install -U pydantic pytest
 
     echo "Dependencies installed successfully. Listing installed dependencies..."
     pip list

--- a/src/fmu/dataio/_models/fmu_results/global_configuration.py
+++ b/src/fmu/dataio/_models/fmu_results/global_configuration.py
@@ -85,11 +85,7 @@ class StratigraphyElement(BaseModel):
 
     name: str
     stratigraphic: bool = Field(default=False)
-
-    # TODO: Remove type ignore when Pydantic issue
-    #  https://github.com/pydantic/pydantic/issues/10950 has been solved
     alias: list[str] | None = Field(default_factory=list)
-
     stratigraphic_alias: list[str] | None = Field(default=None)
     offset: float = Field(default=0.0, allow_inf_nan=False)
     top: data.Layer | None = Field(default=None)


### PR DESCRIPTION
Resolves #990 

We no longer support `python` versions older than `3.11.` Hence this custom `pydantic` handling can be removed.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
