### PR TITLE
MAINT: Group common models into fmu/datamodels/common directory

### DIFF
--- a/examples/example_metadata/fmu_case.yml
+++ b/examples/example_metadata/fmu_case.yml
@@ -1,4 +1,4 @@
-$schema: https://main-fmu-schemas-dev.radix.equinor.com/schemas/0.14.0/fmu_results.json
+$schema: https://main-fmu-schemas-prod.radix.equinor.com/schemas/0.16.1/fmu_results.json
 access:
   asset:
     name: Drogon
@@ -37,6 +37,8 @@ tracklog:
   sysinfo:
     fmu-dataio:
       version: dummy_version
+    komodo:
+      version: dummy_version
     operating_system:
       hostname: dummy_hostname
       operating_system: dummy_os
@@ -45,4 +47,4 @@ tracklog:
       version: dummy_version
   user:
     id: user
-version: 0.14.0
+version: 0.16.1

--- a/examples/example_metadata/geogrid--facies.yml
+++ b/examples/example_metadata/geogrid--facies.yml
@@ -1,4 +1,4 @@
-$schema: https://main-fmu-schemas-dev.radix.equinor.com/schemas/0.14.0/fmu_results.json
+$schema: https://main-fmu-schemas-prod.radix.equinor.com/schemas/0.16.1/fmu_results.json
 _preprocessed: false
 access:
   asset:
@@ -36,7 +36,7 @@ display:
   name: facies
 file:
   absolute_path: /some/absolute/path/
-  checksum_md5: 01f16f2d39337fe5fcf649b427f4d21e
+  checksum_md5: a6a4376b1f4d263ecd8cd6758a85c723
   relative_path: example_exports/share/results/grids/geogrid--facies.roff
   runpath_relative_path: share/results/grids/geogrid--facies.roff
   size_bytes: 3492813
@@ -95,6 +95,8 @@ tracklog:
   sysinfo:
     fmu-dataio:
       version: dummy_version
+    komodo:
+      version: dummy_version
     operating_system:
       hostname: dummy_hostname
       operating_system: dummy_os
@@ -103,4 +105,4 @@ tracklog:
       version: dummy_version
   user:
     id: user
-version: 0.14.0
+version: 0.16.1

--- a/examples/example_metadata/geogrid--phit.yml
+++ b/examples/example_metadata/geogrid--phit.yml
@@ -1,4 +1,4 @@
-$schema: https://main-fmu-schemas-dev.radix.equinor.com/schemas/0.14.0/fmu_results.json
+$schema: https://main-fmu-schemas-prod.radix.equinor.com/schemas/0.16.1/fmu_results.json
 _preprocessed: false
 access:
   asset:
@@ -36,7 +36,7 @@ display:
   name: phit
 file:
   absolute_path: /some/absolute/path/
-  checksum_md5: 73e5c692d942aa4fde69c3258dabb1f3
+  checksum_md5: 792b71588d5925cc6e7a56f976bb88ff
   relative_path: example_exports/share/results/grids/geogrid--phit.roff
   runpath_relative_path: share/results/grids/geogrid--phit.roff
   size_bytes: 3492651
@@ -95,6 +95,8 @@ tracklog:
   sysinfo:
     fmu-dataio:
       version: dummy_version
+    komodo:
+      version: dummy_version
     operating_system:
       hostname: dummy_hostname
       operating_system: dummy_os
@@ -103,4 +105,4 @@ tracklog:
       version: dummy_version
   user:
     id: user
-version: 0.14.0
+version: 0.16.1

--- a/examples/example_metadata/geogrid.yml
+++ b/examples/example_metadata/geogrid.yml
@@ -1,4 +1,4 @@
-$schema: https://main-fmu-schemas-dev.radix.equinor.com/schemas/0.14.0/fmu_results.json
+$schema: https://main-fmu-schemas-prod.radix.equinor.com/schemas/0.16.1/fmu_results.json
 _preprocessed: false
 access:
   asset:
