### PR TITLE
BLD: Loosen fmu-datamodels requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     "fmu-config>=1.1.0",
-    "fmu-datamodels==0.0.1",
+    "fmu-datamodels~=0.0.1",
     "numpy",
     "pandas",
     "pyarrow",


### PR DESCRIPTION
In Komodo bleeding we are getting

```sh
fmu-dataio 2.14.1.dev16+gbb136a6af has requirement fmu-datamodels==0.0.1, but you have fmu-datamodels 0.0.2.dev1+g6dcbff4.
```

It's not totally clear to me what the best way to pin fmu-datamodels to fmu-dataio such that it works in bleeding for now. But this should help.

`~= 0.0.1` basically means `>=0.0.1,<0.1.0` (so any patch version greater than the listed one). This should include development versions like those in komodo bleeding.

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [ ] Checked the boxes in this checklist ✅
