### PR TITLE
REL: Point simple loaders to Sumo prod

### DIFF
--- a/src/fmu/dataio/external_interfaces/sumo_explorer_interface.py
+++ b/src/fmu/dataio/external_interfaces/sumo_explorer_interface.py
@@ -1,3 +1,4 @@
+import os
 from io import BytesIO
 from uuid import UUID
 
@@ -22,8 +23,13 @@ class SumoExplorerInterface:
         self._ensemble_name: str = ensemble_name
         self._fmu_class: ObjectMetadataClass = fmu_class
 
-        # TODO: Use sumo prod when ready
-        sumo = Explorer(env="dev")
+        env = "prod"
+        if "bleeding" in os.environ.get(
+            "KOMODO_RELEASE", os.environ.get("KOMODO_RELEASE_BACKUP", "")
+        ):
+            env = "dev"
+
+        sumo = Explorer(env=env)
         case = sumo.get_case_by_uuid(self._case_id)
         self._search_context: SearchContext = case.filter(
             iteration=self._ensemble_name, standard_result=standard_result_name


### PR DESCRIPTION
Resolves #1302

Point simple loaders to Sumo prod unless simple loader is run from a "Komodo bleeding" environment.

Now that the simple loaders have been released through Komodo, the integration towards Sumo should be updated to point to Sumo prod. This switch will be released in Komodo through the Komodo 2025.08 release. The simple loaders will keep pointing to dev from "bleeding" Komodo environments.

## Checklist

- [X] Tests added (if not, comment why)
- [X] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [X] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [X] Docstrings are correct and updated
- [X] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [X] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅
