### PR TITLE
ENH, DEP: Read sumo environment from env variable

### DIFF
--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -282,12 +282,11 @@ WF_CREATE_CASE_METADATA  <SCRATCH>/<USER>/<CASE_DIR>  <CONFIG_PATH>     <CASE_DI
 
 -- Optional arguments:
 --  --sumo: If passed, case will be registered on Sumo. Use this is intention to upload data.
---  --sumo_env (str): Specify Sumo environment. Default: prod
 --  --global_variables_path (str): Path to global variables relative to CONFIG path
 --
 -- NOTE! If using optional arguments, note that the "--" annotation will be interpreted
 --       as comments by ERT if not wrapped in quotes. This is the syntax to use:
---       (existing arguments) "--sumo" "--sumo_env" dev
+--       (existing arguments) "--sumo"
 ```
 
 ```{note}

--- a/tests/test_ert_integration/conftest.py
+++ b/tests/test_ert_integration/conftest.py
@@ -1,4 +1,3 @@
-import contextlib
 import os
 import pathlib
 import shutil
@@ -16,7 +15,6 @@ def base_ert_config() -> str:
         DEFINE <SCRATCH>    $DATAIO_TMP_PATH/scratch
         DEFINE <CASE_DIR>   snakeoil
 
-        DEFINE <SUMO_ENV>       dev
         DEFINE <SUMO_CASEPATH>  <SCRATCH>/<USER>/<CASE_DIR>
 
         NUM_REALIZATIONS 3
@@ -103,12 +101,12 @@ def mock_sumo_uploader():
             f.write("1")
         return 1
 
-    with contextlib.ExitStack() as stack:
-        stack.enter_context(patch("fmu.sumo.uploader.SumoConnection", spec=True))
-        stack.enter_context(
-            patch(
-                "fmu.sumo.uploader.CaseOnDisk.register",
-                side_effect=register_side_effect,
-            )
-        )
-        yield
+    with (
+        patch("fmu.sumo.uploader.SumoConnection", spec=True) as mock_sumo_connection,
+        patch(
+            "fmu.sumo.uploader.CaseOnDisk.register", side_effect=register_side_effect
+        ),
+    ):
+        yield {
+            "SumoConnection": mock_sumo_connection,
+        }

--- a/tests/test_ert_integration/test_wf_create_case_metadata.py
+++ b/tests/test_ert_integration/test_wf_create_case_metadata.py
@@ -82,7 +82,40 @@ def test_create_case_metadata_enable_mocked_sumo(
         "a",
         encoding="utf-8",
     ) as f:
-        f.write(' "--sumo" "--sumo_env" <SUMO_ENV>')
+        f.write(' "--sumo" "--sumo_env" prod')
+
+    monkeypatch.chdir(fmu_snakeoil_project / "ert/model")
+    add_create_case_workflow("snakeoil.ert")
+
+    mocker.patch(
+        "sys.argv", ["ert", "test_run", "snakeoil.ert", "--disable-monitoring"]
+    )
+    with pytest.warns(FutureWarning, match="'sumo_env' is ignored"):
+        ert.__main__.main()
+
+    # Verifies case.register() was run
+    with open("sumo_case_id", encoding="utf-8") as f:
+        assert f.read() == "1"
+
+
+@pytest.mark.skipif(
+    sys.version_info[:2] == (3, 12),
+    reason="fmu-sumo-uploader not compatible with Python 3.12",
+)
+@pytest.mark.skipif(
+    not importlib.util.find_spec("fmu.sumo.uploader"),
+    reason="fmu-sumo-uploader is not installed",
+)
+def test_create_case_metadata_sumo_env_dev_input_fails(
+    fmu_snakeoil_project, monkeypatch, mocker, mock_sumo_uploader, capsys
+):
+    """Test that if the sumo_env argument is input as dev it raises an error"""
+    with open(
+        fmu_snakeoil_project / "ert/bin/workflows/xhook_create_case_metadata",
+        "a",
+        encoding="utf-8",
+    ) as f:
+        f.write(' "--sumo" "--sumo_env" dev')
 
     monkeypatch.chdir(fmu_snakeoil_project / "ert/model")
     add_create_case_workflow("snakeoil.ert")
@@ -92,6 +125,104 @@ def test_create_case_metadata_enable_mocked_sumo(
     )
     ert.__main__.main()
 
