### PR TITLE
ENH: Add structure depth fault surface standard result loader

### DIFF
--- a/simple_loader_test.py
+++ b/simple_loader_test.py
@@ -1,0 +1,41 @@
+from fmu.dataio.load.load_standard_results import (
+    fluid_contact_surfaces_loader,
+    load_inplace_volumes,
+    load_structure_depth_fault_surfaces,
+    load_structure_depth_surfaces,
+)
+
+my_case_id = "250a65b6-257a-4e47-b720-aebd535c5eb8"
+ensemble_name = "iter-0"
+realization_id = 0
+test_save_path = "./test_only"
+loaders = {
+    "fluid_contact_surfaces_loader": fluid_contact_surfaces_loader,
+    "load_inplace_volumes": load_inplace_volumes,
+    "load_structure_depth_fault_surfaces": load_structure_depth_fault_surfaces,
+    "load_structure_depth_surfaces": load_structure_depth_surfaces,
+}
+
+for selected_loader in loaders:
+    print()
+    print("*************** Setting up loader ***************")
+    print()
+    loader = loaders[selected_loader](my_case_id, ensemble_name)
+
+    print()
+    print("*************** Getting realization ***************")
+    print()
+
+    # Get all structure depth fault surfaces objects for a given realization
+    objects = loader.get_realization(realization_id)
+
+    print()
+    print("*************** Saving realization ***************")
+    print()
+
+    # Save the structure depth fault surfaces objects for a given realization
+    object_paths = loader.save_realization(realization_id, test_save_path)
+
+    print()
+    print("*************** Done ***************")
+    print()

--- a/src/fmu/dataio/load/load_standard_results.py
+++ b/src/fmu/dataio/load/load_standard_results.py
@@ -6,15 +6,21 @@ import numpy as np
 import xtgeo
 from pandas import DataFrame
 
+from fmu.dataio._readers.tsurf import TSurfData, write_tsurf_to_file
 from fmu.dataio.export._decorators import experimental
 from fmu.dataio.external_interfaces.schema_validation_interface import (
     SchemaValidationInterface,
 )
 from fmu.dataio.external_interfaces.sumo_explorer_interface import SumoExplorerInterface
-from fmu.datamodels.fmu_results.enums import ObjectMetadataClass
+from fmu.datamodels.fmu_results.enums import Layout, ObjectMetadataClass
 from fmu.datamodels.standard_results.enums import StandardResultName
 
-DataFrameOrXtgeoObject: TypeAlias = DataFrame | xtgeo.Polygons | xtgeo.RegularSurface
+# TODO: @ecs: could probably use dataio/types.py::Inferrable, which contains
+# all these types. But since it is only available when TYPE_CHECKING == True
+# (namely when running mypy), need to find out how to do it
+DataFrameOrXtgeoObject: TypeAlias = (
+    DataFrame | xtgeo.Polygons | xtgeo.RegularSurface | TSurfData
+)
 
 
 class StandardResultsLoader:
@@ -25,10 +31,11 @@ class StandardResultsLoader:
         case_id: str,
         ensemble_name: str,
         fmu_class: ObjectMetadataClass,
+        fmu_layout: Layout | None,
         standard_result_name: str,
     ) -> None:
         self._sumo_interface = SumoExplorerInterface(
-            case_id, ensemble_name, fmu_class, standard_result_name
+            case_id, ensemble_name, fmu_class, fmu_layout, standard_result_name
         )
 
     def list_realizations(self) -> list[int]:
@@ -128,9 +135,12 @@ class TabularStandardResultsLoader(StandardResultsLoader):
             case_id,
             ensemble_name,
             ObjectMetadataClass.table,
+            None,
             standard_result_name,
         )
 
+    # NOTE: Could possibly avoid this overriding method.
+    # It is there only because of the typing, to narrow the return type.
     def get_realization(self, realization_id: int) -> dict[str, DataFrame]:
         return super().get_realization(realization_id)
 
