### PR TITLE
FIX: replace enum 'faultroom_triangulated' by 'triangulated'

### DIFF
--- a/src/fmu/dataio/providers/objectdata/_faultroom.py
+++ b/src/fmu/dataio/providers/objectdata/_faultroom.py
@@ -49,7 +49,7 @@ class FaultRoomSurfaceProvider(ObjectDataProvider):
 
     @property
     def layout(self) -> Layout:
-        return Layout.faultroom_triangulated
+        return Layout.triangulated
 
     @property
     def table_index(self) -> None:

--- a/tests/test_units/test_objectdataprovider_class.py
+++ b/tests/test_units/test_objectdataprovider_class.py
@@ -65,7 +65,7 @@ def test_objectdata_faultroom_fault_juxtaposition_get_stratigraphy_differ(
     assert isinstance(objdata, FaultRoomSurfaceProvider)
 
     assert objdata.extension == ".json"
-    assert objdata.layout == "faultroom_triangulated"
+    assert objdata.layout == "triangulated"
 
     bbox = objdata.get_bbox()
     assert bbox.xmin == 1.1


### PR DESCRIPTION
Resolves #1424 

`faultroom_triangulated` is removed as an option for `data.Layout` in the schema, see https://github.com/equinor/fmu-datamodels/issues/37.

Here we perform the corresponding updates in `fmu-dataio`, by replacing `faultroom_triangulated` with `triangulated`.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