-    # Verifies case.register() was run
-    with open("sumo_case_id", encoding="utf-8") as f:
-        assert f.read() == "1"
+    _stdout, stderr = capsys.readouterr()
+    assert "ValueError: Setting sumo environment through argument" in stderr
+    assert "SUMO_ENV" in stderr
+
+
+@pytest.mark.skipif(
+    sys.version_info[:2] == (3, 12),
+    reason="fmu-sumo-uploader not compatible with Python 3.12",
+)
+@pytest.mark.skipif(
+    not importlib.util.find_spec("fmu.sumo.uploader"),
+    reason="fmu-sumo-uploader is not installed",
+)
+def test_create_case_metadata_sumo_env_reads_from_environment(
+    fmu_snakeoil_project, monkeypatch, mocker, mock_sumo_uploader
+):
+    """Test that sumo_env is set through the 'SUMO_ENV' environment variable"""
+    with open(
+        fmu_snakeoil_project / "ert/bin/workflows/xhook_create_case_metadata",
+        "a",
+        encoding="utf-8",
+    ) as f:
+        f.write(' "--sumo"')
+
+    sumo_env = "dev"
+    monkeypatch.setenv("SUMO_ENV", sumo_env)
+
+    monkeypatch.chdir(fmu_snakeoil_project / "ert/model")
+    add_create_case_workflow("snakeoil.ert")
+
+    mocker.patch(
+        "sys.argv", ["ert", "test_run", "snakeoil.ert", "--disable-monitoring"]
+    )
+    ert.__main__.main()
+
+    mock_sumo_uploader["SumoConnection"].assert_called_once_with(sumo_env)
+
+
+@pytest.mark.skipif(
+    sys.version_info[:2] == (3, 12),
+    reason="fmu-sumo-uploader not compatible with Python 3.12",
+)
+@pytest.mark.skipif(
+    not importlib.util.find_spec("fmu.sumo.uploader"),
+    reason="fmu-sumo-uploader is not installed",
+)
+def test_create_case_metadata_sumo_env_defaults_to_prod(
+    fmu_snakeoil_project, monkeypatch, mocker, mock_sumo_uploader
+):
+    """Test that sumo_env is defaulted to 'prod' when not set through the environment"""
+    with open(
+        fmu_snakeoil_project / "ert/bin/workflows/xhook_create_case_metadata",
+        "a",
+        encoding="utf-8",
+    ) as f:
+        f.write(' "--sumo"')
+
+    monkeypatch.chdir(fmu_snakeoil_project / "ert/model")
+    add_create_case_workflow("snakeoil.ert")
+
+    mocker.patch(
+        "sys.argv", ["ert", "test_run", "snakeoil.ert", "--disable-monitoring"]
+    )
+    ert.__main__.main()
+
+    # should default to prod when not set
+    mock_sumo_uploader["SumoConnection"].assert_called_once_with("prod")
+
+
+@pytest.mark.skipif(
+    sys.version_info[:2] == (3, 12),
+    reason="fmu-sumo-uploader not compatible with Python 3.12",
+)
+@pytest.mark.skipif(
+    not importlib.util.find_spec("fmu.sumo.uploader"),
+    reason="fmu-sumo-uploader is not installed",
+)
+def test_create_case_metadata_sumo_env_input_is_ignored(
+    fmu_snakeoil_project, monkeypatch, mocker, mock_sumo_uploader
+):
+    """Test that the environment variable is used over the sumo_env argument"""
+    with open(
+        fmu_snakeoil_project / "ert/bin/workflows/xhook_create_case_metadata",
+        "a",
+        encoding="utf-8",
+    ) as f:
+        f.write(' "--sumo" "--sumo_env" prod')
+
+    sumo_env_expected = "dev"
+    monkeypatch.setenv("SUMO_ENV", sumo_env_expected)
+
+    monkeypatch.chdir(fmu_snakeoil_project / "ert/model")
+    add_create_case_workflow("snakeoil.ert")
+
+    mocker.patch(
+        "sys.argv", ["ert", "test_run", "snakeoil.ert", "--disable-monitoring"]
+    )
+    with pytest.warns(FutureWarning, match="'sumo_env' is ignored"):
+        ert.__main__.main()
+
+    mock_sumo_uploader["SumoConnection"].assert_called_once_with(sumo_env_expected)


### PR DESCRIPTION
Resolves #1357 

PR to start ignoring the `sumo_env` argument and read the sumo environment from the `SUMO_ENV` variable instead in  `WF_CREATE_CASE_METADATA`.

For `sumo_env` input `prod` a warning is given to the user to safely remove the argument.
For `sumo_env` input other than `prod` an error is raised informing to use the `SUMO_ENV` variable instead.

This aligns with the planned changes to the `fmu-sumo-uploader` here https://github.com/equinor/fmu-sumo-uploader/pull/165. 
 

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