@@ -187,12 +197,12 @@ class PolygonStandardResultsLoader(StandardResultsLoader):
 
         """
 
-        plygons_with_metadata: list[tuple[xtgeo.Polygons, dict]] = (
+        polygons_with_metadata: list[tuple[xtgeo.Polygons, dict]] = (
             self._sumo_interface.get_objects_with_metadata(realization_id)
         )
 
         file_paths: list[str] = []
-        for polygon, metadata in plygons_with_metadata:
+        for polygon, metadata in polygons_with_metadata:
             # Temporary work-around until xtgeo.Polygons supports storing
             # csv files directly with Polygons.to_file()
             # https://github.com/equinor/xtgeo/issues/1333
@@ -220,6 +230,7 @@ class SurfacesStandardResultsLoader(StandardResultsLoader):
             case_id,
             ensemble_name,
             ObjectMetadataClass.surface,
+            Layout.regular,
             standard_result_name,
         )
 
@@ -248,6 +259,70 @@ class SurfacesStandardResultsLoader(StandardResultsLoader):
             file_paths.append(str(file_path))
 
         return file_paths
+
+
+class TriangulatedSurfacesStandardResultsLoader(StandardResultsLoader):
+    """
+    Base class for the loaded triangulated surface standard results
+    in fmu-dataio
+    """
+
+    # TODO: @ecs: this method is identical to SurfacesStandardResultsLoader, up to
+    # the type of the surface object (xtgeo.RegularSurface / TSurfData).
+    # Can we make this more generic?
+    # By using a type alias or make a generic class?
+    # Note that the file extension is also different ('.gri' / '.ts') ...
+
+    def __init__(
+        self, case_id: str, ensemble_name: str, standard_result_name: str
+    ) -> None:
+        super().__init__(
+            case_id,
+            ensemble_name,
+            ObjectMetadataClass.surface,
+            Layout.triangulated,
+            standard_result_name,
+        )
+
+    def get_realization(self, realization_id: int) -> dict[str, TSurfData]:
+        return super().get_realization(realization_id)
+
+    def save_realization(self, realization_id: int, folder_path: str) -> list[str]:
+        """
+        Saves the loaded surface objects, filtered on the provided
+        realization id, as tsurf files at the provided path.
+
+        Args:
+            realization_id: The id of the realization to filter on.
+            folder_path: The path to where to store the generated tsurf files.
+
+        """
+
+        surfaces_with_metadata: list[tuple[TSurfData, dict]] = (
+            self._sumo_interface.get_objects_with_metadata(realization_id)
+        )
+
+        file_paths: list[str] = []
+        for surface, metadata in surfaces_with_metadata:
+            file_path = self._generate_path_for_saving(folder_path, metadata, ".ts")
+            write_tsurf_to_file(surface, file_path)
+            file_paths.append(str(file_path))
+
+        return file_paths
+
+
+class StructureDepthFaultSurfacesLoader(TriangulatedSurfacesStandardResultsLoader):
+    """
+    Loader object for the Structure Depth Fault Surface standard results
+    in fmu-dataio.
+    Offers a set of methods to easily manage and interact
+    with the loaded structure depth fault surfaces data.
+    """
+
+    def __init__(self, case_id: str, ensemble_name: str) -> None:
+        super().__init__(
+            case_id, ensemble_name, StandardResultName.structure_depth_fault_surface
+        )
 
 
 class InplaceVolumesLoader(TabularStandardResultsLoader):
@@ -398,7 +473,43 @@ def load_structure_depth_surfaces(
 
 
 @experimental
-def load_fluid_contact_surfaces(
+def load_structure_depth_fault_surfaces(
+    case_id: str, ensemble_name: str
+) -> StructureDepthFaultSurfacesLoader:
+    """
+    This function provides a simplified interface for loading
+    structure depth fault surfaces standard results from Sumo.
+    It returns a StructureDepthFaultSurfacesLoader object,
+    which offers a set of methods to easily manage and interact with the
+    loaded structure depth fault surfaces data.
+
+    Args:
+        case_id: The id of the case to load structure depth fault surfaces from.
+        ensemble_name: The name of the ensemble to load structure depth fault surfaces from.
+
+    Note:
+        This function is experimental and may change in future versions.
+
+    Examples:
+        Example usage in a script::
+
+            from fmu.dataio.load.load_standard_results import load_structure_depth_fault_surfaces
+
+            structure_depth_fault_surfaces_loader = load_structure_depth_fault_surfaces(case_id, ensemble_name)
+
+            # Get all structure depth fault surfaces objects for a given realization
+            objects = structure_depth_fault_surfaces_loader.get_realization(realization_id)
+
+            # Save the structure depth fault surfaces objects for a given realization
+            object_paths = structure_depth_fault_surfaces_loader.save_realization(realization_id, folder_path)
+
+    """  # noqa: E501 line too long
+
+    return StructureDepthFaultSurfacesLoader(case_id, ensemble_name)
+
+
+@experimental
+def fluid_contact_surfaces_loader(
     case_id: str, ensemble_name: str
 ) -> FluidContactSurfacesLoader:
     """


### PR DESCRIPTION
Investigation as proposed in #1323.

Investigated possibility for adding simple loader for fault triangulated surfaces.
Status:
Sumo doesn't have a concept of triangulated surfaces, see
https://equinor.slack.com/archives/C07B2E2S2M7/p1759218097362849
Thus we postpone the implementation of StructureDepthFaultSurfaces simple loader.


## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [ ] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [ ] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [ ] Checked the boxes in this checklist ✅
