### PR TITLE
ENH: implement structure depth fault surface standard export (#1228)

### DIFF
--- a/src/fmu/dataio/export/rms/__init__.py
+++ b/src/fmu/dataio/export/rms/__init__.py
@@ -3,12 +3,14 @@ from .fluid_contact_outlines import export_fluid_contact_outlines
 from .fluid_contact_surfaces import export_fluid_contact_surfaces
 from .inplace_volumes import export_inplace_volumes, export_rms_volumetrics
 from .structure_depth_fault_lines import export_structure_depth_fault_lines
+from .structure_depth_fault_surfaces import export_structure_depth_fault_surfaces
 from .structure_depth_isochores import export_structure_depth_isochores
 from .structure_depth_surfaces import export_structure_depth_surfaces
 from .structure_time_surfaces import export_structure_time_surfaces
 
 __all__ = [
     "export_structure_depth_fault_lines",
+    "export_structure_depth_fault_surfaces",
     "export_structure_depth_surfaces",
     "export_structure_time_surfaces",
     "export_structure_depth_isochores",

--- a/src/fmu/dataio/export/rms/structure_depth_fault_surfaces.py
+++ b/src/fmu/dataio/export/rms/structure_depth_fault_surfaces.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Final, Self
+
+import numpy as np
+
+import fmu.dataio as dio
+from fmu.dataio._logging import null_logger
+from fmu.dataio._readers.tsurf import (
+    AllowedKeywordValues,
+    CoordinateSystem,
+    Header,
+    TSurfData,
+)
+from fmu.dataio.export._decorators import experimental
+from fmu.dataio.export._export_result import ExportResult, ExportResultItem
+from fmu.dataio.export.rms._base import SimpleExportRMSBase
+from fmu.dataio.export.rms._utils import (
+    get_rms_project_units,
+)
+from fmu.datamodels.fmu_results.enums import (
+    Classification,
+    Content,
+    DomainReference,
+    VerticalDomain,
+)
+from fmu.datamodels.fmu_results.standard_result import (
+    StructureDepthFaultSurfaceStandardResult,
+)
+from fmu.datamodels.standard_results.enums import StandardResultName
+
+_logger: Final = null_logger(__name__)
+
+
+class _ExportStructureDepthFaultSurfaces(SimpleExportRMSBase):
+    def __init__(
+        self: Self,
+        project: Any,
+        structural_model_name: str,
+    ) -> None:
+        super().__init__()
+
+        _logger.debug("Process data, establish state prior to export.")
+
+        self._unit = "m" if get_rms_project_units(project) == "metric" else "ft"
+
+        self._surfaces = _get_fault_surfaces_from_rms(project, structural_model_name)
+
+        _logger.debug("Process data... DONE")
+
+    @property
+    def _standard_result(self) -> StructureDepthFaultSurfaceStandardResult:
+        """Standard result type for the exported data."""
+        return StructureDepthFaultSurfaceStandardResult(
+            name=StandardResultName.structure_depth_fault_surface
+        )
+
+    @property
+    def _content(self) -> Content:
+        """Get content for the exported data."""
+        return Content.fault_surface
+
+    @property
+    def _classification(self) -> Classification:
+        """Get default classification."""
+        return Classification.internal
+
+    @property
+    def _rep_include(self) -> bool:
+        """rep_include status"""
+        return True
+
+    def _export_surface(self: Self, surf: TSurfData) -> ExportResultItem:
+        edata = dio.ExportData(
+            config=self._config,
+            content=self._content,
+            unit=self._unit,
+            vertical_domain=VerticalDomain.depth.value,
+            domain_reference=DomainReference.msl.value,
+            subfolder=self._subfolder,
+            is_prediction=True,
+            name=surf.header.name,
+            classification=self._classification,
+            rep_include=self._rep_include,
+        )
+
+        absolute_export_path = edata._export_with_standard_result(
+            surf, standard_result=self._standard_result
+        )
+        _logger.debug("Surface exported to: %s", absolute_export_path)
+
+        return ExportResultItem(
+            absolute_path=Path(absolute_export_path),
+        )
+
+    def _export_data_as_standard_result(self) -> ExportResult:
+        """Export the fault surfaces as a standard result."""
+        return ExportResult(
+            items=[self._export_surface(surf) for surf in self._surfaces]
+        )
+
+    def _validate_data_pre_export(self) -> None:
+        """Surface validations before export."""
+        # The surfaces are Pydantic models and are automatically validated
+
+
+def _get_fault_surfaces_from_rms(
+    project: Any,
+    structural_model_name: str,
+) -> list[TSurfData]:
+    """
+    Fetch triangulated fault surfaces in TSurf format from RMS.
+
+    Args:
+        project: the 'magic' project variable in RMS
+        structural_model_name: name of the structural model
+
+    Returns:
+        List of TSurfData objects (GoCAD TSurf) representing
+        all fault surfaces in the structural model as triangulations.
+    """
+
+    if structural_model_name not in project.structural_models:
+        raise ValueError(
+            f"Project does not contain a structural model named: "
+            f"'{structural_model_name}'."
+        )
+
+    fault_model = project.structural_models[structural_model_name].fault_model
+
+    realization = 0
+    tsurf_coord_sys = CoordinateSystem(
+        name="Default",
+        axis_name=AllowedKeywordValues.axis_names["xyz"],
+        axis_unit=(
+            AllowedKeywordValues.axis_units["mmm"]
+            if get_rms_project_units(project) == "metric"
+            else AllowedKeywordValues.axis_units["ft"]
+        ),
+        z_positive=AllowedKeywordValues.z_positives["depth"],
+    )
+
+    fault_surfaces = []
+    for fault_name in fault_model.fault_names:
+        fault_surface = fault_model.get_fault_triangle_surface(
+            name=fault_name,
+            realisation=realization,
+        )
+
+        tsurf_header = Header(name=fault_name)
+
+        vertices = fault_surface.get_vertices()
+        # GoCAD TSurf uses 1-based indexing for triangles while RMS uses 0-based
+        triangles = fault_surface.get_triangles().astype(np.int64) + 1
+
+        tsurf = TSurfData(
+            header=tsurf_header,
+            coordinate_system=tsurf_coord_sys,
+            vertices=vertices,
+            triangles=triangles,
+        )
+
+        fault_surfaces.append(tsurf)
+
+    return fault_surfaces
+
+
+@experimental
+def export_structure_depth_fault_surfaces(
+    project: Any, structural_model_name: str
+) -> ExportResult:
+    """
+    Simplified interface when exporting triangulated fault surfaces from RMS.
+
+    Args:
+        project: the 'magic' project variable in RMS
+        structural_model_name: name of the structural model
+    Note:
+        This function is experimental and may change in future versions.
+
+    Examples:
+        Example usage in an RMS script::
+
+            from fmu.dataio.export.rms import export_structure_depth_fault_surfaces
+
+            export_results = export_structure_depth_fault_surfaces(
+                project,
+                "structural_model_name"
+            )
+
+            for result in export_results.items:
+                print(f"Output surfaces to {result.absolute_path}")
+
+    """
+
+    return _ExportStructureDepthFaultSurfaces(project, structural_model_name).export()

--- a/tests/test_export_rms/conftest.py
+++ b/tests/test_export_rms/conftest.py
@@ -1,4 +1,7 @@
-"""The conftest.py, providing magical fixtures to tests."""
+"""
+The conftest.py, providing magical fixtures to tests.
+All fixtures represent datasets from Drogon.
+"""
 
 import sys
 from unittest.mock import MagicMock, patch
@@ -244,13 +247,46 @@ def mock_general2d_data():
 
 
 @pytest.fixture
-def mock_project_variable(mock_general2d_data):
-    # A mock_project variable for the RMS 'project' (potentially extend for later use)
+def mock_project_variable(mock_general2d_data, mock_structural_model):
+    # A mock_project variable for the RMS 'project'
     mock_project = MagicMock()
     mock_project.horizons.representations = ["DS_final"]
     mock_project.zones.representations = ["IS_final"]
+    mock_project.structural_models = mock_structural_model
     mock_project.general2d_data = mock_general2d_data
+    # Units in the RMS project
+    mock_project.project_units = "metric"
+
     yield mock_project
+
+
+@pytest.fixture
+def mock_fault_model():
+    """A mock fault model."""
+    return MagicMock(fault_names=["F1", "F2", "F3", "F4", "F5", "F6"])
+
+
+@pytest.fixture
+def mock_structural_model(mock_fault_model):
+    """A mock structural model with faults and potentially stratigraphic zones."""
+    structural_model_mock = MagicMock()
+
+    structural_model_mock.fault_model = mock_fault_model
+    # Could add a stratigrapic model
+    return {"GF_depth_hum": structural_model_mock}
+
+
+@pytest.fixture
+def fault_surfaces_triangulated(tsurf, mock_fault_model):
+    """Mock for triangulated fault surfaces on TSurf format."""
+
+    surfaces = []
+    for fault_name in mock_fault_model.fault_names:
+        fault = tsurf.model_copy(deep=True)
+        fault.header.name = fault_name
+        surfaces.append(fault)
+
+    yield surfaces
 
 
 @pytest.fixture

--- a/tests/test_export_rms/test_export_structure_depth_fault_surfaces.py
+++ b/tests/test_export_rms/test_export_structure_depth_fault_surfaces.py
@@ -1,0 +1,152 @@
+"""
+Test the dataio running RMS specific utility function for structure depth fault surfaces
+"""
+
+from unittest import mock
+
+import pytest
+from fmu.datamodels.standard_results.enums import StandardResultName
+
+from fmu import dataio
+from fmu.dataio._logging import null_logger
+
+logger = null_logger(__name__)
+
+
+@pytest.fixture
+def mock_export_class(
+    mock_project_variable,
+    monkeypatch,
+    rmssetup_with_fmuconfig,
+    fault_surfaces_triangulated,
+):
+    monkeypatch.chdir(rmssetup_with_fmuconfig)
+
+    from fmu.dataio.export.rms.structure_depth_fault_surfaces import (
+        _ExportStructureDepthFaultSurfaces,
+    )
+
+    with mock.patch(
+        "fmu.dataio.export.rms.structure_depth_fault_surfaces._get_fault_surfaces_from_rms",
+        return_value=fault_surfaces_triangulated,
+    ):
+        yield _ExportStructureDepthFaultSurfaces(mock_project_variable, "GF_depth_hum")
+
+
+@pytest.mark.usefixtures("inside_rms_interactive")
+def test_files_exported_with_metadata(mock_export_class, rmssetup_with_fmuconfig):
+    """Test that the standard_result is set correctly in the metadata"""
+
+    mock_export_class.export()
+
+    export_folder = (
+        rmssetup_with_fmuconfig
+        / "../../share/results/maps/structure_depth_fault_surface"
+    )
+
+    assert export_folder.exists()
+
+    filename_f3 = "F3.ts".lower()
+    filename_f3_yaml = "." + filename_f3 + ".yml"
+    assert (export_folder / filename_f3).exists()
+    assert (export_folder / filename_f3_yaml).exists()
+
+
+@pytest.mark.usefixtures("inside_rms_interactive")
+def test_standard_result_in_metadata(mock_export_class):
+    """Test that the standard_result is set correctly in the metadata"""
+
+    out = mock_export_class.export()
+    metadata = dataio.read_metadata(out.items[0].absolute_path)
+
+    assert "standard_result" in metadata["data"]
+    assert (
+        metadata["data"]["standard_result"]["name"]
+        == StandardResultName.structure_depth_fault_surface
+    )
+
+
+@pytest.mark.usefixtures("inside_rms_interactive")
+def test_public_export_function(
+    mock_project_variable,
+    mock_structural_model,
+    mock_export_class,  # 'mock_export_class' must be present
+):
+    """Test that the export function works"""
+
+    from fmu.dataio.export.rms import export_structure_depth_fault_surfaces
+
+    struct_mod_name = next(iter(mock_structural_model))
+
+    with pytest.warns(UserWarning, match="is experimental and may change in future"):
+        out = export_structure_depth_fault_surfaces(
+            mock_project_variable, struct_mod_name
+        )
+
+    # Check that all fault surfaces are exported
+    assert len(out.items) == 6
+
+    metadata = dataio.read_metadata(out.items[0].absolute_path)
+
+    assert metadata["access"]["classification"] == "internal"
+    assert metadata["data"]["content"] == "fault_surface"
+    assert metadata["data"]["is_prediction"]
+    assert (
+        metadata["data"]["standard_result"]["name"]
+        == StandardResultName.structure_depth_fault_surface
+    )
+
+    assert metadata["data"]["format"] == "tsurf"
+    assert metadata["data"]["layout"] == "triangulated"
+    assert metadata["class"] == "surface"
+
+    assert metadata["data"]["spec"]["num_triangles"] == 2
+    assert metadata["data"]["spec"]["num_vertices"] == 4
+
+
+@pytest.mark.usefixtures("inside_rms_interactive")
+def test_config_missing(
+    mock_project_variable,
+    mock_structural_model,
+):
+    """Test that an exception is raised if the config is missing."""
+
+    from fmu.dataio.export.rms import export_structure_depth_fault_surfaces
+
+    struct_mod_name = next(iter(mock_structural_model))
+    with (
+        pytest.raises(FileNotFoundError, match="Could not detect"),
+        pytest.warns(UserWarning, match="is experimental and may change in future"),
+    ):
+        export_structure_depth_fault_surfaces(
+            mock_project_variable,
+            struct_mod_name,
+        )
+
+
+@pytest.mark.usefixtures("inside_rms_interactive")
+def test_unknown_structural_model_name_raises(
+    mock_project_variable,
+    monkeypatch,
+    rmssetup_with_fmuconfig,
+    mock_structural_model,
+):
+    """
+    Test that an exception is raised if the structural model is not found
+    among the structural models in RMS.
+    """
+
+    from fmu.dataio.export.rms import export_structure_depth_fault_surfaces
+
+    monkeypatch.chdir(rmssetup_with_fmuconfig)
+
+    with (
+        pytest.raises(
+            ValueError, match="Project does not contain a structural model named"
+        ),
+        pytest.warns(UserWarning, match="is experimental and may change in future"),
+    ):
+        export_structure_depth_fault_surfaces(
+            mock_project_variable,
+            "Non-existing structural model name",
+        )


### PR DESCRIPTION
Resolves #1228 

Implements standard export for structure depth fault surfaces

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is handled separately
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