@@ -54,7 +54,7 @@ display:
   name: geogrid
 file:
   absolute_path: /some/absolute/path/
-  checksum_md5: d24f17360e70ed082b7b3ba1963ce55e
+  checksum_md5: 2c21552d03a9b4217abe73034509f332
   relative_path: example_exports/share/results/grids/geogrid.roff
   runpath_relative_path: share/results/grids/geogrid.roff
   size_bytes: 16540658
@@ -113,6 +113,8 @@ tracklog:
   sysinfo:
     fmu-dataio:
       version: dummy_version
+    komodo:
+      version: dummy_version
     operating_system:
       hostname: dummy_hostname
       operating_system: dummy_os
@@ -121,4 +123,4 @@ tracklog:
       version: dummy_version
   user:
     id: user
-version: 0.14.0
+version: 0.16.1

--- a/examples/example_metadata/polygons_field_outline.yml
+++ b/examples/example_metadata/polygons_field_outline.yml
@@ -1,4 +1,4 @@
-$schema: https://main-fmu-schemas-dev.radix.equinor.com/schemas/0.14.0/fmu_results.json
+$schema: https://main-fmu-schemas-prod.radix.equinor.com/schemas/0.16.1/fmu_results.json
 _preprocessed: false
 access:
   asset:
@@ -106,6 +106,8 @@ tracklog:
   sysinfo:
     fmu-dataio:
       version: dummy_version
+    komodo:
+      version: dummy_version
     operating_system:
       hostname: dummy_hostname
       operating_system: dummy_os
@@ -114,4 +116,4 @@ tracklog:
       version: dummy_version
   user:
     id: user
-version: 0.14.0
+version: 0.16.1

--- a/examples/example_metadata/polygons_field_region.yml
+++ b/examples/example_metadata/polygons_field_region.yml
@@ -1,4 +1,4 @@
-$schema: https://main-fmu-schemas-dev.radix.equinor.com/schemas/0.14.0/fmu_results.json
+$schema: https://main-fmu-schemas-prod.radix.equinor.com/schemas/0.16.1/fmu_results.json
 _preprocessed: false
 access:
   asset:
@@ -106,6 +106,8 @@ tracklog:
   sysinfo:
     fmu-dataio:
       version: dummy_version
+    komodo:
+      version: dummy_version
     operating_system:
       hostname: dummy_hostname
       operating_system: dummy_os
@@ -114,4 +116,4 @@ tracklog:
       version: dummy_version
   user:
     id: user
-version: 0.14.0
+version: 0.16.1

--- a/examples/example_metadata/preprocessed_surface_depth.yml
+++ b/examples/example_metadata/preprocessed_surface_depth.yml
@@ -1,4 +1,4 @@
-$schema: https://main-fmu-schemas-dev.radix.equinor.com/schemas/0.14.0/fmu_results.json
+$schema: https://main-fmu-schemas-prod.radix.equinor.com/schemas/0.16.1/fmu_results.json
 _preprocessed: true
 access:
   asset:
@@ -86,6 +86,8 @@ tracklog:
   sysinfo:
     fmu-dataio:
       version: dummy_version
+    komodo:
+      version: dummy_version
     operating_system:
       hostname: dummy_hostname
       operating_system: dummy_os
@@ -94,4 +96,4 @@ tracklog:
       version: dummy_version
   user:
     id: user
-version: 0.14.0
+version: 0.16.1

--- a/examples/example_metadata/surface_depth.yml
+++ b/examples/example_metadata/surface_depth.yml
@@ -1,4 +1,4 @@
-$schema: https://main-fmu-schemas-dev.radix.equinor.com/schemas/0.14.0/fmu_results.json
+$schema: https://main-fmu-schemas-prod.radix.equinor.com/schemas/0.16.1/fmu_results.json
 _preprocessed: false
 access:
   asset:
@@ -103,6 +103,8 @@ tracklog:
   sysinfo:
     fmu-dataio:
       version: dummy_version
