### PR TITLE
ENH: Add check of rms object type

### DIFF
--- a/src/fmu/dataio/export/rms/_utils.py
+++ b/src/fmu/dataio/export/rms/_utils.py
@@ -118,12 +118,17 @@ def get_horizons_in_folder(
 
     surfaces = []
     for horizon in project.horizons:
-        if not horizon[horizon_folder].is_empty():
+        rms_object = horizon[horizon_folder]
+        if isinstance(rms_object, rmsapi.Surface) and not rms_object.is_empty():
             surfaces.append(
                 xtgeo.surface_from_roxar(
                     project, horizon.name, horizon_folder, stype="horizons"
                 )
             )
+    if not surfaces:
+        raise RuntimeError(
+            f"No surfaces detected in the provided folder '{horizon_folder}'"
+        )
     return surfaces
 
 
@@ -135,10 +140,15 @@ def get_zones_in_folder(project: Any, zone_folder: str) -> list[xtgeo.RegularSur
 
     surfaces = []
     for zone in project.zones:
-        if not zone[zone_folder].is_empty():
+        rms_object = zone[zone_folder]
+        if isinstance(rms_object, rmsapi.Surface) and not rms_object.is_empty():
             surfaces.append(
                 xtgeo.surface_from_roxar(project, zone.name, zone_folder, stype="zones")
             )
+    if not surfaces:
+        raise RuntimeError(
+            f"No surfaces detected in the provided folder '{zone_folder}'"
+        )
     return surfaces
 
 
@@ -152,7 +162,8 @@ def get_polygons_in_folder(
 
     polygons = []
     for horizon in project.horizons:
-        if not horizon[horizon_folder].is_empty():
+        rms_object = horizon[horizon_folder]
+        if isinstance(rms_object, rmsapi.Polylines) and not rms_object.is_empty():
             polygons.append(
                 xtgeo.polygons_from_roxar(
                     project,
@@ -162,6 +173,10 @@ def get_polygons_in_folder(
                     stype="horizons",
                 )
             )
+    if not polygons:
+        raise RuntimeError(
+            f"No polygons detected in the provided folder '{horizon_folder}'"
+        )
     return polygons
 
 

--- a/tests/test_export_rms/test_utils.py
+++ b/tests/test_export_rms/test_utils.py
@@ -60,6 +60,27 @@ def test_get_horizons_in_folder_all_empty(mock_project_variable):
         get_horizons_in_folder(mock_project_variable, horizon_folder)
 
 
+def test_get_horizons_in_folder_wrong_type(mock_project_variable):
+    """Test that an error is raised if no surfaces are detected due to wrong type"""
+    from fmu.dataio.export.rms._utils import get_horizons_in_folder
+
+    horizon_folder = "DS_final"
+
+    class MockSurface(mock.MagicMock): ...
+
+    class MockPolygon(mock.MagicMock): ...
+
+    with mock.patch("fmu.dataio.export.rms._utils.rmsapi.Surface", MockSurface):
+        horizon1 = mock.MagicMock()
+        horizon1[horizon_folder] = MockPolygon  # Mock not being a Surface
+        horizon1[horizon_folder].is_empty.return_value = False
+
+        mock_project_variable.horizons.__iter__.return_value = [horizon1]
+
+        with pytest.raises(RuntimeError, match="No surfaces detected"):
+            get_horizons_in_folder(mock_project_variable, horizon_folder)
+
+
 def test_get_zones_in_folder(mock_project_variable):
     from fmu.dataio.export.rms._utils import get_zones_in_folder
 
@@ -112,6 +133,27 @@ def test_get_zones_in_folder_all_empty(mock_project_variable):
         get_zones_in_folder(mock_project_variable, zone_folder)
 
 
+def test_get_zones_in_folder_wrong_type(mock_project_variable):
+    """Test that an error is raised if no surfaces are detected due to wrong type"""
+    from fmu.dataio.export.rms._utils import get_zones_in_folder
+
+    zone_folder = "IS_final"
+
+    class MockSurface(mock.MagicMock): ...
+
+    class MockPolygon(mock.MagicMock): ...
+
+    with mock.patch("fmu.dataio.export.rms._utils.rmsapi.Surface", MockSurface):
+        zone1 = mock.MagicMock()
+        zone1[zone_folder] = MockPolygon  # Mock not being a Surface
+        zone1[zone_folder].is_empty.return_value = False
+
+        mock_project_variable.zones.__iter__.return_value = [zone1]
+
+        with pytest.raises(RuntimeError, match="No surfaces detected"):
+            get_zones_in_folder(mock_project_variable, zone_folder)
+
+
 def test_get_polygons_in_folder_folder_not_exist(mock_project_variable):
     from fmu.dataio.export.rms._utils import get_polygons_in_folder
 
@@ -133,6 +175,27 @@ def test_get_polygons_in_folder_all_empty(mock_project_variable):
 
     with pytest.raises(RuntimeError, match="only empty items"):
         get_polygons_in_folder(mock_project_variable, horizon_folder)
+
+
+def test_get_polygons_in_folder_wrong_type(mock_project_variable):
+    """Test that an error is raised if no polygons are detected due to wrong type"""
+    from fmu.dataio.export.rms._utils import get_polygons_in_folder
+
+    horizon_folder = "DS_final"
+
+    class MockSurface(mock.MagicMock): ...
+
+    class MockPolygon(mock.MagicMock): ...
+
+    with mock.patch("fmu.dataio.export.rms._utils.rmsapi.Polylines", MockPolygon):
+        horizon1 = mock.MagicMock()
+        horizon1[horizon_folder] = MockSurface  # Mock not being a Polygon
+        horizon1[horizon_folder].is_empty.return_value = False
+
+        mock_project_variable.horizons.__iter__.return_value = [horizon1]
+
+        with pytest.raises(RuntimeError, match="No polygons detected"):
+            get_polygons_in_folder(mock_project_variable, horizon_folder)
 
 
 def test_get_faultlines_in_folder(mock_project_variable, polygons):


### PR DESCRIPTION
Resolves #1202

PR to add a check of the RMS object type before initializing them with xtgeo. This prevents cryptic errors coming from the `rmsapi` from reaching the user. Ideally xtgeo should give a more user friendly error here. @jcrivenaes I'll make an issue 👍 .

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
