### PR TITLE
ENH: Add standard table index for well_completions and production_network

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     "fmu-config>=1.1.0",
-    "fmu-datamodels~=0.15.0",
+    "fmu-datamodels~=0.16.0",
     "numpy",
     "pandas",
     "pyarrow",

--- a/src/fmu/dataio/_definitions.py
+++ b/src/fmu/dataio/_definitions.py
@@ -59,6 +59,10 @@ STANDARD_TABLE_INDEX_COLUMNS: Final[dict[Content, StandardTableIndex]] = {
         columns=InplaceVolumes.index_columns(),
         required=InplaceVolumes.required_index_columns(),
     ),
+    Content.production_network: StandardTableIndex(
+        columns=["DATE", "CHILD", "PARENT", "KEYWORD"],
+        required=["DATE", "CHILD", "PARENT", "KEYWORD"],
+    ),
     Content.rft: StandardTableIndex(
         columns=["WELL", "DATE"],
         required=["WELL", "DATE"],
@@ -78,6 +82,10 @@ STANDARD_TABLE_INDEX_COLUMNS: Final[dict[Content, StandardTableIndex]] = {
     Content.relperm: StandardTableIndex(
         columns=["SATNUM"],
         required=["SATNUM"],
+    ),
+    Content.well_completions: StandardTableIndex(
+        columns=["WELL", "DATE", "ZONE"],
+        required=["WELL", "DATE", "ZONE"],
     ),
 }
 

--- a/tests/test_units/test_contents.py
+++ b/tests/test_units/test_contents.py
@@ -356,6 +356,28 @@ def test_content_wellpicks(wellpicks, globalconfig2):
     assert meta["data"]["content"] == "wellpicks"
 
 
+def test_content_production_network(wellpicks, globalconfig2):
+    """Test export of the production network content."""
+    meta = ExportData(
+        config=globalconfig2,
+        name="MyName",
+        content="production_network",
+    ).generate_metadata(wellpicks)
+
+    assert meta["data"]["content"] == "production_network"
+
+
+def test_content_well_completions(wellpicks, globalconfig2):
+    """Test export of the well completions content."""
+    meta = ExportData(
+        config=globalconfig2,
+        name="MyName",
+        content="well_completions",
+    ).generate_metadata(wellpicks)
+
+    assert meta["data"]["content"] == "well_completions"
+
+
 def test_content_requires_metadata():
     """Test the content_requires_metadata function"""
 

--- a/tests/test_units/test_table.py
+++ b/tests/test_units/test_table.py
@@ -267,6 +267,56 @@ def test_table_wellpicks(wellpicks, globalconfig1):
     assert metadata["data"]["table_index"] == ["WELL", "HORIZON"]
 
 
+def test_production_network_index(globalconfig1):
+    """Test that the table index is set correct for production network data"""
+
+    mock_table = pd.DataFrame(
+        {
+            "DATE": ["2000-01-01", "2000-01-01"],
+            "CHILD": ["OPWEST", "OP1"],
+            "PARENT": ["OP", "OPWEST"],
+            "KEYWORD": ["GROUPTREE", "WELSPECS"],
+            "TERMINAL_PRESSURE": [100, 90],
+        }
+    )
+
+    exp = ExportData(
+        config=globalconfig1, name="production_network", content="production_network"
+    )
+
+    metadata = exp.generate_metadata(mock_table)
+
+    assert metadata["data"]["content"] == "production_network"
+
+    # table index shall be inserted automatically
+    assert metadata["data"]["table_index"] == ["DATE", "CHILD", "PARENT", "KEYWORD"]
+
+
+def test_well_completions_index(globalconfig1):
+    """Test that the table index is set correct for well completions data"""
+
+    mock_table = pd.DataFrame(
+        {
+            "DATE": ["2000-01-01", "2000-01-01"],
+            "WELL": ["OP2", "OP1"],
+            "OP/SH": ["OPEN", "SHUT"],
+            "ZONE": ["UPPER", "LOWER"],
+            "KH": [10, 50],
+        }
+    )
+
+    exp = ExportData(
+        config=globalconfig1, name="well_completions", content="well_completions"
+    )
+
+    metadata = exp.generate_metadata(mock_table)
+
+    assert metadata["data"]["content"] == "well_completions"
+
+    # table index shall be inserted automatically
+    assert metadata["data"]["table_index"] == ["WELL", "DATE", "ZONE"]
+
+
 def test_standard_table_index_valid():
     """Test the StandardTableIndex model"""
     index = StandardTableIndex(


### PR DESCRIPTION
Resolves #1397 
Resolves #1392 

PR to add standard table index columns for the two new content types `well_completions` and `production_network`

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
