### PR TITLE
ENH: Set datetime in examples to unix epoch

### DIFF
--- a/examples/example_metadata/aggregated_surface_depth.yml
+++ b/examples/example_metadata/aggregated_surface_depth.yml
@@ -93,7 +93,7 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-03-11T14:05:02.738077Z'
+- datetime: '1970-01-01T00:00:00Z'
   event: created
   sysinfo:
     fmu-dataio:

--- a/examples/example_metadata/fmu_case.yml
+++ b/examples/example_metadata/fmu_case.yml
@@ -32,10 +32,12 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-06-17T09:31:03.551274Z'
+- datetime: '1970-01-01T00:00:00Z'
   event: created
   sysinfo:
     fmu-dataio:
+      version: dummy_version
+    komodo:
       version: dummy_version
     operating_system:
       hostname: dummy_hostname

--- a/examples/example_metadata/polygons_field_outline.yml
+++ b/examples/example_metadata/polygons_field_outline.yml
@@ -64,7 +64,7 @@ fmu:
     name: iter-0
     uuid: 00000000-0000-0000-0000-000000000000
   entity:
-    uuid: eb3578dd-abff-f535-1cba-132dc961820e
+    uuid: 00000000-0000-0000-0000-000000000000
   ert:
     experiment:
       id: 00000000-0000-0000-0000-000000000000
@@ -101,10 +101,12 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-06-17T09:31:05.868883Z'
+- datetime: '1970-01-01T00:00:00Z'
   event: created
   sysinfo:
     fmu-dataio:
+      version: dummy_version
+    komodo:
       version: dummy_version
     operating_system:
       hostname: dummy_hostname

--- a/examples/example_metadata/polygons_field_region.yml
+++ b/examples/example_metadata/polygons_field_region.yml
@@ -64,7 +64,7 @@ fmu:
     name: iter-0
     uuid: 00000000-0000-0000-0000-000000000000
   entity:
-    uuid: 5eef5241-e23c-e080-f5cc-5ee67696225f
+    uuid: 00000000-0000-0000-0000-000000000000
   ert:
     experiment:
       id: 00000000-0000-0000-0000-000000000000
@@ -101,10 +101,12 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-06-17T09:31:05.846826Z'
+- datetime: '1970-01-01T00:00:00Z'
   event: created
   sysinfo:
     fmu-dataio:
+      version: dummy_version
+    komodo:
       version: dummy_version
     operating_system:
       hostname: dummy_hostname

--- a/examples/example_metadata/preprocessed_surface_depth.yml
+++ b/examples/example_metadata/preprocessed_surface_depth.yml
@@ -81,10 +81,12 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-06-17T09:31:09.191895Z'
+- datetime: '1970-01-01T00:00:00Z'
   event: created
   sysinfo:
     fmu-dataio:
+      version: dummy_version
+    komodo:
       version: dummy_version
     operating_system:
       hostname: dummy_hostname

--- a/examples/example_metadata/surface_depth.yml
+++ b/examples/example_metadata/surface_depth.yml
@@ -61,7 +61,7 @@ fmu:
     name: iter-0
     uuid: 00000000-0000-0000-0000-000000000000
   entity:
-    uuid: 312141f7-29b2-ce44-441e-04e053956b4b
+    uuid: 00000000-0000-0000-0000-000000000000
   ert:
     experiment:
       id: 00000000-0000-0000-0000-000000000000
@@ -98,10 +98,12 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-06-17T09:31:10.322973Z'
+- datetime: '1970-01-01T00:00:00Z'
   event: created
   sysinfo:
     fmu-dataio:
+      version: dummy_version
+    komodo:
       version: dummy_version
     operating_system:
       hostname: dummy_hostname

--- a/examples/example_metadata/surface_fluid_contact.yml
+++ b/examples/example_metadata/surface_fluid_contact.yml
@@ -64,7 +64,7 @@ fmu:
     name: iter-0
     uuid: 00000000-0000-0000-0000-000000000000
   entity:
-    uuid: 0725ec3e-5abb-7190-7a02-b191bdf5b801
+    uuid: 00000000-0000-0000-0000-000000000000
   ert:
     experiment:
       id: 00000000-0000-0000-0000-000000000000
@@ -101,10 +101,12 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-06-17T09:31:10.350679Z'
+- datetime: '1970-01-01T00:00:00Z'
   event: created
   sysinfo:
     fmu-dataio:
+      version: dummy_version
+    komodo:
       version: dummy_version
     operating_system:
       hostname: dummy_hostname

--- a/examples/example_metadata/surface_seismic_amplitude.yml
+++ b/examples/example_metadata/surface_seismic_amplitude.yml
@@ -82,7 +82,7 @@ fmu:
     name: iter-0
     uuid: 00000000-0000-0000-0000-000000000000
   entity:
-    uuid: d32da6c6-731c-b929-0a8f-78cc097a47dd
+    uuid: 00000000-0000-0000-0000-000000000000
   ert:
     experiment:
       id: 00000000-0000-0000-0000-000000000000
@@ -119,10 +119,12 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-06-17T09:31:10.377257Z'
+- datetime: '1970-01-01T00:00:00Z'
   event: created
   sysinfo:
     fmu-dataio:
+      version: dummy_version
+    komodo:
       version: dummy_version
     operating_system:
       hostname: dummy_hostname

--- a/examples/example_metadata/table_inplace_volumes.yml
+++ b/examples/example_metadata/table_inplace_volumes.yml
@@ -52,10 +52,10 @@ display:
   name: geogrid
 file:
   absolute_path: /some/absolute/path/
-  checksum_md5: 173c646133f5a47c9bfbc4432a0a2812
+  checksum_md5: 0cb778f91e6074c471b4bbce1f919165
   relative_path: example_exports/share/results/tables/geogrid--volumes.csv
   runpath_relative_path: share/results/tables/geogrid--volumes.csv
-  size_bytes: 3921
+  size_bytes: 3911
 fmu:
   case:
     name: MyCase
@@ -69,7 +69,7 @@ fmu:
     name: iter-0
     uuid: 00000000-0000-0000-0000-000000000000
   entity:
-    uuid: 5868c973-6a25-73c1-a995-09e0f98cc85d
+    uuid: 00000000-0000-0000-0000-000000000000
   ert:
     experiment:
       id: 00000000-0000-0000-0000-000000000000
@@ -106,10 +106,12 @@ masterdata:
       uuid: ad214d85-8a1d-19da-e053-c918a4889310
 source: fmu
 tracklog:
-- datetime: '2025-06-17T09:31:12.777384Z'
+- datetime: '1970-01-01T00:00:00Z'
   event: created
   sysinfo:
     fmu-dataio:
+      version: dummy_version
+    komodo:
       version: dummy_version
     operating_system:
       hostname: dummy_hostname

--- a/examples/metadata_scripts/post_process_metadata.py
+++ b/examples/metadata_scripts/post_process_metadata.py
@@ -20,6 +20,8 @@ def remove_machine_data(metadata_yaml: dict) -> dict:
             metadata_yaml["fmu"]["iteration"]["uuid"] = DUMMY_UUID
         if "ensemble" in metadata_yaml["fmu"]:
             metadata_yaml["fmu"]["ensemble"]["uuid"] = DUMMY_UUID
+        if "entity" in metadata_yaml["fmu"]:
+            metadata_yaml["fmu"]["entity"]["uuid"] = DUMMY_UUID
 
     if "file" in metadata_yaml and "absolute_path" in metadata_yaml["file"]:
         metadata_yaml["file"]["absolute_path"] = "/some/absolute/path/"
@@ -27,6 +29,7 @@ def remove_machine_data(metadata_yaml: dict) -> dict:
     if "tracklog" in metadata_yaml:
         for tracklog_event in metadata_yaml["tracklog"]:
             tracklog_event["user"]["id"] = "user"
+            tracklog_event["datetime"] = "1970-01-01T00:00:00Z"  # Set to the Unix epoch
             if "sysinfo" in tracklog_event:
                 if "operating_system" in tracklog_event["sysinfo"]:
                     tracklog_event["sysinfo"]["operating_system"] = {


### PR DESCRIPTION
Resolves #1283 

PR to make future schema change PR's a bit less verbose and reduce merge conflicts, by setting the `datetime` in the tracklog to the` unix epoch`.
Also hardcoded the `fmu.entity.uuid` like the other uuid's

## Checklist

- [x] Tests added (if not, comment why): not needed for this change
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
