### PR TITLE
ENH: Improve error message when stratigraphy is missing

### DIFF
--- a/src/fmu/dataio/export/rms/_utils.py
+++ b/src/fmu/dataio/export/rms/_utils.py
@@ -281,9 +281,12 @@ def get_faultlines_in_folder(project: Any, horizon_folder: str) -> list[xtgeo.Po
 
 
 def validate_name_in_stratigraphy(name: str, config: GlobalConfiguration) -> None:
-    """Validate that an input name is present in the config.stratigraphy"""
-    assert config.stratigraphy is not None
-
+    """Validate that an input name is present in the config.stratigraphy."""
+    if not config.stratigraphy:
+        raise ValidationError(
+            "The 'stratigraphy' block is lacking in the config. "
+            "This is required for the export function to work."
+        )
     if name not in config.stratigraphy:
         raise ValidationError(
             f"The stratigraphic {name=} is not listed in the 'stratigraphy' "

--- a/tests/test_export_rms/test_export_fluid_contact_outlines.py
+++ b/tests/test_export_rms/test_export_fluid_contact_outlines.py
@@ -186,6 +186,26 @@ def test_unknown_name_in_stratigraphy_raises(mock_export_class):
 
 
 @pytest.mark.usefixtures("inside_rms_interactive")
+def test_stratigraphy_missing_raises(
+    mock_project_variable, mock_export_class, globalconfig1
+):
+    """Test that an error is raised if stratigraphy is missing from the config"""
+
+    from fmu.dataio.export.rms import export_fluid_contact_outlines
+
+    # remove the stratigraphy block
+    del globalconfig1["stratigraphy"]
+
+    with (
+        mock.patch(
+            "fmu.dataio.export._base.load_config_from_path", return_value=globalconfig1
+        ),
+        pytest.raises(ValueError, match=r"stratigraphy.*is lacking"),
+    ):
+        export_fluid_contact_outlines(mock_project_variable)
+
+
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_config_missing(mock_project_variable, rmssetup_with_fmuconfig, monkeypatch):
     """Test that an exception is raised if the config is missing."""
 

--- a/tests/test_export_rms/test_export_fluid_contact_surfaces.py
+++ b/tests/test_export_rms/test_export_fluid_contact_surfaces.py
@@ -171,6 +171,26 @@ def test_unknown_name_in_stratigraphy_raises(mock_export_class):
 
 
 @pytest.mark.usefixtures("inside_rms_interactive")
+def test_stratigraphy_missing_raises(
+    mock_project_variable, mock_export_class, globalconfig1
+):
+    """Test that an error is raised if stratigraphy is missing from the config"""
+
+    from fmu.dataio.export.rms import export_fluid_contact_surfaces
+
+    # remove the stratigraphy block
+    del globalconfig1["stratigraphy"]
+
+    with (
+        mock.patch(
+            "fmu.dataio.export._base.load_config_from_path", return_value=globalconfig1
+        ),
+        pytest.raises(ValueError, match=r"stratigraphy.*is lacking"),
+    ):
+        export_fluid_contact_surfaces(mock_project_variable)
+
+
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_config_missing(mock_project_variable, rmssetup_with_fmuconfig, monkeypatch):
     """Test that an exception is raised if the config is missing."""
 

--- a/tests/test_export_rms/test_export_structure_depth_fault_lines.py
+++ b/tests/test_export_rms/test_export_structure_depth_fault_lines.py
@@ -133,6 +133,26 @@ def test_unknown_name_in_stratigraphy_raises(mock_export_class):
 
 
 @pytest.mark.usefixtures("inside_rms_interactive")
+def test_stratigraphy_missing_raises(
+    mock_project_variable, mock_export_class, globalconfig1
+):
+    """Test that an error is raised if stratigraphy is missing from the config"""
+
+    from fmu.dataio.export.rms import export_structure_depth_fault_lines
+
+    # remove the stratigraphy block
+    del globalconfig1["stratigraphy"]
+
+    with (
+        mock.patch(
+            "fmu.dataio.export._base.load_config_from_path", return_value=globalconfig1
+        ),
+        pytest.raises(ValueError, match=r"stratigraphy.*is lacking"),
+    ):
+        export_structure_depth_fault_lines(mock_project_variable, "DS_extracted")
+
+
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_config_missing(mock_project_variable, rmssetup_with_fmuconfig, monkeypatch):
     """Test that an exception is raised if the config is missing."""
 

--- a/tests/test_export_rms/test_export_structure_depth_isochores.py
+++ b/tests/test_export_rms/test_export_structure_depth_isochores.py
@@ -99,6 +99,26 @@ def test_unknown_name_in_stratigraphy_raises(mock_export_class):
 
 
 @pytest.mark.usefixtures("inside_rms_interactive")
+def test_stratigraphy_missing_raises(
+    mock_project_variable, mock_export_class, globalconfig1
+):
+    """Test that an error is raised if stratigraphy is missing from the config"""
+
+    from fmu.dataio.export.rms import export_structure_depth_isochores
+
+    # remove the stratigraphy block
+    del globalconfig1["stratigraphy"]
+
+    with (
+        mock.patch(
+            "fmu.dataio.export._base.load_config_from_path", return_value=globalconfig1
+        ),
+        pytest.raises(ValueError, match=r"stratigraphy.*is lacking"),
+    ):
+        export_structure_depth_isochores(mock_project_variable, "IS_extracted")
+
+
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_validation_negative_values(
     mock_project_variable, monkeypatch, rmssetup_with_fmuconfig, regsurf
 ):

--- a/tests/test_export_rms/test_export_structure_depth_surfaces.py
+++ b/tests/test_export_rms/test_export_structure_depth_surfaces.py
@@ -124,6 +124,26 @@ def test_unknown_name_in_stratigraphy_raises(mock_export_class):
 
 
 @pytest.mark.usefixtures("inside_rms_interactive")
+def test_stratigraphy_missing_raises(
+    mock_project_variable, mock_export_class, globalconfig1
+):
+    """Test that an error is raised if stratigraphy is missing from the config"""
+
+    from fmu.dataio.export.rms import export_structure_depth_surfaces
+
+    # remove the stratigraphy block
+    del globalconfig1["stratigraphy"]
+
+    with (
+        mock.patch(
+            "fmu.dataio.export._base.load_config_from_path", return_value=globalconfig1
+        ),
+        pytest.raises(ValueError, match=r"stratigraphy.*is lacking"),
+    ):
+        export_structure_depth_surfaces(mock_project_variable, "DS_extracted")
+
+
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_config_missing(mock_project_variable, rmssetup_with_fmuconfig, monkeypatch):
     """Test that an exception is raised if the config is missing."""
 

--- a/tests/test_export_rms/test_export_structure_time_surfaces.py
+++ b/tests/test_export_rms/test_export_structure_time_surfaces.py
@@ -98,6 +98,26 @@ def test_unknown_name_in_stratigraphy_raises(mock_export_class):
 
 
 @pytest.mark.usefixtures("inside_rms_interactive")
+def test_stratigraphy_missing_raises(
+    mock_project_variable, mock_export_class, globalconfig1
+):
+    """Test that an error is raised if stratigraphy is missing from the config"""
+
+    from fmu.dataio.export.rms import export_structure_time_surfaces
+
+    # remove the stratigraphy block
+    del globalconfig1["stratigraphy"]
+
+    with (
+        mock.patch(
+            "fmu.dataio.export._base.load_config_from_path", return_value=globalconfig1
+        ),
+        pytest.raises(ValueError, match=r"stratigraphy.*is lacking"),
+    ):
+        export_structure_time_surfaces(mock_project_variable, "TS_extracted")
+
+
+@pytest.mark.usefixtures("inside_rms_interactive")
 def test_config_missing(mock_project_variable, rmssetup_with_fmuconfig, monkeypatch):
     """Test that an exception is raised if the config is missing."""
 


### PR DESCRIPTION
Resolves #1373

PR to give users a proper error message if `stratigraphy` is missing from the `config` instead of an `assert.` 
Only added to simple exports that validates against the stratigraphy.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
