### PR TITLE
BUG: Make 'ert_username' actually optional

### DIFF
--- a/src/fmu/dataio/scripts/create_case_metadata.py
+++ b/src/fmu/dataio/scripts/create_case_metadata.py
@@ -145,6 +145,8 @@ def get_parser() -> argparse.ArgumentParser:
         "ert_username",
         type=str,
         help="Deprecated and can safely be removed",
+        nargs="?",  # Makes it optional
+        default=None,
     )
     parser.add_argument(
         "--sumo",

--- a/tests/test_ert_integration/conftest.py
+++ b/tests/test_ert_integration/conftest.py
@@ -54,8 +54,7 @@ def fmu_snakeoil_project(
         "WF_CREATE_CASE_METADATA "
         "<SCRATCH>/<USER>/<CASE_DIR> "  # ert case root
         "<CONFIG_PATH> "  # ert config path
-        "<CASE_DIR> "  # ert case dir
-        "<USER>",  # ert username
+        "<CASE_DIR>",  # ert case dir
         encoding="utf-8",
     )
     pathlib.Path(

--- a/tests/test_ert_integration/test_simple_export_run.py
+++ b/tests/test_ert_integration/test_simple_export_run.py
@@ -60,3 +60,41 @@ def test_simple_export_ert_environment_variables(snakeoil_export_surface: Path) 
     avg_poro = FmuResults.model_validate(avg_poro_metadata)  # asserts valid
     assert avg_poro.root.fmu.ert.simulation_mode == ErtSimulationMode.test_run
     assert avg_poro.root.fmu.ert.experiment.id is not None
+
+
+def test_snakeoil_wf_case_metadata_includes_user(
+    fmu_snakeoil_project: Path, monkeypatch: Any, mocker: Any
+) -> None:
+    """Test that if 'ert_username' argument is specified in WF_CREATE_CASE_METADATA
+    a deprecation warning is emitted and the input is ignored.
+    """
+    monkeypatch.chdir(fmu_snakeoil_project / "ert/model")
+
+    Path(
+        fmu_snakeoil_project / "ert/bin/workflows/xhook_create_case_metadata"
+    ).write_text(
+        "WF_CREATE_CASE_METADATA <SCRATCH>/<USER>/<CASE_DIR> <CONFIG_PATH> <CASE_DIR> "
+        "<USER>",  # ert user (now deprecated)
+        encoding="utf-8",
+    )
+
+    add_create_case_workflow("snakeoil.ert")
+
+    mocker.patch(
+        "sys.argv",
+        ["ert", "ensemble_experiment", "snakeoil.ert", "--disable-monitoring"],
+    )
+    with pytest.warns(FutureWarning, match="'ert_username' is deprecated"):
+        ert.__main__.main()
+
+    fmu_case_yml = (
+        fmu_snakeoil_project / "scratch/user/snakeoil/share/metadata/fmu_case.yml"
+    )
+    assert fmu_case_yml.exists()
+
+    with open(fmu_case_yml, encoding="utf-8") as f:
+        fmu_case = yaml.safe_load(f)
+
+    # check that user input is ignored
+    assert fmu_case["fmu"]["case"]["user"]["id"] != "user"
+    assert fmu_case["fmu"]["case"]["user"]["id"] == getpass.getuser()


### PR DESCRIPTION
Resolves #1329 

PR that fixes a bug where the user is told to remove the `ert_username` argument from the `WF_CREATE_CASE_METADATA`, but doing so triggers a failure since the argument is still required.

## Checklist

- [x] Tests modified
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