+    komodo:
+      version: dummy_version
     operating_system:
       hostname: dummy_hostname
       operating_system: dummy_os
@@ -111,4 +113,4 @@ tracklog:
       version: dummy_version
   user:
     id: user
-version: 0.14.0
+version: 0.16.1

--- a/examples/example_metadata/surface_fluid_contact.yml
+++ b/examples/example_metadata/surface_fluid_contact.yml
@@ -1,4 +1,4 @@
-$schema: https://main-fmu-schemas-dev.radix.equinor.com/schemas/0.14.0/fmu_results.json
+$schema: https://main-fmu-schemas-prod.radix.equinor.com/schemas/0.16.1/fmu_results.json
 _preprocessed: false
 access:
   asset:
@@ -106,6 +106,8 @@ tracklog:
   sysinfo:
     fmu-dataio:
       version: dummy_version
+    komodo:
+      version: dummy_version
     operating_system:
       hostname: dummy_hostname
       operating_system: dummy_os
@@ -114,4 +116,4 @@ tracklog:
       version: dummy_version
   user:
     id: user
-version: 0.14.0
+version: 0.16.1

--- a/examples/example_metadata/surface_seismic_amplitude.yml
+++ b/examples/example_metadata/surface_seismic_amplitude.yml
@@ -1,4 +1,4 @@
-$schema: https://main-fmu-schemas-dev.radix.equinor.com/schemas/0.14.0/fmu_results.json
+$schema: https://main-fmu-schemas-prod.radix.equinor.com/schemas/0.16.1/fmu_results.json
 _preprocessed: false
 access:
   asset:
@@ -124,6 +124,8 @@ tracklog:
   sysinfo:
     fmu-dataio:
       version: dummy_version
+    komodo:
+      version: dummy_version
     operating_system:
       hostname: dummy_hostname
       operating_system: dummy_os
@@ -132,4 +134,4 @@ tracklog:
       version: dummy_version
   user:
     id: user
-version: 0.14.0
+version: 0.16.1

--- a/examples/example_metadata/table_inplace_volumes.yml
+++ b/examples/example_metadata/table_inplace_volumes.yml
@@ -1,4 +1,4 @@
-$schema: https://main-fmu-schemas-dev.radix.equinor.com/schemas/0.14.0/fmu_results.json
+$schema: https://main-fmu-schemas-prod.radix.equinor.com/schemas/0.16.1/fmu_results.json
 _preprocessed: false
 access:
   asset:
@@ -52,10 +52,10 @@ display:
   name: geogrid
 file:
   absolute_path: /some/absolute/path/
-  checksum_md5: 173c646133f5a47c9bfbc4432a0a2812
+  checksum_md5: 0cb778f91e6074c471b4bbce1f919165
   relative_path: example_exports/share/results/tables/geogrid--volumes.csv
   runpath_relative_path: share/results/tables/geogrid--volumes.csv
-  size_bytes: 3921
+  size_bytes: 3911
 fmu:
   case:
     name: MyCase
@@ -111,6 +111,8 @@ tracklog:
   sysinfo:
     fmu-dataio:
       version: dummy_version
+    komodo:
+      version: dummy_version
     operating_system:
       hostname: dummy_hostname
       operating_system: dummy_os
@@ -119,4 +121,4 @@ tracklog:
       version: dummy_version
   user:
     id: user
-version: 0.14.0
+version: 0.16.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     "fmu-config>=1.1.0",
-    "fmu-datamodels~=0.16.0",
+    "fmu-datamodels~=0.17.0",
     "numpy",
     "pandas",
     "pyarrow",

--- a/src/fmu/dataio/_metadata.py
+++ b/src/fmu/dataio/_metadata.py
@@ -15,6 +15,9 @@ from typing import TYPE_CHECKING, Final
 from pydantic import Field
 
 from fmu.dataio.version import __version__
