### PR TITLE
DEP: Add ExportData.aggregation to migration guide

### DIFF
--- a/docs/src/dataio_3_migration.rst
+++ b/docs/src/dataio_3_migration.rst
@@ -69,6 +69,7 @@ They can safely be removed.
    the ``geometry`` argument instead.
  - ``realization`` is deprecated, realization number is automatically picked up from environment variables.
  - ``verbosity`` is deprecated, logging level should be set from client script in a standard manner instead.
+ - ``aggregation`` is deprecated and was never used.
 
 
 The following arguments will be required if specific data types are exported.

--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -322,7 +322,7 @@ class ExportData:
 
     # input keys (alphabetic)
     access_ssdl: dict = field(default_factory=dict)
-    aggregation: bool = False
+    aggregation: bool = False  # deprecated
     casepath: str | Path | None = None
     classification: str | None = None
     config: dict | GlobalConfiguration = field(default_factory=dict)
@@ -593,6 +593,12 @@ class ExportData:
         if self.realization:
             warn(
                 "The 'realization' key is deprecated and has no effect. "
+                "Please remove it from the argument list.",
+                UserWarning,
+            )
+        if self.aggregation:
+            warn(
+                "The 'aggregation' key is deprecated and has no effect. "
                 "Please remove it from the argument list.",
                 UserWarning,
             )


### PR DESCRIPTION
PR to deprecate the `aggregation` argument in `ExportData.` 
It was not documented and is not used anywhere in the code.

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
