### PR TITLE
MAINT: adapt to cleanup in fmu-datamodels.TrackLog

### DIFF
--- a/src/fmu/dataio/preprocessed.py
+++ b/src/fmu/dataio/preprocessed.py
@@ -183,7 +183,7 @@ class ExportPreprocessedData:
             # TODO: Would like to use meta.Root.model_validate() here
             # but then the '$schema' field is dropped from the meta_existing
             validated_metadata = ObjectMetadataExport.model_validate(meta_existing)
-            validated_metadata.tracklog.extend(
+            validated_metadata.tracklog.append(
                 enums.TrackLogEventType.merged, __version__
             )
             return validated_metadata.model_dump(


### PR DESCRIPTION
See issue #https://github.com/equinor/fmu-datamodels/issues/69 and PR #https://github.com/equinor/fmu-datamodels/pull/70.

Adapted `fmu-dataio` to small change in `fmu-datamodels.TrackLog` class API.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
