### PR TITLE
BUG: Use uuid as string in StandardResultLoaders

### DIFF
--- a/src/fmu/dataio/external_interfaces/sumo_explorer_interface.py
+++ b/src/fmu/dataio/external_interfaces/sumo_explorer_interface.py
@@ -1,6 +1,5 @@
 import os
 from io import BytesIO
-from uuid import UUID
 
 import pandas as pd
 import xtgeo
@@ -13,12 +12,12 @@ from pandas import DataFrame
 class SumoExplorerInterface:
     def __init__(
         self,
-        case_id: UUID,
+        case_id: str,
         ensemble_name: str,
         fmu_class: ObjectMetadataClass,
         standard_result_name: str,
     ) -> None:
-        self._case_id: UUID = case_id
+        self._case_id: str = case_id
         self._ensemble_name: str = ensemble_name
         self._fmu_class: ObjectMetadataClass = fmu_class
 

--- a/src/fmu/dataio/load/load_standard_results.py
+++ b/src/fmu/dataio/load/load_standard_results.py
@@ -1,7 +1,6 @@
 from io import BytesIO
 from pathlib import Path
 from typing import TypeAlias
-from uuid import UUID
 
 import numpy as np
 import xtgeo
@@ -23,7 +22,7 @@ class StandardResultsLoader:
 
     def __init__(
         self,
-        case_id: UUID,
+        case_id: str,
         ensemble_name: str,
         fmu_class: ObjectMetadataClass,
         standard_result_name: str,
@@ -123,7 +122,7 @@ class TabularStandardResultsLoader(StandardResultsLoader):
     """Base class for the loaded tabular standard results in fmu-dataio"""
 
     def __init__(
-        self, case_id: UUID, ensemble_name: str, standard_result_name: str
+        self, case_id: str, ensemble_name: str, standard_result_name: str
     ) -> None:
         super().__init__(
             case_id,
@@ -168,7 +167,7 @@ class PolygonStandardResultsLoader(StandardResultsLoader):
     """Base class for the loaded polygon standard results in fmu-dataio"""
 
     def __init__(
-        self, case_id: UUID, ensemble_name: str, standard_result_name: str
+        self, case_id: str, ensemble_name: str, standard_result_name: str
     ) -> None:
         super().__init__(
             case_id, ensemble_name, ObjectMetadataClass.polygons, standard_result_name
@@ -215,7 +214,7 @@ class SurfacesStandardResultsLoader(StandardResultsLoader):
     """Base class for the loaded surface standard results in fmu-dataio"""
 
     def __init__(
-        self, case_id: UUID, ensemble_name: str, standard_result_name: str
+        self, case_id: str, ensemble_name: str, standard_result_name: str
     ) -> None:
         super().__init__(
             case_id,
@@ -258,7 +257,7 @@ class InplaceVolumesLoader(TabularStandardResultsLoader):
     with the loaded inplace volumes data.
     """
 
-    def __init__(self, case_id: UUID, ensemble_name: str):
+    def __init__(self, case_id: str, ensemble_name: str):
         super().__init__(case_id, ensemble_name, StandardResultName.inplace_volumes)
 
 
@@ -269,7 +268,7 @@ class FieldOutlinesLoader(PolygonStandardResultsLoader):
     with the loaded field outlines data.
     """
 
-    def __init__(self, case_id: UUID, ensemble_name: str) -> None:
+    def __init__(self, case_id: str, ensemble_name: str) -> None:
         super().__init__(case_id, ensemble_name, StandardResultName.field_outline)
 
 
@@ -280,7 +279,7 @@ class StructureDepthSurfacesLoader(SurfacesStandardResultsLoader):
     with the loaded structure depth surfaces data.
     """
 
-    def __init__(self, case_id: UUID, ensemble_name: str) -> None:
+    def __init__(self, case_id: str, ensemble_name: str) -> None:
         super().__init__(
             case_id, ensemble_name, StandardResultName.structure_depth_surface
         )
@@ -293,7 +292,7 @@ class FluidContactSurfacesLoader(SurfacesStandardResultsLoader):
     with the loaded fluid contact surfaces data.
     """
 
-    def __init__(self, case_id: UUID, ensemble_name: str) -> None:
+    def __init__(self, case_id: str, ensemble_name: str) -> None:
         super().__init__(
             case_id, ensemble_name, StandardResultName.fluid_contact_surface
         )
@@ -328,7 +327,7 @@ def load_inplace_volumes(case_id: str, ensemble_name: str) -> InplaceVolumesLoad
 
     """  # noqa: E501 line too long
 
-    return InplaceVolumesLoader(UUID(case_id), ensemble_name)
+    return InplaceVolumesLoader(case_id, ensemble_name)
 
 
 @experimental
@@ -360,7 +359,7 @@ def load_field_outlines(case_id: str, ensemble_name: str) -> FieldOutlinesLoader
 
     """  # noqa: E501 line too long
 
-    return FieldOutlinesLoader(UUID(case_id), ensemble_name)
+    return FieldOutlinesLoader(case_id, ensemble_name)
 
 
 @experimental
@@ -395,7 +394,7 @@ def load_structure_depth_surfaces(
 
     """  # noqa: E501 line too long
 
-    return StructureDepthSurfacesLoader(UUID(case_id), ensemble_name)
+    return StructureDepthSurfacesLoader(case_id, ensemble_name)
 
 
 @experimental
@@ -430,4 +429,4 @@ def load_fluid_contact_surfaces(
 
     """  # noqa: E501 line too long
 
-    return FluidContactSurfacesLoader(UUID(case_id), ensemble_name)
+    return FluidContactSurfacesLoader(case_id, ensemble_name)


### PR DESCRIPTION
Resolves #1364 

PR to fix a bug in the simple loaders where an error is raised in the `SumoExplorer` if an uuid is passed as an  `UUID` object instead of a `str` .
The tests did not catch this error, we need to adjust our mock set-up to detect these. Will create a separate issue for it.


## Checklist

- [ ] Tests added (will create separate issue)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
