### PR TITLE
ENH: Improve error messages for WF_CREATE_CASE_METADATA

### DIFF
--- a/src/fmu/dataio/case.py
+++ b/src/fmu/dataio/case.py
@@ -109,11 +109,11 @@ class CreateCaseMetadata:
         """
         if not self._establish_metadata_files():
             exists_warning = (
-                "Using existing case metadata from runpath: "
+                f"Using existing case metadata from casepath: '{self.rootfolder}'. "
                 "All data exported to Sumo will be stored to this existing case in "
                 "Sumo. If you want to create a new case in Sumo to store your data to, "
-                "delete the old case through Ert, or run on a different runpath "
-                "by editing it in your Ert configuration model.\n\n"
+                "delete the old case from the scratch disk, or run on a different "
+                "casepath by editing your ERT configuration file.\n\n"
                 "Ignore this warning if your model is not enabled for Sumo yet, "
                 "or if storing to the existing case in Sumo is what you want."
             )

--- a/src/fmu/dataio/scripts/create_case_metadata.py
+++ b/src/fmu/dataio/scripts/create_case_metadata.py
@@ -92,9 +92,17 @@ def check_arguments(args: argparse.Namespace) -> None:
     logger.debug("Checking input arguments")
     logger.debug("Arguments: %s", args)
 
-    if not Path(args.ert_caseroot).is_absolute():
-        logger.debug("Argument ert_caseroot was not absolute: %s", args.ert_caseroot)
-        raise ValueError("ert_caseroot must be an absolute path")
+    casepath = args.ert_caseroot
+    if not Path(casepath).is_absolute():
+        logger.debug("Argument ert_caseroot was not absolute: %s", casepath)
+        if casepath.startswith("<") and casepath.endswith(">"):
+            raise ValueError(
+                f"ERT variable used for the case root is not defined: {casepath}"
+            )
+        raise ValueError(
+            "The 'ert_caseroot' argument must be an absolute path, "
+            f"received {casepath}."
+        )
 
     if args.ert_username:
         warnings.warn(

--- a/tests/test_units/test_initialize_case.py
+++ b/tests/test_units/test_initialize_case.py
@@ -131,7 +131,7 @@ def test_create_case_metadata_generate_metadata_warn_if_exists(
         rootfolder=casemetafolder,
         casename="abc",
     )
-    with pytest.warns(UserWarning, match=r"Using existing case metadata from runpath:"):
+    with pytest.warns(UserWarning, match="Using existing case metadata from casepath:"):
         icase.generate_metadata()
 
 


### PR DESCRIPTION
Resolves #1348 
Resolves #1351 

PR with improvements to the error messages given by `WF_CREATE_CASE_METADATA`

- if the `caseroot` argument is given as an undefined ERT variable, i.e. starts with `<` and ends with `>` , this is now informed to the user.
- if the `caseroot` argument is not absolute, the input value is now provided in the error message
- stop informing users to delete their case through ERT to get a new case in Sumo (this doesn't work), and switch to informing them to delete the case from scratch instead.
 
## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
