### PR TITLE
CI: Add AJV validation of examples

### DIFF
--- a/.github/workflows/schemas-up-to-date.yml
+++ b/.github/workflows/schemas-up-to-date.yml
@@ -34,3 +34,8 @@ jobs:
         run: |
           npm install ajv ajv-formats
           ./tools/schema-validate-ajv.mjs ./schemas/
+
+      - name: Ensure examples validates with AJV
+        run: |
+          npm install yaml
+          ./tools/examples-validate-ajv.mjs ./examples/example_metadata ./schemas/

--- a/tools/examples-validate-ajv.mjs
+++ b/tools/examples-validate-ajv.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+
+/**
+ * Script to validate the metadata files inside the examples directory 
+ * against local schemas using AJV. The schema version to use is picked up
+ * from the metadata field 'version'.
+ */
+
+import Ajv2020 from "ajv/dist/2020.js"
+import addFormats from "ajv-formats";
+import fs from "fs/promises";
+import path from "path";
+import yaml from "yaml";
+
+const ajv = new Ajv2020({ strict: false, discriminator: true });
+addFormats(ajv);
+
+const validatorCache = {}; 
+
+const GREEN = "\x1b[32m";
+const RED = "\x1b[31m";
+const YELLOW = "\x1b[93m";
+const NC = "\x1b[0m";
+const BOLD = "\x1b[1m";
+const SUCCESS = `[${BOLD}${GREEN}✔${NC}]`;
+const FAILURE = `[${BOLD}${RED}✖${NC}]`;
+const INFO = `[${BOLD}${YELLOW}+${NC}]`;
+
+
+async function loadSchema(version, schemasRoot) {
+  try {
+    const schemaPath = path.join(schemasRoot, version, "fmu_results.json");
+    const fileContent = await fs.readFile(schemaPath, "utf-8");
+    return JSON.parse(fileContent);
+  } catch (err) {
+    console.error(`${FAILURE} Error loading schema for version ${version}: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+async function loadYaml(filePath) {
+  try {
+    const fileContent = await fs.readFile(path.resolve(filePath), "utf-8");
+    return yaml.parse(fileContent);
+  } catch (err) {
+    console.error(`${FAILURE} Error reading YAML at ${filePath}: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+async function validateMetadataFile(yamlPath, schemasRoot) {
+  const data = await loadYaml(yamlPath);
+  const version = data.version;
+  if (!version) {
+    console.error(`${FAILURE} No 'version' field found in ${yamlPath}`);
+    process.exit(1);
+  }
+
+  // Check if validator for this version is already compiled
+  let validate = validatorCache[version];
+  if (!validate) {
+    const schema = await loadSchema(version, schemasRoot);
+    validate = ajv.compile(schema);
+    validatorCache[version] = validate;
+  }
+
+  const valid = validate(data);
+
+  if (valid) {
+    console.log(`${SUCCESS} Metadata is valid (schema ${version}): ${yamlPath}`);
+    return valid
+  } else {
+    console.error(`${FAILURE} Metadata is invalid (schema ${version}): ${yamlPath}`);
+    console.error(`    ${INFO} Reason:`, ajv.errorsText(validate.errors, {dataVar: ""}));
+    return false;
+  }
+}
+
+async function findYmlFiles(dir) {
+  let results = [];
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results = results.concat(await findYmlFiles(fullPath));
+    } else if (entry.isFile() && entry.name.endsWith(".yml")) {
+      results.push(fullPath);
+    }
+  }
+
+  return results;
+}
+
+async function validateMetadataExamplesInDirectory(dirPath, schemasRoot) {
+  const metadataFiles = await findYmlFiles(dirPath);
+
+  if (metadataFiles.length === 0) {
+    console.log(`${INFO} No JSON schema files found in directory: ${dirPath}`);
+    return;
+  }
+
+  let shouldFail = false;
+  console.log(`${INFO} Found ${metadataFiles.length} Yaml file(s) in directory: ${dirPath}`);
+  for (const metadataPath of metadataFiles) {
+    const isValid = await validateMetadataFile(metadataPath, schemasRoot);
+    if (!isValid) {
+        shouldFail = true;
+    }
+  }
+  if (shouldFail) {
+    process.exit(1);
+  }
+}
+
+const exampleDirectory = process.argv[2];
+const schemasRoot = process.argv[3];
+
+if (!exampleDirectory) {
+  console.error("Usage: examples-validate-ajv.mjs <exampleDirectory> <schemasRoot>");
+  process.exit(1);
+}
+
+validateMetadataExamplesInDirectory(exampleDirectory, schemasRoot).catch((err) => {
+  console.error(`${FAILURE} Unknown error: ${err.message}`);
+  process.exit(1);
+});

--- a/tools/schema-validate-ajv.mjs
+++ b/tools/schema-validate-ajv.mjs
@@ -85,7 +85,7 @@ async function validateSchemasInDirectory(dirPath) {
 const directory = process.argv[2];
 
 if (!directory) {
-  console.error("Usage: validate-schema-ajv.mjs <directory>");
+  console.error("Usage: schema-validate-ajv.mjs <directory>");
   process.exit(1);
 }
 


### PR DESCRIPTION
Resolves #1200 

PR to add a CI test with validation of the metadata examples with AJV. 
The test picks up the schema version from the metadata and validates against the corresponding schema in the `schemas` directory.

Tested locally to set the `iso-date-time` format back to `date-time` (ref #1184)  and the validation failed as experienced by sudo.   

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