+from fmu.datamodels.common.access import Asset, Ssdl, SsdlAccess
+from fmu.datamodels.common.masterdata import Masterdata
+from fmu.datamodels.common.tracklog import Tracklog
 from fmu.datamodels.fmu_results import data, fields
 from fmu.datamodels.fmu_results.fmu_results import (
     ObjectMetadata,
@@ -41,8 +44,8 @@ class ObjectMetadataExport(ObjectMetadata, populate_by_name=True):
 
     # These type ignores are for making the field optional
     fmu: fields.FMU | None  # type: ignore
-    access: fields.SsdlAccess | None  # type: ignore
-    masterdata: fields.Masterdata | None  # type: ignore
+    access: SsdlAccess | None  # type: ignore
+    masterdata: Masterdata | None  # type: ignore
     # !! Keep UnsetData first in this union
     data: UnsetData | data.AnyData  # type: ignore
     preprocessed: bool | None = Field(alias="_preprocessed", default=None)
@@ -62,15 +65,15 @@ def _get_meta_fmu(fmudata: FmuProvider) -> fields.FMU | None:
         return None
 
 
-def _get_meta_access(dataio: ExportData) -> fields.SsdlAccess:
-    return fields.SsdlAccess(
+def _get_meta_access(dataio: ExportData) -> SsdlAccess:
+    return SsdlAccess(
         asset=(
             dataio.config.access.asset
             if isinstance(dataio.config, GlobalConfiguration)
-            else fields.Asset(name="")
+            else Asset(name="")
         ),
         classification=dataio._classification,
-        ssdl=fields.Ssdl(
+        ssdl=Ssdl(
             access_level=dataio._classification,
             rep_include=dataio._rep_include,
         ),
@@ -126,7 +129,7 @@ def generate_export_metadata(
         access=_get_meta_access(dataio),
         data=objdata.get_metadata(),
         file=_get_meta_filedata(dataio._runcontext, objdata),
-        tracklog=fields.Tracklog.initialize(__version__),
+        tracklog=Tracklog.initialize(__version__),
         display=_get_meta_display(dataio, objdata),
         preprocessed=dataio.preprocessed,
     )

--- a/src/fmu/dataio/aggregation.py
+++ b/src/fmu/dataio/aggregation.py
@@ -10,8 +10,8 @@ from pydantic import ValidationError
 
 from fmu.dataio import types
 from fmu.dataio.version import __version__
+from fmu.datamodels.common.tracklog import Tracklog
 from fmu.datamodels.fmu_results.enums import FMUContext
-from fmu.datamodels.fmu_results.fields import Tracklog
 
 from . import _utils, dataio
 from ._logging import null_logger

--- a/src/fmu/dataio/case.py
+++ b/src/fmu/dataio/case.py
@@ -10,6 +10,9 @@ from typing import Final
 from pydantic import ValidationError
 
 from fmu.dataio.version import __version__
+from fmu.datamodels.common.access import Access
+from fmu.datamodels.common.masterdata import Masterdata
+from fmu.datamodels.common.tracklog import Tracklog, User
 from fmu.datamodels.fmu_results import enums, fields, global_configuration
 from fmu.datamodels.fmu_results.fmu_results import CaseMetadata
 
@@ -124,8 +127,8 @@ class CreateCaseMetadata:
 
         self._metadata = CaseMetadata(  # type: ignore[call-arg]
             class_=enums.FMUResultsMetadataClass.case,
-            masterdata=fields.Masterdata.model_validate(self.config["masterdata"]),
-            access=fields.Access.model_validate(self.config["access"]),
+            masterdata=Masterdata.model_validate(self.config["masterdata"]),
+            access=Access.model_validate(self.config["access"]),
             fmu=fields.FMUBase(
                 model=fields.Model.model_validate(
                     self.config["model"],
@@ -133,11 +136,11 @@ class CreateCaseMetadata:
                 case=fields.Case(
                     name=self.casename,
                     uuid=self._case_uuid(),
-                    user=fields.User(id=getpass.getuser()),
+                    user=User(id=getpass.getuser()),
                     description=None,
                 ),
             ),
-            tracklog=fields.Tracklog.initialize(__version__),
+            tracklog=Tracklog.initialize(__version__),
         ).model_dump(
             mode="json",
             exclude_none=True,

--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Final, Literal
 from warnings import warn
 
 from fmu.dataio.aggregation import AggregatedData
+from fmu.datamodels.common.enums import Classification
 from fmu.datamodels.fmu_results import enums, global_configuration
 from fmu.datamodels.fmu_results.global_configuration import GlobalConfiguration
 
@@ -265,7 +266,7 @@ class ExportData:
     are validated against a current list of them. In the following enumeration you would
     use **only** the string values of the classification type.
 
-    .. autoclass:: fmu.datamodels.fmu_results.enums.Classification
+    .. autoclass:: fmu.datamodels.common.enums.Classification
        :members:
        :exclude-members: __new__
        :no-index:
@@ -599,7 +600,7 @@ class ExportData:
     #
     # ----------------------------------------------------------------------------------
 
-    _classification: enums.Classification = enums.Classification.internal
+    _classification: Classification = Classification.internal
     _rep_include: bool = field(default=False, init=False)
 
     def __post_init__(self) -> None:
@@ -648,7 +649,7 @@ class ExportData:
         casepath_proposed = Path(self.casepath) if self.casepath else None
         return RunContext(casepath_proposed, fmu_context=self.fmu_context)
 
-    def _get_classification(self) -> enums.Classification:
+    def _get_classification(self) -> Classification:
         """
         Get the security classification.
         The order of how the classification is set is:
@@ -674,17 +675,17 @@ class ExportData:
             # note the one below here will never be used, because that
             # means the config is invalid and no metadata will be produced
             logger.info("Using default classification 'internal'")
-            classification = enums.Classification.internal
+            classification = Classification.internal
 
-        if enums.Classification(classification) == enums.Classification.asset:
+        if Classification(classification) == Classification.asset:
             warnings.warn(
                 "The value 'asset' for access.ssdl.access_level is deprecated. "
                 "Please use 'restricted' in input arguments or global variables "
                 "to silence this warning.",
                 FutureWarning,
             )
-            return enums.Classification.restricted
-        return enums.Classification(classification)
+            return Classification.restricted
+        return Classification(classification)
 
     def _get_rep_include(self) -> bool:
         """

--- a/src/fmu/dataio/export/_base.py
+++ b/src/fmu/dataio/export/_base.py
@@ -15,8 +15,9 @@ from fmu.datamodels.fmu_results.global_configuration import GlobalConfiguration
 
 if TYPE_CHECKING:
     from fmu.dataio.export._export_result import ExportResult
-    from fmu.datamodels.fmu_results.enums import Classification
     from fmu.datamodels.fmu_results.standard_result import StandardResult
+
+from fmu.datamodels.common.enums import Classification
 
 logger: Final = null_logger(__name__)
 

--- a/src/fmu/dataio/export/rms/field_outline.py
+++ b/src/fmu/dataio/export/rms/field_outline.py
@@ -12,8 +12,8 @@ from fmu.dataio.export._decorators import experimental
 from fmu.dataio.export._export_result import ExportResult, ExportResultItem
 from fmu.dataio.export.rms._base import SimpleExportRMSBase
 from fmu.dataio.export.rms._utils import get_open_polygons_id
+from fmu.datamodels.common.enums import Classification
 from fmu.datamodels.fmu_results.enums import (
-    Classification,
     Content,
     DomainReference,
     FluidContactType,

--- a/src/fmu/dataio/export/rms/fluid_contact_outlines.py
+++ b/src/fmu/dataio/export/rms/fluid_contact_outlines.py
@@ -15,9 +15,9 @@ from fmu.dataio.export.rms._utils import (
     list_folder_names_in_general2d_folder,
     validate_name_in_stratigraphy,
 )
+from fmu.datamodels.common.enums import Classification
 from fmu.datamodels.fmu_results import standard_result
 from fmu.datamodels.fmu_results.enums import (
-    Classification,
     Content,
     DomainReference,
     FluidContactType,

--- a/src/fmu/dataio/export/rms/fluid_contact_surfaces.py
+++ b/src/fmu/dataio/export/rms/fluid_contact_surfaces.py
@@ -15,9 +15,9 @@ from fmu.dataio.export.rms._utils import (
     list_folder_names_in_general2d_folder,
     validate_name_in_stratigraphy,
 )
+from fmu.datamodels.common.enums import Classification
 from fmu.datamodels.fmu_results import standard_result
 from fmu.datamodels.fmu_results.enums import (
-    Classification,
     Content,
     DomainReference,
     FluidContactType,

--- a/src/fmu/dataio/export/rms/inplace_volumes.py
+++ b/src/fmu/dataio/export/rms/inplace_volumes.py
@@ -19,9 +19,9 @@ from fmu.dataio.export.rms._utils import (
     get_rms_project_units,
 )
 from fmu.datamodels import InplaceVolumesResult
+from fmu.datamodels.common.enums import Classification
 from fmu.datamodels.fmu_results import standard_result
 from fmu.datamodels.fmu_results.enums import (
-    Classification,
     Content,
     DomainReference,
     VerticalDomain,

--- a/src/fmu/dataio/export/rms/structure_depth_fault_lines.py
+++ b/src/fmu/dataio/export/rms/structure_depth_fault_lines.py
@@ -15,8 +15,8 @@ from fmu.dataio.export.rms._utils import (
     get_rms_project_units,
     validate_name_in_stratigraphy,
 )
+from fmu.datamodels.common.enums import Classification
 from fmu.datamodels.fmu_results.enums import (
-    Classification,
     Content,
     DomainReference,
     VerticalDomain,

--- a/src/fmu/dataio/export/rms/structure_depth_fault_surfaces.py
+++ b/src/fmu/dataio/export/rms/structure_depth_fault_surfaces.py
@@ -19,8 +19,8 @@ from fmu.dataio.export.rms._base import SimpleExportRMSBase
 from fmu.dataio.export.rms._utils import (
     get_rms_project_units,
 )
+from fmu.datamodels.common.enums import Classification
 from fmu.datamodels.fmu_results.enums import (
-    Classification,
     Content,
     DomainReference,
     VerticalDomain,

--- a/src/fmu/dataio/export/rms/structure_depth_isochores.py
+++ b/src/fmu/dataio/export/rms/structure_depth_isochores.py
@@ -14,9 +14,9 @@ from fmu.dataio.export.rms._utils import (
     get_zones_in_folder,
     validate_name_in_stratigraphy,
 )
+from fmu.datamodels.common.enums import Classification
 from fmu.datamodels.fmu_results import standard_result
 from fmu.datamodels.fmu_results.enums import (
-    Classification,
     Content,
     DomainReference,
     VerticalDomain,

--- a/src/fmu/dataio/export/rms/structure_depth_surfaces.py
+++ b/src/fmu/dataio/export/rms/structure_depth_surfaces.py
@@ -13,9 +13,9 @@ from fmu.dataio.export.rms._utils import (
     get_rms_project_units,
     validate_name_in_stratigraphy,
 )
+from fmu.datamodels.common.enums import Classification
 from fmu.datamodels.fmu_results import standard_result
 from fmu.datamodels.fmu_results.enums import (
-    Classification,
     Content,
     DomainReference,
     VerticalDomain,

--- a/src/fmu/dataio/export/rms/structure_time_surfaces.py
+++ b/src/fmu/dataio/export/rms/structure_time_surfaces.py
@@ -13,9 +13,9 @@ from fmu.dataio.export.rms._utils import (
     get_rms_project_units,
     validate_name_in_stratigraphy,
 )
+from fmu.datamodels.common.enums import Classification
 from fmu.datamodels.fmu_results import standard_result
 from fmu.datamodels.fmu_results.enums import (
-    Classification,
     Content,
     DomainReference,
     VerticalDomain,

--- a/src/fmu/dataio/preprocessed.py
+++ b/src/fmu/dataio/preprocessed.py
@@ -9,7 +9,7 @@ import yaml
 from pydantic import ValidationError
 
 from fmu.dataio.version import __version__
-from fmu.datamodels.fmu_results import enums
+from fmu.datamodels.common.enums import TrackLogEventType
 from fmu.datamodels.fmu_results.enums import FMUContext
 from fmu.datamodels.fmu_results.fields import File
 
@@ -183,9 +183,7 @@ class ExportPreprocessedData:
             # TODO: Would like to use meta.Root.model_validate() here
             # but then the '$schema' field is dropped from the meta_existing
             validated_metadata = ObjectMetadataExport.model_validate(meta_existing)
-            validated_metadata.tracklog.append(
-                enums.TrackLogEventType.merged, __version__
-            )
+            validated_metadata.tracklog.append(TrackLogEventType.merged, __version__)
             return validated_metadata.model_dump(
                 mode="json", exclude_none=True, by_alias=True
             )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,15 @@ import pytest
 import xtgeo
 import yaml
 from fmu.config import utilities as ut
+from fmu.datamodels.common.access import Asset
+from fmu.datamodels.common.masterdata import (
+    CoordinateSystem,
+    CountryItem,
+    DiscoveryItem,
+    Masterdata,
+    Smda,
+    StratigraphicColumn,
+)
 from fmu.datamodels.fmu_results import FmuResults, fields, global_configuration
 from pydantic import BaseModel
 from pytest import MonkeyPatch
@@ -339,25 +348,25 @@ def casesetup(tmp_path_factory: pytest.TempPathFactory) -> Path:
 def mock_global_config() -> dict[str, Any]:
     """Minimalistic global config variables no. 1 in ExportData class."""
     return global_configuration.GlobalConfiguration(
-        masterdata=fields.Masterdata(
-            smda=fields.Smda(
-                coordinate_system=fields.CoordinateSystem(
+        masterdata=Masterdata(
+            smda=Smda(
+                coordinate_system=CoordinateSystem(
                     identifier="ST_WGS84_UTM37N_P32637",
                     uuid=uuid.UUID("15ce3b84-766f-4c93-9050-b154861f9100"),
                 ),
                 country=[
-                    fields.CountryItem(
+                    CountryItem(
                         identifier="Norway",
                         uuid=uuid.UUID("ad214d85-8a1d-19da-e053-c918a4889309"),
                     ),
                 ],
                 discovery=[
-                    fields.DiscoveryItem(
+                    DiscoveryItem(
                         short_identifier="abdcef",
                         uuid=uuid.UUID("56c92484-8798-4f1f-9f14-d237a3e1a4ff"),
                     ),
                 ],
-                stratigraphic_column=fields.StratigraphicColumn(
+                stratigraphic_column=StratigraphicColumn(
                     identifier="TestStratigraphicColumn",
                     uuid=uuid.UUID("56c92484-8798-4f1f-9f14-d237a3e1a4ff"),
                 ),
@@ -365,8 +374,8 @@ def mock_global_config() -> dict[str, Any]:
             )
         ),
         access=global_configuration.Access(
-            asset=fields.Asset(name="Test"),
-            classification=global_configuration.enums.Classification.internal,
+            asset=Asset(name="Test"),
+            classification=global_configuration.Classification.internal,
         ),
         model=fields.Model(
             name="Test",

--- a/tests/test_units/test_metadata_class.py
+++ b/tests/test_units/test_metadata_class.py
@@ -6,11 +6,12 @@ from typing import Any
 
 import pytest
 import xtgeo
-from fmu.datamodels.fmu_results import FmuResultsSchema, enums
-from fmu.datamodels.fmu_results.fields import (
+from fmu.datamodels.common.enums import TrackLogEventType
+from fmu.datamodels.common.tracklog import (
     OperatingSystem,
     TracklogEvent,
 )
+from fmu.datamodels.fmu_results import FmuResultsSchema
 from pytest import MonkeyPatch
 
 import fmu.dataio as dio
@@ -61,10 +62,10 @@ def test_generate_meta_tracklog_fmu_dataio_version(
     tracklog = mymeta.tracklog
 
     assert isinstance(tracklog.root, list)
-    assert len(tracklog.root) == 1  # assume enums.TrackLogEventType.created
+    assert len(tracklog.root) == 1  # assume TrackLogEventType.created
 
     parsed = TracklogEvent.model_validate(tracklog[0])
-    assert parsed.event == enums.TrackLogEventType.created
+    assert parsed.event == TrackLogEventType.created
 
     # datetime in tracklog shall include time zone offset
     assert parsed.datetime.tzinfo is not None
@@ -90,10 +91,10 @@ def test_generate_meta_tracklog_komodo_version(
     tracklog = mymeta.tracklog
 
     assert isinstance(tracklog.root, list)
-    assert len(tracklog.root) == 1  # assume enums.TrackLogEventType.created
+    assert len(tracklog.root) == 1  # assume TrackLogEventType.created
 
     parsed = TracklogEvent.model_validate(tracklog[0])
-    assert parsed.event == enums.TrackLogEventType.created
+    assert parsed.event == TrackLogEventType.created
 
     # datetime in tracklog shall include time zone offset
     assert parsed.datetime.tzinfo is not None
@@ -163,7 +164,7 @@ def test_generate_meta_tracklog_operating_system(
     tracklog = mymeta.tracklog
 
     assert isinstance(tracklog.root, list)
-    assert len(tracklog.root) == 1  # assume enums.TrackLogEventType.created
+    assert len(tracklog.root) == 1  # assume TrackLogEventType.created
 
     parsed = TracklogEvent.model_validate(tracklog[0])
     assert isinstance(

--- a/tests/test_units/test_utils.py
+++ b/tests/test_units/test_utils.py
@@ -6,6 +6,8 @@ from tempfile import NamedTemporaryFile
 
 import numpy as np
 import pytest
+from fmu.datamodels.common.access import Access
+from fmu.datamodels.common.tracklog import Tracklog
 from fmu.datamodels.fmu_results import fields
 from xtgeo import Grid, Polygons, RegularSurface
 
@@ -141,27 +143,27 @@ def test_read_named_envvar() -> None:
     assert utils.read_named_envvar("MYTESTENV") == "mytestvalue"
 
 
-def test_get_pydantic_models_from_annotation() -> None:
-    annotation = list[fields.Access] | fields.File
+def test_get_pydantic_models_from_annotation():
+    annotation = list[Access] | fields.File
     assert _get_pydantic_models_from_annotation(annotation) == [
-        fields.Access,
+        Access,
         fields.File,
     ]
-    annotation = dict[str, fields.Access] | list[fields.File] | None
+    annotation = dict[str, Access] | list[fields.File] | None
     assert _get_pydantic_models_from_annotation(annotation) == [
-        fields.Access,
+        Access,
         fields.File,
     ]
 
-    annotation = list[fields.Access | fields.File | fields.Tracklog]
+    annotation = list[Access | fields.File | Tracklog]
     assert _get_pydantic_models_from_annotation(annotation) == [
-        fields.Access,
+        Access,
         fields.File,
-        fields.Tracklog,
+        Tracklog,
     ]
 
-    annotation = list[list[list[list[fields.Tracklog]]]]
-    assert _get_pydantic_models_from_annotation(annotation) == [fields.Tracklog]
+    annotation = list[list[list[list[Tracklog]]]]
+    assert _get_pydantic_models_from_annotation(annotation) == [Tracklog]
 
     annotation = str | list[int] | dict[str, int]
     assert not _get_pydantic_models_from_annotation(annotation)


### PR DESCRIPTION
Part of resolving issue 87 in fmu-datamodels

Fixed dependencies in fmu-dataio related to grouping of all shared models in fmu-datamodels into a separate directory. 

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
