### PR TITLE
FIX, SCHEMA: rename content enum and update schema (#1293)

### DIFF
--- a/examples/example_metadata/fmu_case.yml
+++ b/examples/example_metadata/fmu_case.yml
@@ -37,8 +37,6 @@ tracklog:
   sysinfo:
     fmu-dataio:
       version: dummy_version
-    komodo:
-      version: dummy_version
     operating_system:
       hostname: dummy_hostname
       operating_system: dummy_os

--- a/examples/example_metadata/geogrid--facies.yml
+++ b/examples/example_metadata/geogrid--facies.yml
@@ -36,7 +36,7 @@ display:
   name: facies
 file:
   absolute_path: /some/absolute/path/
-  checksum_md5: d205770796667096bac52031c0c6c421
+  checksum_md5: dcb63dea7fee7baaae6e0c04d80317b1
   relative_path: example_exports/share/results/grids/geogrid--facies.roff
   runpath_relative_path: share/results/grids/geogrid--facies.roff
   size_bytes: 3492813
@@ -94,8 +94,6 @@ tracklog:
   event: created
   sysinfo:
     fmu-dataio:
-      version: dummy_version
-    komodo:
       version: dummy_version
     operating_system:
       hostname: dummy_hostname

--- a/examples/example_metadata/geogrid--phit.yml
+++ b/examples/example_metadata/geogrid--phit.yml
@@ -36,7 +36,7 @@ display:
   name: phit
 file:
   absolute_path: /some/absolute/path/
-  checksum_md5: f575f69c96d6f1b349a7a82a9f1c22a1
+  checksum_md5: 42f6de6d3e989d41e88369105d7d4ce0
   relative_path: example_exports/share/results/grids/geogrid--phit.roff
   runpath_relative_path: share/results/grids/geogrid--phit.roff
   size_bytes: 3492651
@@ -94,8 +94,6 @@ tracklog:
   event: created
   sysinfo:
     fmu-dataio:
-      version: dummy_version
-    komodo:
       version: dummy_version
     operating_system:
       hostname: dummy_hostname

--- a/examples/example_metadata/geogrid.yml
+++ b/examples/example_metadata/geogrid.yml
@@ -54,7 +54,7 @@ display:
   name: geogrid
 file:
   absolute_path: /some/absolute/path/
-  checksum_md5: bc9ff702f0ca2d389f2a3219ba85e3de
+  checksum_md5: e731649fd1b59c2998c7d0edce9a5b7f
   relative_path: example_exports/share/results/grids/geogrid.roff
   runpath_relative_path: share/results/grids/geogrid.roff
   size_bytes: 16540658
@@ -112,8 +112,6 @@ tracklog:
   event: created
   sysinfo:
     fmu-dataio:
-      version: dummy_version
-    komodo:
       version: dummy_version
     operating_system:
       hostname: dummy_hostname

--- a/examples/example_metadata/polygons_field_outline.yml
+++ b/examples/example_metadata/polygons_field_outline.yml
@@ -106,8 +106,6 @@ tracklog:
   sysinfo:
     fmu-dataio:
       version: dummy_version
-    komodo:
-      version: dummy_version
     operating_system:
       hostname: dummy_hostname
       operating_system: dummy_os

--- a/examples/example_metadata/polygons_field_region.yml
+++ b/examples/example_metadata/polygons_field_region.yml
@@ -106,8 +106,6 @@ tracklog:
   sysinfo:
     fmu-dataio:
       version: dummy_version
-    komodo:
-      version: dummy_version
     operating_system:
       hostname: dummy_hostname
       operating_system: dummy_os

--- a/examples/example_metadata/preprocessed_surface_depth.yml
+++ b/examples/example_metadata/preprocessed_surface_depth.yml
@@ -86,8 +86,6 @@ tracklog:
   sysinfo:
     fmu-dataio:
       version: dummy_version
-    komodo:
-      version: dummy_version
     operating_system:
       hostname: dummy_hostname
       operating_system: dummy_os

--- a/examples/example_metadata/surface_depth.yml
+++ b/examples/example_metadata/surface_depth.yml
@@ -103,8 +103,6 @@ tracklog:
   sysinfo:
     fmu-dataio:
       version: dummy_version
-    komodo:
-      version: dummy_version
     operating_system:
       hostname: dummy_hostname
       operating_system: dummy_os

--- a/examples/example_metadata/surface_fluid_contact.yml
+++ b/examples/example_metadata/surface_fluid_contact.yml
@@ -106,8 +106,6 @@ tracklog:
   sysinfo:
     fmu-dataio:
       version: dummy_version
-    komodo:
-      version: dummy_version
     operating_system:
       hostname: dummy_hostname
       operating_system: dummy_os

--- a/examples/example_metadata/surface_seismic_amplitude.yml
+++ b/examples/example_metadata/surface_seismic_amplitude.yml
@@ -124,8 +124,6 @@ tracklog:
   sysinfo:
     fmu-dataio:
       version: dummy_version
-    komodo:
-      version: dummy_version
     operating_system:
       hostname: dummy_hostname
       operating_system: dummy_os

--- a/examples/example_metadata/table_inplace_volumes.yml
+++ b/examples/example_metadata/table_inplace_volumes.yml
@@ -52,10 +52,10 @@ display:
   name: geogrid
 file:
   absolute_path: /some/absolute/path/
-  checksum_md5: 0cb778f91e6074c471b4bbce1f919165
+  checksum_md5: 173c646133f5a47c9bfbc4432a0a2812
   relative_path: example_exports/share/results/tables/geogrid--volumes.csv
   runpath_relative_path: share/results/tables/geogrid--volumes.csv
-  size_bytes: 3911
+  size_bytes: 3921
 fmu:
   case:
     name: MyCase
@@ -110,8 +110,6 @@ tracklog:
   event: created
   sysinfo:
     fmu-dataio:
-      version: dummy_version
-    komodo:
       version: dummy_version
     operating_system:
       hostname: dummy_hostname

--- a/schemas/0.13.0/fmu_results.json
+++ b/schemas/0.13.0/fmu_results.json
@@ -126,7 +126,7 @@
           "$ref": "#/$defs/FaciesThicknessData"
         },
         {
-          "$ref": "#/$defs/FaultTriangulatedSurfaceData"
+          "$ref": "#/$defs/FaultSurfaceData"
         },
         {
           "$ref": "#/$defs/FaultLinesData"
@@ -2383,7 +2383,7 @@
       "title": "FaultRoomSurfaceSpecification",
       "type": "object"
     },
