### PR TITLE
ENH: Make simple loader input case_id a str

### DIFF
--- a/src/fmu/dataio/load/load_standard_results.py
+++ b/src/fmu/dataio/load/load_standard_results.py
@@ -300,7 +300,7 @@ class FluidContactSurfacesLoader(SurfacesStandardResultsLoader):
 
 
 @experimental
-def load_inplace_volumes(case_id: UUID, ensemble_name: str) -> InplaceVolumesLoader:
+def load_inplace_volumes(case_id: str, ensemble_name: str) -> InplaceVolumesLoader:
     """
     This function provides a simplified interface for loading inplace volumes
     standard results from Sumo. It returns an InplaceVolumesLoader object, which offers
@@ -328,11 +328,11 @@ def load_inplace_volumes(case_id: UUID, ensemble_name: str) -> InplaceVolumesLoa
 
     """  # noqa: E501 line too long
 
-    return InplaceVolumesLoader(case_id, ensemble_name)
+    return InplaceVolumesLoader(UUID(case_id), ensemble_name)
 
 
 @experimental
-def load_field_outlines(case_id: UUID, ensemble_name: str) -> FieldOutlinesLoader:
+def load_field_outlines(case_id: str, ensemble_name: str) -> FieldOutlinesLoader:
     """
     This function provides a simplified interface for loading field outlines
     standard results from Sumo. It returns a FieldOutlinesLoader object, which offers
@@ -360,12 +360,12 @@ def load_field_outlines(case_id: UUID, ensemble_name: str) -> FieldOutlinesLoade
 
     """  # noqa: E501 line too long
 
-    return FieldOutlinesLoader(case_id, ensemble_name)
+    return FieldOutlinesLoader(UUID(case_id), ensemble_name)
 
 
 @experimental
 def load_structure_depth_surfaces(
-    case_id: UUID, ensemble_name: str
+    case_id: str, ensemble_name: str
 ) -> StructureDepthSurfacesLoader:
     """
     This function provides a simplified interface for loading structure depth surfaces
@@ -395,12 +395,12 @@ def load_structure_depth_surfaces(
 
     """  # noqa: E501 line too long
 
-    return StructureDepthSurfacesLoader(case_id, ensemble_name)
+    return StructureDepthSurfacesLoader(UUID(case_id), ensemble_name)
 
 
 @experimental
 def load_fluid_contact_surfaces(
-    case_id: UUID, ensemble_name: str
+    case_id: str, ensemble_name: str
 ) -> FluidContactSurfacesLoader:
     """
     This function provides a simplified interface for loading fluid contact surfaces
@@ -430,4 +430,4 @@ def load_fluid_contact_surfaces(
 
     """  # noqa: E501 line too long
 
-    return FluidContactSurfacesLoader(case_id, ensemble_name)
+    return FluidContactSurfacesLoader(UUID(case_id), ensemble_name)

--- a/tests/test_loaders/test_standard_result_loaders.py
+++ b/tests/test_loaders/test_standard_result_loaders.py
@@ -9,6 +9,8 @@ from pandas import DataFrame
 
 import fmu.dataio.load.load_standard_results as load_standard_results
 
+TEST_UUID = "00000000-0000-0000-0000-000000000000"
+
 
 def _generate_metadata_mock(
     case_name: str = "mock_case",
@@ -57,7 +59,7 @@ def test_list_realizations():
         ) as get_realizations_mock,
     ):
         inplace_volumes = load_standard_results.load_inplace_volumes(
-            "test_id", "some_ensemble_name"
+            TEST_UUID, "some_ensemble_name"
         )
         assert class_init_mock.assert_called_once
 
@@ -92,7 +94,7 @@ def test_get_blobs(unregister_pandas_parquet):
         ) as get_blobs_mock,
     ):
         inplace_volumes_loader = load_standard_results.load_inplace_volumes(
-            "test_id", "some_ensemble_name"
+            TEST_UUID, "some_ensemble_name"
         )
         assert class_init_mock.assert_called_once
 
@@ -132,7 +134,7 @@ def test_get_realization():
         ) as get_realizations_mock,
     ):
         inplace_volumes_loader = load_standard_results.load_inplace_volumes(
-            "test_id", "some_ensemble_name"
+            TEST_UUID, "some_ensemble_name"
         )
         assert class_init_mock.assert_called_once
 
@@ -185,7 +187,7 @@ def test_save_realization_for_tabular(monkeypatch, tmp_path):
         ) as validate_object_mock,
     ):
         inplace_volumes_loader = load_standard_results.load_inplace_volumes(
-            "test_id", "some_ensemble_name"
+            TEST_UUID, "some_ensemble_name"
         )
         assert class_init_mock.assert_called_once
 
@@ -243,7 +245,7 @@ def test_save_realization_for_ploygons(monkeypatch, tmp_path):
         ) as validate_object_mock,
     ):
         field_outlines_loader = load_standard_results.load_field_outlines(
-            "test_id", "some_ensemble_name"
+            TEST_UUID, "some_ensemble_name"
         )
         assert class_init_mock.assert_called_once
 
@@ -308,7 +310,7 @@ def test_save_realization_for_surfaces(monkeypatch, tmp_path):
     ):
         structure_depth_surface_loader = (
             load_standard_results.load_structure_depth_surfaces(
-                "test_id", "some_ensemble_name"
+                TEST_UUID, "some_ensemble_name"
             )
         )
         assert class_init_mock.assert_called_once
@@ -353,7 +355,7 @@ def test_construct_object_key():
     ):
         fluid_contact_surfaces_loader = (
             load_standard_results.load_fluid_contact_surfaces(
-                "test_id", "some_ensemble_name"
+                TEST_UUID, "some_ensemble_name"
             )
         )
 


### PR DESCRIPTION
Resolves #1308 

The simple loader input parameter `case_id` is now a str. This change was made by request from FMU User @richypitman through #1308

## Checklist

- [X] Tests added (if not, comment why)
- [X] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [X] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [X] Docstrings are correct and updated
- [X] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [X] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅
