### PR TITLE
ENH: Add structure depth fault surface standard result loader (issue #1323)

### DIFF
--- a/src/fmu/dataio/external_interfaces/sumo_explorer_interface.py
+++ b/src/fmu/dataio/external_interfaces/sumo_explorer_interface.py
@@ -4,10 +4,12 @@ from uuid import UUID
 
 import pandas as pd
 import xtgeo
-from fmu.datamodels.fmu_results.enums import ObjectMetadataClass
+from fmu.datamodels.fmu_results.enums import Layout, ObjectMetadataClass
 from fmu.sumo.explorer import Explorer
 from fmu.sumo.explorer.objects import SearchContext
 from pandas import DataFrame
+
+from fmu.dataio._readers.tsurf import TSurfData
 
 
 class SumoExplorerInterface:
@@ -16,11 +18,13 @@ class SumoExplorerInterface:
         case_id: UUID,
         ensemble_name: str,
         fmu_class: ObjectMetadataClass,
+        fmu_layout: Layout,
         standard_result_name: str,
     ) -> None:
         self._case_id: UUID = case_id
         self._ensemble_name: str = ensemble_name
         self._fmu_class: ObjectMetadataClass = fmu_class
+        self._fmu_layout: Layout = fmu_layout
 
         env = "prod"
         if "bleeding" in os.environ.get(
@@ -34,9 +38,10 @@ class SumoExplorerInterface:
             iteration=self._ensemble_name, standard_result=standard_result_name
         )
 
+    # NOTE: 'SeachContext' could possibly be replaced by 'Child'
     def _get_formatted_data(
         self, data_object: SearchContext
-    ) -> DataFrame | xtgeo.Polygons | xtgeo.RegularSurface:
+    ) -> DataFrame | xtgeo.Polygons | xtgeo.RegularSurface | TSurfData:
         """Get a fmu-dataio formatted data object from the Sumo Explorer object."""
 
         match self._fmu_class:
@@ -50,15 +55,30 @@ class SumoExplorerInterface:
                 return xtgeo.Polygons(data_frame)
 
             case ObjectMetadataClass.surface:
-                # Dataformat: 'irap_binary'
-                return data_object.to_regular_surface()
+                match self._fmu_layout:
+                    case Layout.regular:
+                        # TODO: @ecs: "data_object.to_regular_surface()": is defined
+                        # somewhere in SUMO; Child, Document, Realization...?
+                        return data_object.to_regular_surface()
+
+                    case Layout.triangulated:
+                        # TODO: proposed by Copilot, is most likely wrong
+                        # Probably we need new functionality in SUMO
+                        return TSurfData.from_blob(data_object.blob)
+
+                    case _:
+                        raise ValueError(
+                            f"Unknown FMULayout {self._fmu_layout} in provided"
+                        )
 
             case _:
                 raise ValueError(f"Unknown FMUClass {self._fmu_class}. in provided ")
 
     def get_objects_with_metadata(
         self, realization_id: int
-    ) -> list[tuple[DataFrame | xtgeo.Polygons | xtgeo.RegularSurface, dict]]:
+    ) -> list[
+        tuple[DataFrame | xtgeo.Polygons | xtgeo.RegularSurface | TSurfData, dict]
+    ]:
         """
         Get the standard results data objects and metadata from Sumo,
         filtered on the provided realization id. The results are returned
@@ -70,7 +90,7 @@ class SumoExplorerInterface:
         )
 
         realization_data: list[
-            tuple[DataFrame | xtgeo.Polygons | xtgeo.RegularSurface, dict]
+            tuple[DataFrame | xtgeo.Polygons | xtgeo.RegularSurface | TSurfData, dict]
         ] = []
         for object in search_context_realization:
             realization_data.append((self._get_formatted_data(object), object.metadata))


### PR DESCRIPTION
Investigation as proposed in #1323 

Investigated possible adding simple loader for fault triangulated surfaces.
Status:
The simple loader cannot currently be tested with real data from SUMO.
Thus we postpone the implementation of StructureDepthFaultSurfaces simple export. 
It will most likely be worked over in 2026.

Don’t expect the code suggestion in this PR to work.
The PR is left as a source of ideas when working it over.


## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [ ] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [ ] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [ ] Checked the boxes in this checklist ✅