-    "FaultTriangulatedSurfaceData": {
+    "FaultSurfaceData": {
       "description": "The ``data`` block contains information about the data contained in this object.\nThis class contains metadata for faults represented as triangulated surfaces.",
       "properties": {
         "alias": {
@@ -2428,7 +2428,7 @@
           "title": "Bbox"
         },
         "content": {
-          "const": "fault_triangulated_surface",
+          "const": "fault_surface",
           "title": "Content",
           "type": "string"
         },
@@ -2680,7 +2680,7 @@
         "is_observation",
         "is_prediction"
       ],
-      "title": "FaultTriangulatedSurfaceData",
+      "title": "FaultSurfaceData",
       "type": "object"
     },
     "FieldItem": {

--- a/src/fmu/dataio/_models/fmu_results/data.py
+++ b/src/fmu/dataio/_models/fmu_results/data.py
@@ -366,13 +366,13 @@ class FaciesThicknessData(Data):
     """The type of content these data represent."""
 
 
-class FaultTriangulatedSurfaceData(Data):
+class FaultSurfaceData(Data):
     """
     The ``data`` block contains information about the data contained in this object.
     This class contains metadata for faults represented as triangulated surfaces.
     """
 
-    content: Literal[enums.Content.fault_triangulated_surface]
+    content: Literal[enums.Content.fault_surface]
     """The type of content these data represent."""
 
 
@@ -670,7 +670,7 @@ class AnyData(RootModel):
     root: Annotated[
         DepthData
         | FaciesThicknessData
-        | FaultTriangulatedSurfaceData
+        | FaultSurfaceData
         | FaultLinesData
         | FieldOutlineData
         | FieldRegionData

--- a/src/fmu/dataio/_models/fmu_results/enums.py
+++ b/src/fmu/dataio/_models/fmu_results/enums.py
@@ -37,7 +37,7 @@ class Content(StrEnum):
 
     depth = "depth"
     facies_thickness = "facies_thickness"
-    fault_triangulated_surface = "fault_triangulated_surface"
+    fault_surface = "fault_surface"
     fault_lines = "fault_lines"
     fault_properties = "fault_properties"
     field_outline = "field_outline"

--- a/src/fmu/dataio/_models/fmu_results/fmu_results.py
+++ b/src/fmu/dataio/_models/fmu_results/fmu_results.py
@@ -50,6 +50,8 @@ class FmuResultsSchema(SchemaBase):
     VERSION_CHANGELOG: str = """
     #### 0.13.0
 
+    - Content 'fault_triangulated_surface' renamed to 'fault_surface'
+
     #### 0.12.0
 
     - `fmu.ert.simulation_mode` now supports `ensemble_information_filter`

--- a/tests/test_units/test_contents.py
+++ b/tests/test_units/test_contents.py
@@ -33,15 +33,15 @@ def test_content_fault_lines(polygons, globalconfig2):
     assert meta["data"]["content"] == "fault_lines"
 
 
-def test_content_fault_triangulated_surface(tsurf, globalconfig2):
-    """Test export of the fault_triangulated_surface content."""
+def test_content_fault_surface(tsurf, globalconfig2):
+    """Test export of the fault_surface content."""
     meta = ExportData(
         config=globalconfig2,
         name="MyName",
-        content="fault_triangulated_surface",
+        content="fault_surface",
     ).generate_metadata(tsurf)
 
-    assert meta["data"]["content"] == "fault_triangulated_surface"
+    assert meta["data"]["content"] == "fault_surface"
 
 
 def test_fault_properties():


### PR DESCRIPTION
Resolves #1293 

Renamed the item 'fault_triangulated_surface' in the Content enum to 'fault_surface' so that it aligns better with the general pattern in the other Contents

## Checklist

- [x] Tests updated
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
