### PR TITLE
BLD: install 'fmu-datamodels' from main branch in CI (#1332)

### DIFF
--- a/.github/workflows/ci-fmudataio.yml
+++ b/.github/workflows/ci-fmudataio.yml
@@ -32,13 +32,23 @@ jobs:
           pip install pip -U
           pip install -e .[dev]
 
+
+      # Install repos from their Github main branches instead of Pypi.
+      # This removes the need to manually pin these version of the repos
+      # during the development phase.
+
+      - name: Install fmu-datamodels
+        run: |
+          pip install \
+            "fmu-datamodels @ git+https://github.com/equinor/fmu-datamodels.git"
+
        # fmu-sumo-uploader blocked by OpenVDS on Python 3.12
       - name: Install fmu-sumo-uploader for Python 3.11
         if: matrix.python-version == '3.11'
         run:
           pip install \
             "fmu-sumo-uploader @ git+https://github.com/equinor/fmu-sumo-uploader.git"
-
+      
       - name: Full test
         run: |
 

--- a/.github/workflows/fmudataio-documention.yml
+++ b/.github/workflows/fmudataio-documention.yml
@@ -26,6 +26,16 @@ jobs:
         run: |
           pip install -U pip
           pip install .[docs]
+      
+      # Install repos from their Github main branches instead of Pypi.
+      # This removes the need to manually pin these version of the repos
+      # during the development phase.
+
+      - name: Install fmu-datamodels
+        run: |
+          pip install \
+            "fmu-datamodels @ git+https://github.com/equinor/fmu-datamodels.git"
+
 
       - name: Generate updated examples
         run: sh examples/update_examples.sh

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -23,6 +23,15 @@ jobs:
           pip install -U pip
           pip install ".[dev]"
 
+      # Install repos from their Github main branches instead of Pypi.
+      # This removes the need to manually pin these version of the repos
+      # during the development phase.
+
+      - name: Install fmu-datamodels
+        run: |
+          pip install \
+            "fmu-datamodels @ git+https://github.com/equinor/fmu-datamodels.git"
+
       - name: Ruff check
         if: ${{ always() }}
         run: ruff check .

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -28,6 +28,15 @@ jobs:
           pip install -U pip
           pip install ".[dev]"
 
+      # Install repos from their Github main branches instead of Pypi.
+      # This removes the need to manually pin these version of the repos
+      # during the development phase.
+
+      - name: Install fmu-datamodels
+        run: |
+          pip install \
+            "fmu-datamodels @ git+https://github.com/equinor/fmu-datamodels.git"
+
       - name: Mypy
         run: |
           mypy .


### PR DESCRIPTION
Resolves #1332 

For `fmu-datamodels`:
Install repos from their Github main branches instead of Pypi.
This removes the need to manually pin these version of the repos
during the development phase (prior to release of the repos).


## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
