### PR TITLE
FIX: update enums for triangulated surfaces (#1336)

### DIFF
--- a/src/fmu/dataio/providers/objectdata/_triangulated_surface.py
+++ b/src/fmu/dataio/providers/objectdata/_triangulated_surface.py
@@ -33,7 +33,7 @@ class TriangulatedSurfaceProvider(ObjectDataProvider):
 
     @property
     def classname(self) -> ObjectMetadataClass:
-        return ObjectMetadataClass.triangulated_surface
+        return ObjectMetadataClass.surface
 
     @property
     def efolder(self) -> str:
@@ -49,7 +49,7 @@ class TriangulatedSurfaceProvider(ObjectDataProvider):
 
     @property
     def layout(self) -> Layout:
-        return Layout.triangulated_surface
+        return Layout.triangulated
 
     @property
     def table_index(self) -> None:

--- a/tests/test_units/test_objectdataprovider_class.py
+++ b/tests/test_units/test_objectdataprovider_class.py
@@ -97,11 +97,11 @@ def test_objectdata_triangulated_surface_validate_spec(tsurf, edataobj2):
     objdata = objectdata_provider_factory(tsurf, edataobj2)
     assert isinstance(objdata, TriangulatedSurfaceProvider)
 
-    assert objdata.classname.value == "triangulated_surface"
+    assert objdata.classname.value == "surface"
     assert objdata.efolder == "maps"
     assert objdata.extension == ".ts"
     assert objdata.fmt == "tsurf"
-    assert objdata.layout == "triangulated_surface"
+    assert objdata.layout == "triangulated"
 
     bbox = objdata.get_bbox()
     assert bbox.xmin == 0.1


### PR DESCRIPTION
Resolves #1336 

In `fmu-datamodels` two enums regarding triangulated surfaces are given a work-over in issue https://github.com/equinor/fmu-datamodels/issues/36 and PR https://github.com/equinor/fmu-datamodels/pull/38.

Now these changes are captured in `fmu-dataio`.


## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
