### PR TITLE
TST: Rename mock global config fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -336,7 +336,7 @@ def casesetup(tmp_path_factory: pytest.TempPathFactory) -> Path:
 
 
 @pytest.fixture(scope="function")
-def globalconfig1() -> dict[str, Any]:
+def mock_global_config() -> dict[str, Any]:
     """Minimalistic global config variables no. 1 in ExportData class."""
     return global_configuration.GlobalConfiguration(
         masterdata=fields.Masterdata(
@@ -386,7 +386,7 @@ def globalconfig1() -> dict[str, Any]:
 
 @pytest.fixture(scope="function")
 def edataobj1(
-    globalconfig1: Any, tmp_path: Path, monkeypatch: MonkeyPatch
+    mock_global_config: dict[str, Any], tmp_path: Path, monkeypatch: MonkeyPatch
 ) -> ExportData:
     """Combined globalconfig and settings to instance, for internal testing"""
     logger.debug("Establish edataobj1")
@@ -394,7 +394,7 @@ def edataobj1(
     monkeypatch.chdir(tmp_path)
 
     eobj = dio.ExportData(
-        config=globalconfig1,
+        config=mock_global_config,
         name="TopWhatever",
         content="depth",
         tagname="mytag",
@@ -793,11 +793,11 @@ def aggr_surfs_mean(
 
 
 @pytest.fixture()
-def edataobj3(globalconfig1: dict[str, Any]) -> ExportData:
+def edataobj3(mock_global_config: dict[str, Any]) -> ExportData:
     """Combined globalconfig and settings to instance, for internal testing"""
 
     return ExportData(
-        config=globalconfig1,
+        config=mock_global_config,
         name="summary",
         content="simulationtimeseries",
         tagname="",
@@ -805,11 +805,11 @@ def edataobj3(globalconfig1: dict[str, Any]) -> ExportData:
 
 
 @pytest.fixture
-def export_data_obj_timeseries(globalconfig1: dict[str, Any]) -> ExportData:
+def export_data_obj_timeseries(mock_global_config: dict[str, Any]) -> ExportData:
     """Combined globalconfig and settings to instance, for internal testing"""
 
     return ExportData(
-        config=globalconfig1,
+        config=mock_global_config,
         name="some timeseries",
         content="timeseries",
         tagname="",

--- a/tests/test_export_rms/test_export_fluid_contact_outlines.py
+++ b/tests/test_export_rms/test_export_fluid_contact_outlines.py
@@ -213,18 +213,19 @@ def test_unknown_name_in_stratigraphy_raises(
 def test_stratigraphy_missing_raises(
     mock_project_variable: MagicMock,
     mock_export_class: _ExportFluidContactOutlines,
-    globalconfig1: dict[str, Any],
+    mock_global_config: dict[str, Any],
 ) -> None:
     """Test that an error is raised if stratigraphy is missing from the config"""
 
     from fmu.dataio.export.rms import export_fluid_contact_outlines
 
     # remove the stratigraphy block
-    del globalconfig1["stratigraphy"]
+    del mock_global_config["stratigraphy"]
 
     with (
         mock.patch(
-            "fmu.dataio.export._base.load_config_from_path", return_value=globalconfig1
+            "fmu.dataio.export._base.load_config_from_path",
+            return_value=mock_global_config,
         ),
         pytest.raises(ValueError, match=r"stratigraphy.*is lacking"),
     ):

--- a/tests/test_export_rms/test_export_fluid_contact_surfaces.py
+++ b/tests/test_export_rms/test_export_fluid_contact_surfaces.py
@@ -197,18 +197,19 @@ def test_unknown_name_in_stratigraphy_raises(
 def test_stratigraphy_missing_raises(
     mock_project_variable: MagicMock,
     mock_export_class: _ExportFluidContactSurfaces,
-    globalconfig1: dict[str, Any],
+    mock_global_config: dict[str, Any],
 ) -> None:
     """Test that an error is raised if stratigraphy is missing from the config"""
 
     from fmu.dataio.export.rms import export_fluid_contact_surfaces
 
     # remove the stratigraphy block
-    del globalconfig1["stratigraphy"]
+    del mock_global_config["stratigraphy"]
 
     with (
         mock.patch(
-            "fmu.dataio.export._base.load_config_from_path", return_value=globalconfig1
+            "fmu.dataio.export._base.load_config_from_path",
+            return_value=mock_global_config,
         ),
         pytest.raises(ValueError, match=r"stratigraphy.*is lacking"),
     ):

--- a/tests/test_export_rms/test_export_structure_depth_fault_lines.py
+++ b/tests/test_export_rms/test_export_structure_depth_fault_lines.py
@@ -166,18 +166,19 @@ def test_unknown_name_in_stratigraphy_raises(
 def test_stratigraphy_missing_raises(
     mock_project_variable: MagicMock,
     mock_export_class: _ExportStructureDepthFaultLines,
-    globalconfig1: dict[str, Any],
+    mock_global_config: dict[str, Any],
 ) -> None:
     """Test that an error is raised if stratigraphy is missing from the config"""
 
     from fmu.dataio.export.rms import export_structure_depth_fault_lines
 
     # remove the stratigraphy block
-    del globalconfig1["stratigraphy"]
+    del mock_global_config["stratigraphy"]
 
     with (
         mock.patch(
-            "fmu.dataio.export._base.load_config_from_path", return_value=globalconfig1
+            "fmu.dataio.export._base.load_config_from_path",
+            return_value=mock_global_config,
         ),
         pytest.warns(UserWarning, match="is experimental and may change in future"),
         pytest.raises(ValueError, match=r"stratigraphy.*is lacking"),

--- a/tests/test_export_rms/test_export_structure_depth_isochores.py
+++ b/tests/test_export_rms/test_export_structure_depth_isochores.py
@@ -124,18 +124,19 @@ def test_unknown_name_in_stratigraphy_raises(
 def test_stratigraphy_missing_raises(
     mock_project_variable: MagicMock,
     mock_export_class: _ExportStructureDepthIsochores,
-    globalconfig1: dict[str, Any],
+    mock_global_config: dict[str, Any],
 ) -> None:
     """Test that an error is raised if stratigraphy is missing from the config"""
 
     from fmu.dataio.export.rms import export_structure_depth_isochores
 
     # remove the stratigraphy block
-    del globalconfig1["stratigraphy"]
+    del mock_global_config["stratigraphy"]
 
     with (
         mock.patch(
-            "fmu.dataio.export._base.load_config_from_path", return_value=globalconfig1
+            "fmu.dataio.export._base.load_config_from_path",
+            return_value=mock_global_config,
         ),
         pytest.raises(ValueError, match=r"stratigraphy.*is lacking"),
     ):

--- a/tests/test_export_rms/test_export_structure_depth_surfaces.py
+++ b/tests/test_export_rms/test_export_structure_depth_surfaces.py
@@ -150,18 +150,19 @@ def test_unknown_name_in_stratigraphy_raises(
 def test_stratigraphy_missing_raises(
     mock_project_variable: MagicMock,
     mock_export_class: _ExportStructureDepthSurfaces,
-    globalconfig1: dict[str, Any],
+    mock_global_config: dict[str, Any],
 ) -> None:
     """Test that an error is raised if stratigraphy is missing from the config"""
 
     from fmu.dataio.export.rms import export_structure_depth_surfaces
 
     # remove the stratigraphy block
-    del globalconfig1["stratigraphy"]
+    del mock_global_config["stratigraphy"]
 
     with (
         mock.patch(
-            "fmu.dataio.export._base.load_config_from_path", return_value=globalconfig1
+            "fmu.dataio.export._base.load_config_from_path",
+            return_value=mock_global_config,
         ),
         pytest.raises(ValueError, match=r"stratigraphy.*is lacking"),
     ):

--- a/tests/test_export_rms/test_export_structure_time_surfaces.py
+++ b/tests/test_export_rms/test_export_structure_time_surfaces.py
@@ -123,18 +123,19 @@ def test_unknown_name_in_stratigraphy_raises(
 def test_stratigraphy_missing_raises(
     mock_project_variable: MagicMock,
     mock_export_class: _ExportStructureTimeSurfaces,
-    globalconfig1: dict[str, Any],
+    mock_global_config: dict[str, Any],
 ) -> None:
     """Test that an error is raised if stratigraphy is missing from the config"""
 
     from fmu.dataio.export.rms import export_structure_time_surfaces
 
     # remove the stratigraphy block
-    del globalconfig1["stratigraphy"]
+    del mock_global_config["stratigraphy"]
 
     with (
         mock.patch(
-            "fmu.dataio.export._base.load_config_from_path", return_value=globalconfig1
+            "fmu.dataio.export._base.load_config_from_path",
+            return_value=mock_global_config,
         ),
         pytest.raises(ValueError, match=r"stratigraphy.*is lacking"),
     ):

--- a/tests/test_export_rms/test_simpleexport_class.py
+++ b/tests/test_export_rms/test_simpleexport_class.py
@@ -6,14 +6,14 @@ from fmu.datamodels.fmu_results.global_configuration import GlobalConfiguration
 from fmu.dataio.export._base import SimpleExportBase
 
 
-def test_validate_global_config_invalid(globalconfig1: dict[str, Any]) -> None:
-    invalid_config = globalconfig1.copy()
+def test_validate_global_config_invalid(mock_global_config: dict[str, Any]) -> None:
+    invalid_config = mock_global_config.copy()
     invalid_config.pop("masterdata")
 
     with pytest.raises(ValueError, match="valid config"):
         SimpleExportBase._validate_global_config(invalid_config)
 
 
-def test_validate_global_config(globalconfig1: dict[str, Any]) -> None:
-    config = SimpleExportBase._validate_global_config(globalconfig1)
+def test_validate_global_config(mock_global_config: dict[str, Any]) -> None:
+    config = SimpleExportBase._validate_global_config(mock_global_config)
     assert isinstance(config, GlobalConfiguration)

--- a/tests/test_units/test_checksum_md5.py
+++ b/tests/test_units/test_checksum_md5.py
@@ -14,7 +14,7 @@ from fmu.dataio.dataio import ExportData, read_metadata
 def test_checksum_md5_for_regsurf(
     monkeypatch: MonkeyPatch,
     tmp_path: Path,
-    globalconfig1: dict[str, Any],
+    mock_global_config: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
 ) -> None:
     """
@@ -25,7 +25,7 @@ def test_checksum_md5_for_regsurf(
 
     export_path = Path(
         ExportData(
-            config=globalconfig1,
+            config=mock_global_config,
             content="depth",
             name="myname",
         ).export(regsurf)
@@ -38,7 +38,7 @@ def test_checksum_md5_for_regsurf(
 def test_checksum_md5_for_gridproperty(
     monkeypatch: MonkeyPatch,
     tmp_path: Path,
-    globalconfig1: dict[str, Any],
+    mock_global_config: dict[str, Any],
     gridproperty: xtgeo.GridProperty,
 ) -> None:
     """
@@ -49,7 +49,7 @@ def test_checksum_md5_for_gridproperty(
 
     export_path = Path(
         ExportData(
-            config=globalconfig1,
+            config=mock_global_config,
             content="depth",
             name="myname",
         ).export(gridproperty)
@@ -62,7 +62,7 @@ def test_checksum_md5_for_gridproperty(
 def test_checksum_md5_for_grid(
     monkeypatch: MonkeyPatch,
     tmp_path: Path,
-    globalconfig1: dict[str, Any],
+    mock_global_config: dict[str, Any],
     grid: xtgeo.Grid,
 ) -> None:
     """
@@ -73,7 +73,7 @@ def test_checksum_md5_for_grid(
 
     export_path = Path(
         ExportData(
-            config=globalconfig1,
+            config=mock_global_config,
             content="depth",
             name="myname",
         ).export(grid)
@@ -86,7 +86,7 @@ def test_checksum_md5_for_grid(
 def test_checksum_md5_for_points(
     monkeypatch: MonkeyPatch,
     tmp_path: Path,
-    globalconfig1: dict[str, Any],
+    mock_global_config: dict[str, Any],
     points: xtgeo.Points,
 ) -> None:
     """
@@ -97,7 +97,7 @@ def test_checksum_md5_for_points(
 
     export_path = Path(
         ExportData(
-            config=globalconfig1,
+            config=mock_global_config,
             content="depth",
             name="myname",
         ).export(points)
@@ -110,7 +110,7 @@ def test_checksum_md5_for_points(
 def test_checksum_md5_for_polygons(
     monkeypatch: MonkeyPatch,
     tmp_path: Path,
-    globalconfig1: dict[str, Any],
+    mock_global_config: dict[str, Any],
     polygons: xtgeo.Polygons,
 ) -> None:
     """
@@ -121,7 +121,7 @@ def test_checksum_md5_for_polygons(
 
     export_path = Path(
         ExportData(
-            config=globalconfig1,
+            config=mock_global_config,
             content="depth",
             name="myname",
         ).export(polygons)
@@ -134,7 +134,7 @@ def test_checksum_md5_for_polygons(
 def test_checksum_md5_for_cube(
     monkeypatch: MonkeyPatch,
     tmp_path: Path,
-    globalconfig1: dict[str, Any],
+    mock_global_config: dict[str, Any],
     cube: xtgeo.Cube,
 ) -> None:
     """
@@ -145,7 +145,7 @@ def test_checksum_md5_for_cube(
 
     export_path = Path(
         ExportData(
-            config=globalconfig1,
+            config=mock_global_config,
             content="depth",
             name="myname",
         ).export(cube)
@@ -158,7 +158,7 @@ def test_checksum_md5_for_cube(
 def test_checksum_md5_for_dataframe(
     monkeypatch: MonkeyPatch,
     tmp_path: Path,
-    globalconfig1: dict[str, Any],
+    mock_global_config: dict[str, Any],
     dataframe: pd.DataFrame,
 ) -> None:
     """
@@ -169,7 +169,7 @@ def test_checksum_md5_for_dataframe(
 
     export_path = Path(
         ExportData(
-            config=globalconfig1,
+            config=mock_global_config,
             content="depth",
             name="myname",
         ).export(dataframe)
@@ -182,7 +182,7 @@ def test_checksum_md5_for_dataframe(
 def test_checksum_md5_for_arrowtable(
     monkeypatch: MonkeyPatch,
     tmp_path: Path,
-    globalconfig1: dict[str, Any],
+    mock_global_config: dict[str, Any],
     arrowtable: pa.Table,
 ) -> None:
     """
@@ -193,7 +193,7 @@ def test_checksum_md5_for_arrowtable(
 
     export_path = Path(
         ExportData(
-            config=globalconfig1,
+            config=mock_global_config,
             content="depth",
             name="myname",
         ).export(arrowtable)
@@ -204,7 +204,7 @@ def test_checksum_md5_for_arrowtable(
 
 
 def test_checksum_md5_for_dictionary(
-    monkeypatch: MonkeyPatch, tmp_path: Path, globalconfig1: dict[str, Any]
+    monkeypatch: MonkeyPatch, tmp_path: Path, mock_global_config: dict[str, Any]
 ) -> None:
     """
     Test that the MD5 hash in the metadata is equal to one computed for
@@ -216,7 +216,7 @@ def test_checksum_md5_for_dictionary(
 
     export_path = Path(
         ExportData(
-            config=globalconfig1,
+            config=mock_global_config,
             content="depth",
             name="myname",
         ).export(mydict)

--- a/tests/test_units/test_dataio.py
+++ b/tests/test_units/test_dataio.py
@@ -31,16 +31,16 @@ from fmu.dataio.providers._fmu import ERT_RELATIVE_CASE_METADATA_FILE
 logger = logging.getLogger(__name__)
 
 
-def test_generate_metadata_simple(globalconfig1: dict[str, Any]) -> None:
+def test_generate_metadata_simple(mock_global_config: dict[str, Any]) -> None:
     """Test generating metadata"""
 
     default_fformat = ExportData.grid_fformat
     ExportData.grid_fformat = "grdecl"
 
-    logger.info("Config in: \n%s", globalconfig1)
+    logger.info("Config in: \n%s", mock_global_config)
     # using the class variable to set the grid format has no effect
     with pytest.warns(UserWarning, match="deprecated"):
-        edata = ExportData(config=globalconfig1, content="depth")
+        edata = ExportData(config=mock_global_config, content="depth")
 
     assert edata.config.model.name == "Test"
 
@@ -77,7 +77,7 @@ def test_missing_or_wrong_config_exports_with_warning(
 def test_wrong_config_exports_correctly_ouside_fmu(
     monkeypatch: MonkeyPatch,
     tmp_path: Path,
-    globalconfig1: dict[str, Any],
+    mock_global_config: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
 ) -> None:
     """
@@ -100,7 +100,7 @@ def test_wrong_config_exports_correctly_ouside_fmu(
         ).export(regsurf)
 
     objpath_cfg_valid = ExportData(
-        config=globalconfig1,
+        config=mock_global_config,
         content="depth",
         name=name,
     ).export(regsurf)
@@ -112,7 +112,7 @@ def test_wrong_config_exports_correctly_ouside_fmu(
 
     # test that it works with deprecated pattern also
     with pytest.warns(FutureWarning):
-        objpath_cfg_valid = ExportData(config=globalconfig1).export(
+        objpath_cfg_valid = ExportData(config=mock_global_config).export(
             regsurf,
             content="depth",
             name=name,
@@ -123,7 +123,7 @@ def test_wrong_config_exports_correctly_ouside_fmu(
 def test_wrong_config_exports_correctly_in_fmu(
     monkeypatch: MonkeyPatch,
     fmurun_w_casemetadata: Path,
-    globalconfig1: dict[str, Any],
+    mock_global_config: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
 ) -> None:
     """
@@ -145,7 +145,7 @@ def test_wrong_config_exports_correctly_in_fmu(
         ).export(regsurf)
 
     objpath_cfg_valid = ExportData(
-        config=globalconfig1,
+        config=mock_global_config,
         content="depth",
         name=name,
     ).export(regsurf)
@@ -160,7 +160,7 @@ def test_wrong_config_exports_correctly_in_fmu(
 
     # test that it works with deprecated pattern also
     with pytest.warns(FutureWarning):
-        objpath_cfg_valid = ExportData(config=globalconfig1).export(
+        objpath_cfg_valid = ExportData(config=mock_global_config).export(
             regsurf,
             content="depth",
             name=name,
@@ -171,14 +171,14 @@ def test_wrong_config_exports_correctly_in_fmu(
 def test_config_miss_required_fields(
     monkeypatch: MonkeyPatch,
     tmp_path: Path,
-    globalconfig1: dict[str, Any],
+    mock_global_config: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
 ) -> None:
     """Global config exists but missing critical data; export file but skip metadata."""
 
     monkeypatch.chdir(tmp_path)
 
-    cfg = globalconfig1.copy()
+    cfg = mock_global_config.copy()
 
     del cfg["access"]
     del cfg["masterdata"]
@@ -270,13 +270,13 @@ def test_config_stratigraphy_stratigraphic_not_bool(
         ExportData(config=cfg, content="depth")
 
 
-def test_update_check_settings_shall_fail(globalconfig1: dict[str, Any]) -> None:
+def test_update_check_settings_shall_fail(mock_global_config: dict[str, Any]) -> None:
     # pylint: disable=unexpected-keyword-arg
     with pytest.raises(TypeError):
-        _ = ExportData(config=globalconfig1, stupid="str", content="depth")
+        _ = ExportData(config=mock_global_config, stupid="str", content="depth")
 
     newsettings = {"invalidkey": "some"}
-    some = ExportData(config=globalconfig1, content="depth")
+    some = ExportData(config=mock_global_config, content="depth")
     with pytest.warns(FutureWarning), pytest.raises(KeyError):
         some._update_check_settings(newsettings)
 
@@ -297,7 +297,7 @@ def test_update_check_settings_shall_fail(globalconfig1: dict[str, Any]) -> None
     ],
 )
 def test_deprecated_keys(
-    globalconfig1: dict[str, Any],
+    mock_global_config: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
     key: dict[str, Any],
     value: str,
@@ -308,10 +308,10 @@ def test_deprecated_keys(
     # under primary initialisation
     kval = {key: value}
     with pytest.warns(UserWarning, match=expected_msg):
-        ExportData(config=globalconfig1, content="depth", **kval)
+        ExportData(config=mock_global_config, content="depth", **kval)
 
     # under override should give FutureWarning for these
-    edata = ExportData(config=globalconfig1, content="depth")
+    edata = ExportData(config=mock_global_config, content="depth")
     with (
         pytest.warns(UserWarning, match=expected_msg),
         pytest.warns(FutureWarning, match="move them up to initialization"),
@@ -320,7 +320,7 @@ def test_deprecated_keys(
 
 
 def test_access_ssdl_vs_classification_rep_include(
-    globalconfig1: dict[str, Any], regsurf: xtgeo.RegularSurface
+    mock_global_config: dict[str, Any], regsurf: xtgeo.RegularSurface
 ) -> None:
     """
     The access_ssdl is deprecated, and replaced by the 'classification' and
@@ -330,7 +330,7 @@ def test_access_ssdl_vs_classification_rep_include(
     # verify that a deprecation warning is given for access_ssdl argument
     with pytest.warns(FutureWarning, match="'access_ssdl' argument is deprecated"):
         exp = ExportData(
-            config=globalconfig1,
+            config=mock_global_config,
             access_ssdl={"access_level": "restricted", "rep_include": True},
             content="depth",
         )
@@ -371,7 +371,7 @@ def test_access_ssdl_vs_classification_rep_include(
 
     # using 'classification' / 'rep_include' as arguments is the preferred pattern
     exp = ExportData(
-        config=globalconfig1,
+        config=mock_global_config,
         classification="restricted",
         rep_include=True,
         content="depth",
@@ -382,12 +382,12 @@ def test_access_ssdl_vs_classification_rep_include(
 
 
 def test_classification(
-    globalconfig1: dict[str, Any], regsurf: xtgeo.RegularSurface
+    mock_global_config: dict[str, Any], regsurf: xtgeo.RegularSurface
 ) -> None:
     """Test that 'classification' is set correctly."""
 
     # test assumptions
-    config = deepcopy(globalconfig1)
+    config = deepcopy(mock_global_config)
     assert config["access"]["classification"] == "internal"
     assert "ssdl" not in config["access"]
 
@@ -426,33 +426,35 @@ def test_classification(
 
 
 def test_rep_include(
-    globalconfig1: dict[str, Any], regsurf: xtgeo.RegularSurface
+    mock_global_config: dict[str, Any], regsurf: xtgeo.RegularSurface
 ) -> None:
     """Test that 'classification' is set correctly."""
 
     # test assumptions
-    assert "ssdl" not in globalconfig1["access"]  # means no rep_include
+    assert "ssdl" not in mock_global_config["access"]  # means no rep_include
 
     # test that rep_include can be given directly and will override config
-    exp = ExportData(config=globalconfig1, rep_include=True, content="depth")
+    exp = ExportData(config=mock_global_config, rep_include=True, content="depth")
     mymeta = exp.generate_metadata(regsurf)
     assert mymeta["access"]["ssdl"]["rep_include"] is True
 
     # test that rep_include can be given through access_ssdl
     with pytest.warns(FutureWarning, match="'access_ssdl' argument is deprecated"):
         exp = ExportData(
-            config=globalconfig1, access_ssdl={"rep_include": True}, content="depth"
+            config=mock_global_config,
+            access_ssdl={"rep_include": True},
+            content="depth",
         )
     mymeta = exp.generate_metadata(regsurf)
     assert mymeta["access"]["ssdl"]["rep_include"] is True
 
     # test that rep_include is defaulted to false if not provided
-    exp = ExportData(config=globalconfig1, content="depth")
+    exp = ExportData(config=mock_global_config, content="depth")
     mymeta = exp.generate_metadata(regsurf)
     assert mymeta["access"]["ssdl"]["rep_include"] is False
 
     # add ssdl.rep_include to the config
-    config = deepcopy(globalconfig1)
+    config = deepcopy(mock_global_config)
     config["access"]["ssdl"] = {"rep_include": True}
 
     # test that rep_include can be read from config
@@ -462,19 +464,19 @@ def test_rep_include(
 
 
 def test_unit_is_none(
-    globalconfig1: dict[str, Any], regsurf: xtgeo.RegularSurface
+    mock_global_config: dict[str, Any], regsurf: xtgeo.RegularSurface
 ) -> None:
     """Test that unit=None works and is translated into an enpty string"""
-    eobj = ExportData(config=globalconfig1, unit=None, content="depth")
+    eobj = ExportData(config=mock_global_config, unit=None, content="depth")
     meta = eobj.generate_metadata(regsurf)
     assert meta["data"]["unit"] == ""
 
 
 def test_content_not_given(
-    globalconfig1: dict[str, Any], regsurf: xtgeo.RegularSurface
+    mock_global_config: dict[str, Any], regsurf: xtgeo.RegularSurface
 ) -> None:
     """When content is not explicitly given, warning shall be issued."""
-    eobj = ExportData(config=globalconfig1)
+    eobj = ExportData(config=mock_global_config)
     with pytest.warns(FutureWarning, match="The <content> is not provided"):
         mymeta = eobj.generate_metadata(regsurf)
 
@@ -482,10 +484,10 @@ def test_content_not_given(
 
 
 def test_content_given_init_or_later(
-    globalconfig1: dict[str, Any], regsurf: xtgeo.RegularSurface
+    mock_global_config: dict[str, Any], regsurf: xtgeo.RegularSurface
 ) -> None:
     """When content is not explicitly given, warning shall be issued."""
-    eobj = ExportData(config=globalconfig1, content="time")
+    eobj = ExportData(config=mock_global_config, content="time")
     mymeta = eobj.generate_metadata(regsurf)
 
     assert mymeta["data"]["content"] == "time"
@@ -498,35 +500,36 @@ def test_content_given_init_or_later(
 
 
 def test_content_invalid_string(
-    globalconfig1: dict[str, Any], regsurf: xtgeo.RegularSurface
+    mock_global_config: dict[str, Any], regsurf: xtgeo.RegularSurface
 ) -> None:
-    eobj = ExportData(config=globalconfig1, content="not_valid")
+    eobj = ExportData(config=mock_global_config, content="not_valid")
     with pytest.raises(ValueError, match="Invalid 'content' value='not_valid'"):
         eobj.generate_metadata(regsurf)
 
 
 def test_content_invalid_dict(
-    globalconfig1: dict[str, Any], regsurf: xtgeo.RegularSurface
+    mock_global_config: dict[str, Any], regsurf: xtgeo.RegularSurface
 ) -> None:
     eobj = ExportData(
-        config=globalconfig1, content={"not_valid": {"some_key": "some_value"}}
+        config=mock_global_config, content={"not_valid": {"some_key": "some_value"}}
     )
     with pytest.raises(ValueError, match="Invalid 'content' value='not_valid'"):
         eobj.generate_metadata(regsurf)
 
     eobj = ExportData(
-        config=globalconfig1, content={"seismic": "some_key", "extra": "some_value"}
+        config=mock_global_config,
+        content={"seismic": "some_key", "extra": "some_value"},
     )
     with pytest.raises(ValueError):
         eobj.generate_metadata(regsurf)
 
 
 def test_content_metadata_valid(
-    globalconfig1: dict[str, Any], regsurf: xtgeo.RegularSurface
+    mock_global_config: dict[str, Any], regsurf: xtgeo.RegularSurface
 ) -> None:
     content_metadata = {"attribute": "amplitude", "calculation": "mean"}
     meta = ExportData(
-        config=globalconfig1,
+        config=mock_global_config,
         content="seismic",
         content_metadata=content_metadata,
     ).generate_metadata(regsurf)
@@ -537,11 +540,11 @@ def test_content_metadata_valid(
 
 
 def test_content_metadata_invalid(
-    globalconfig1: dict[str, Any], regsurf: xtgeo.RegularSurface
+    mock_global_config: dict[str, Any], regsurf: xtgeo.RegularSurface
 ) -> None:
     with pytest.raises(pydantic.ValidationError):
         ExportData(
-            config=globalconfig1,
+            config=mock_global_config,
             content="seismic",
             content_metadata={"attribute": 182},
         ).generate_metadata(regsurf)
@@ -666,12 +669,12 @@ def test_content_deprecated_seismic_offset(
 
 
 def test_content_metdata_ignored(
-    globalconfig1: dict[str, Any], regsurf: xtgeo.RegularSurface
+    mock_global_config: dict[str, Any], regsurf: xtgeo.RegularSurface
 ) -> None:
     """Test that warning is given when content does not require content_metadata"""
     with pytest.warns(UserWarning, match="ignoring input"):
         ExportData(
-            config=globalconfig1,
+            config=mock_global_config,
             content="depth",
             content_metadata={"extra": "invalid"},
         ).generate_metadata(regsurf)
@@ -679,7 +682,7 @@ def test_content_metdata_ignored(
 
 @pytest.mark.filterwarnings("ignore: Number of maps nodes are 0")
 def test_surfaces_with_non_finite_values(
-    globalconfig1: dict[str, Any],
+    mock_global_config: dict[str, Any],
     regsurf_masked_only: xtgeo.RegularSurface,
     regsurf_nan_only: xtgeo.RegularSurface,
     regsurf: xtgeo.RegularSurface,
@@ -689,7 +692,7 @@ def test_surfaces_with_non_finite_values(
     in the metadata.
     """
 
-    eobj = ExportData(config=globalconfig1, content="time")
+    eobj = ExportData(config=mock_global_config, content="time")
 
     # test surface with only masked values
     mymeta = eobj.generate_metadata(regsurf_masked_only)
@@ -710,7 +713,7 @@ def test_surfaces_with_non_finite_values(
 def test_workflow_as_string(
     fmurun_w_casemetadata: Path,
     monkeypatch: MonkeyPatch,
-    globalconfig1: dict[str, Any],
+    mock_global_config: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
 ) -> None:
     """
@@ -721,25 +724,25 @@ def test_workflow_as_string(
     workflow = "My test workflow"
 
     # check that it works in ExportData
-    edata = ExportData(config=globalconfig1, workflow=workflow, content="depth")
+    edata = ExportData(config=mock_global_config, workflow=workflow, content="depth")
     meta = edata.generate_metadata(regsurf)
     assert meta["fmu"]["workflow"]["reference"] == workflow
 
     # doing actual export with a few ovverides
-    edata = ExportData(config=globalconfig1, content="depth")
+    edata = ExportData(config=mock_global_config, content="depth")
     with pytest.warns(FutureWarning, match="move them up to initialization"):
         meta = edata.generate_metadata(regsurf, workflow="My test workflow")
     assert meta["fmu"]["workflow"]["reference"] == workflow
 
 
 def test_vertical_domain(
-    regsurf: xtgeo.RegularSurface, globalconfig1: dict[str, Any]
+    regsurf: xtgeo.RegularSurface, mock_global_config: dict[str, Any]
 ) -> None:
     """test inputting vertical_domain and domain_reference in various ways"""
 
     # test that giving vertical_domain and domain_reference as strings
     mymeta = ExportData(
-        config=globalconfig1,
+        config=mock_global_config,
         vertical_domain="time",
         domain_reference="rkb",
         content="time",
@@ -750,64 +753,72 @@ def test_vertical_domain(
     # test giving vertical_domain as dictionary
     with pytest.warns(FutureWarning, match="deprecated"):
         mymeta = ExportData(
-            config=globalconfig1, vertical_domain={"time": "sb"}, content="thickness"
+            config=mock_global_config,
+            vertical_domain={"time": "sb"},
+            content="thickness",
         ).generate_metadata(regsurf)
     assert mymeta["data"]["vertical_domain"] == "time"
     assert mymeta["data"]["domain_reference"] == "sb"
 
     # test excluding vertical_domain and domain_reference
-    mymeta = ExportData(config=globalconfig1, content="thickness").generate_metadata(
-        regsurf
-    )
+    mymeta = ExportData(
+        config=mock_global_config, content="thickness"
+    ).generate_metadata(regsurf)
     assert mymeta["data"]["vertical_domain"] == "depth"  # default value
     assert mymeta["data"]["domain_reference"] == "msl"  # default value
 
     # test invalid input
     with pytest.raises(pydantic.ValidationError, match="vertical_domain"):
         ExportData(
-            config=globalconfig1, vertical_domain="wrong", content="thickness"
+            config=mock_global_config, vertical_domain="wrong", content="thickness"
         ).generate_metadata(regsurf)
     with pytest.raises(pydantic.ValidationError, match="domain_reference"):
         ExportData(
-            config=globalconfig1, domain_reference="wrong", content="thickness"
+            config=mock_global_config, domain_reference="wrong", content="thickness"
         ).generate_metadata(regsurf)
     with (
         pytest.warns(FutureWarning, match="deprecated"),
         pytest.raises(pydantic.ValidationError, match="2 validation errors"),
     ):
         ExportData(
-            config=globalconfig1, vertical_domain={"invalid": 5}, content="thickness"
+            config=mock_global_config,
+            vertical_domain={"invalid": 5},
+            content="thickness",
         ).generate_metadata(regsurf)
 
 
 def test_vertical_domain_vs_depth_time_content(
-    regsurf: xtgeo.RegularSurface, globalconfig1: dict[str, Any]
+    regsurf: xtgeo.RegularSurface, mock_global_config: dict[str, Any]
 ) -> None:
     """Test the vertical_domain vs content depth/time"""
 
     # test content depth/time sets vertical_domain
-    eobj = ExportData(config=globalconfig1, content="depth")
+    eobj = ExportData(config=mock_global_config, content="depth")
     mymeta = eobj.generate_metadata(regsurf)
     assert mymeta["data"]["vertical_domain"] == "depth"
     assert mymeta["data"]["domain_reference"] == "msl"  # default value
 
-    eobj = ExportData(config=globalconfig1, content="depth", domain_reference="sb")
+    eobj = ExportData(config=mock_global_config, content="depth", domain_reference="sb")
     mymeta = eobj.generate_metadata(regsurf)
     assert mymeta["data"]["vertical_domain"] == "depth"
     assert mymeta["data"]["domain_reference"] == "sb"
 
-    eobj = ExportData(config=globalconfig1, content="time")
+    eobj = ExportData(config=mock_global_config, content="time")
     mymeta = eobj.generate_metadata(regsurf)
     assert mymeta["data"]["vertical_domain"] == "time"
     assert mymeta["data"]["domain_reference"] == "msl"  # default value
 
     # test mismatch between content and vertical_domain
     with pytest.warns(UserWarning, match="'vertical_domain' will be set to 'depth'"):
-        eobj = ExportData(config=globalconfig1, content="depth", vertical_domain="time")
+        eobj = ExportData(
+            config=mock_global_config, content="depth", vertical_domain="time"
+        )
         mymeta = eobj.generate_metadata(regsurf)
 
     with pytest.warns(UserWarning, match="'vertical_domain' will be set to 'time'"):
-        eobj = ExportData(config=globalconfig1, content="time", vertical_domain="depth")
+        eobj = ExportData(
+            config=mock_global_config, content="time", vertical_domain="depth"
+        )
         mymeta = eobj.generate_metadata(regsurf)
 
 
@@ -837,7 +848,7 @@ def test_set_display_name(
 def test_global_config_from_env(
     monkeypatch: MonkeyPatch,
     drogon_global_config_path: Path,
-    globalconfig1: dict[str, Any],
+    mock_global_config: dict[str, Any],
 ) -> None:
     """Testing getting global config from a file"""
     monkeypatch.setenv("FMU_GLOBAL_CONFIG", str(drogon_global_config_path))
@@ -847,7 +858,7 @@ def test_global_config_from_env(
     assert edata.config.model.name == "ff"
 
     # do not use global config from environment when explicitly given
-    edata = ExportData(config=globalconfig1, content="depth")
+    edata = ExportData(config=mock_global_config, content="depth")
     assert edata.config.model.name == "Test"
 
 
@@ -1133,7 +1144,7 @@ def test_norwegian_letters_globalconfig(
 
 
 def test_metadata_format_deprecated(
-    globalconfig1: dict[str, Any],
+    mock_global_config: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -1147,7 +1158,7 @@ def test_metadata_format_deprecated(
     ExportData.meta_format = "json"
     with pytest.warns(UserWarning, match="meta_format"):
         result = ExportData(
-            config=globalconfig1, name="TopBlåbær", content="depth"
+            config=mock_global_config, name="TopBlåbær", content="depth"
         ).export(regsurf)
 
     result = pathlib.Path(result)
@@ -1158,7 +1169,7 @@ def test_metadata_format_deprecated(
     # test that also value "yaml" will cause warning
     ExportData.meta_format = "yaml"
     with pytest.warns(UserWarning, match="meta_format"):
-        ExportData(config=globalconfig1, name="TopBlåbær", content="depth")
+        ExportData(config=mock_global_config, name="TopBlåbær", content="depth")
 
     ExportData.meta_format = None  # reset
 
@@ -1227,9 +1238,9 @@ def test_forcefolder_absolute_shall_raise_or_warn(
     ExportData.allow_forcefolder_absolute = False
 
 
-def test_deprecated_verbosity(globalconfig1: dict[str, Any]) -> None:
+def test_deprecated_verbosity(mock_global_config: dict[str, Any]) -> None:
     with pytest.warns(UserWarning, match="Using the 'verbosity' key is now deprecated"):
-        ExportData(config=globalconfig1, verbosity="INFO")
+        ExportData(config=mock_global_config, verbosity="INFO")
 
 
 @pytest.mark.parametrize("encoding", ("utf-8", "latin1"))
@@ -1316,25 +1327,27 @@ def test_alias_as_none(
 
 
 def test_standard_result_not_present_in_generated_metadata(
-    globalconfig1: dict[str, Any], regsurf: xtgeo.RegularSurface
+    mock_global_config: dict[str, Any], regsurf: xtgeo.RegularSurface
 ) -> None:
     """Test that data.standard_result is not set for regular exports through
     ExportData"""
 
-    meta = ExportData(config=globalconfig1, content="depth").generate_metadata(regsurf)
+    meta = ExportData(config=mock_global_config, content="depth").generate_metadata(
+        regsurf
+    )
     assert "standard_result" not in meta["data"]
 
 
 def test_ert_experiment_id_present_in_generated_metadata(
     fmurun_w_casemetadata: Path,
     monkeypatch: MonkeyPatch,
-    globalconfig1: dict[str, Any],
+    mock_global_config: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
 ) -> None:
     """Test that the ert experiment id has been set correctly
     in the generated metadata"""
 
-    edata = ExportData(config=globalconfig1, content="depth")
+    edata = ExportData(config=mock_global_config, content="depth")
     meta = edata.generate_metadata(regsurf)
     expected_id = "6a8e1e0f-9315-46bb-9648-8de87151f4c7"
     assert meta["fmu"]["ert"]["experiment"]["id"] == expected_id
@@ -1343,13 +1356,13 @@ def test_ert_experiment_id_present_in_generated_metadata(
 def test_ert_experiment_id_present_in_exported_metadata(
     fmurun_w_casemetadata: Path,
     monkeypatch: MonkeyPatch,
-    globalconfig1: dict[str, Any],
+    mock_global_config: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
 ) -> None:
     """Test that the ert experiment id has been set correctly
     in the exported metadata"""
 
-    edata = ExportData(config=globalconfig1, content="depth")
+    edata = ExportData(config=mock_global_config, content="depth")
     out = Path(edata.export(regsurf))
     with open(out.parent / f".{out.name}.yml", encoding="utf-8") as f:
         export_meta = yaml.safe_load(f)
@@ -1360,13 +1373,13 @@ def test_ert_experiment_id_present_in_exported_metadata(
 def test_ert_simulation_mode_present_in_generated_metadata(
     fmurun_w_casemetadata: Path,
     monkeypatch: MonkeyPatch,
-    globalconfig1: dict[str, Any],
+    mock_global_config: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
 ) -> None:
     """Test that the ert simulation mode has been set correctly
     in the generated metadata"""
 
-    edata = ExportData(config=globalconfig1, content="depth")
+    edata = ExportData(config=mock_global_config, content="depth")
     meta = edata.generate_metadata(regsurf)
     assert meta["fmu"]["ert"]["simulation_mode"] == "test_run"
 
@@ -1374,13 +1387,13 @@ def test_ert_simulation_mode_present_in_generated_metadata(
 def test_ert_simulation_mode_present_in_exported_metadata(
     fmurun_w_casemetadata: Path,
     monkeypatch: MonkeyPatch,
-    globalconfig1: dict[str, Any],
+    mock_global_config: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
 ) -> None:
     """Test that the ert simulation mode has been set correctly
     in the exported metadata"""
 
-    edata = ExportData(config=globalconfig1, content="depth")
+    edata = ExportData(config=mock_global_config, content="depth")
     out = Path(edata.export(regsurf))
     with open(out.parent / f".{out.name}.yml", encoding="utf-8") as f:
         export_meta = yaml.safe_load(f)
@@ -1388,16 +1401,16 @@ def test_ert_simulation_mode_present_in_exported_metadata(
 
 
 def test_offset_top_base_present_in_exported_metadata(
-    globalconfig1: dict[str, Any], regsurf: xtgeo.RegularSurface
+    mock_global_config: dict[str, Any], regsurf: xtgeo.RegularSurface
 ) -> None:
     """
     Test that top, base and offset information provided from the config are
     preserved in the exported metadata.
     """
-    config = deepcopy(globalconfig1)
+    config = deepcopy(mock_global_config)
     name = "TopWhatever"
 
-    # the globalconfig1 does not have this information so add it
+    # the mock_global_config does not have this information so add it
     config["stratigraphy"][name].update(
         {
             "top": {"name": "TheTopHorizon"},
@@ -1420,13 +1433,13 @@ def test_offset_top_base_present_in_exported_metadata(
 
 
 def test_top_base_as_strings_from_config(
-    globalconfig1: dict[str, Any], regsurf: xtgeo.RegularSurface
+    mock_global_config: dict[str, Any], regsurf: xtgeo.RegularSurface
 ) -> None:
     """
     Test that entering top, base as string is allowed and it sets
     the name attribute automatically.
     """
-    config = deepcopy(globalconfig1)
+    config = deepcopy(mock_global_config)
     name = "TopWhatever"
 
     # add top and base info as string input to the config
@@ -1445,14 +1458,14 @@ def test_top_base_as_strings_from_config(
 
 
 def test_timedata_single_date(
-    globalconfig1: dict[str, Any], regsurf: xtgeo.RegularSurface
+    mock_global_config: dict[str, Any], regsurf: xtgeo.RegularSurface
 ) -> None:
     """Test that entering a single date works"""
 
     t0 = "20230101"
 
     meta = ExportData(
-        config=globalconfig1,
+        config=mock_global_config,
         content="depth",
         name="TopWhatever",
         timedata=[t0],
@@ -1463,7 +1476,7 @@ def test_timedata_single_date(
 
     # should also work with the double list syntax
     meta = ExportData(
-        config=globalconfig1,
+        config=mock_global_config,
         content="depth",
         name="TopWhatever",
         timedata=[[t0]],
@@ -1474,7 +1487,7 @@ def test_timedata_single_date(
 
 
 def test_timedata_multiple_date(
-    globalconfig1: dict[str, Any], regsurf: xtgeo.RegularSurface
+    mock_global_config: dict[str, Any], regsurf: xtgeo.RegularSurface
 ) -> None:
     """Test that entering two dates works"""
 
@@ -1482,7 +1495,7 @@ def test_timedata_multiple_date(
     t1 = "20240101"
 
     meta = ExportData(
-        config=globalconfig1,
+        config=mock_global_config,
         content="depth",
         name="TopWhatever",
         timedata=[t0, t1],
@@ -1493,7 +1506,7 @@ def test_timedata_multiple_date(
 
     # should also work with the double list syntax
     meta = ExportData(
-        config=globalconfig1,
+        config=mock_global_config,
         content="depth",
         name="TopWhatever",
         timedata=[[t0], [t1]],
@@ -1504,7 +1517,7 @@ def test_timedata_multiple_date(
 
 
 def test_timedata_multiple_date_sorting(
-    globalconfig1: dict[str, Any], regsurf: xtgeo.RegularSurface
+    mock_global_config: dict[str, Any], regsurf: xtgeo.RegularSurface
 ) -> None:
     """Test that dates are sorted no matter the input order"""
 
@@ -1512,7 +1525,7 @@ def test_timedata_multiple_date_sorting(
     t1 = "20240101"
 
     meta = ExportData(
-        config=globalconfig1,
+        config=mock_global_config,
         content="depth",
         name="TopWhatever",
         timedata=[t1, t0],  # set oldest first
@@ -1524,13 +1537,13 @@ def test_timedata_multiple_date_sorting(
 
 
 def test_timedata_wrong_format(
-    globalconfig1: dict[str, Any], regsurf: xtgeo.RegularSurface
+    mock_global_config: dict[str, Any], regsurf: xtgeo.RegularSurface
 ) -> None:
     """Test that error is raised if timedata is input incorrect"""
 
     with pytest.raises(ValueError, match="should be a list"):
         ExportData(
-            config=globalconfig1,
+            config=mock_global_config,
             content="depth",
             name="TopWhatever",
             timedata="20230101",
@@ -1538,7 +1551,7 @@ def test_timedata_wrong_format(
 
     with pytest.raises(ValueError, match="two dates"):
         ExportData(
-            config=globalconfig1,
+            config=mock_global_config,
             content="depth",
             name="TopWhatever",
             timedata=["20230101", "20240101", "20250101"],
@@ -1548,14 +1561,14 @@ def test_timedata_wrong_format(
 def test_export_with_standard_result_valid_config(
     fmurun_w_casemetadata: Path,
     monkeypatch: MonkeyPatch,
-    globalconfig1: dict[str, Any],
+    mock_global_config: dict[str, Any],
     mock_volumes: pd.DataFrame,
 ) -> None:
     """Test that standard result is set in metadata when
     export_with_standard_result is used"""
 
     edata = ExportData(
-        config=globalconfig1,
+        config=mock_global_config,
         content="volumes",
         name="TopWhatever",
     )

--- a/tests/test_units/test_manifest.py
+++ b/tests/test_units/test_manifest.py
@@ -78,7 +78,7 @@ def test_get_manifest_path_case_context_no_casepath(fmurun_prehook: Path) -> Non
 
 def test_manifest_realization_context(
     fmurun_w_casemetadata: Path,
-    globalconfig1: dict[str, Any],
+    mock_global_config: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
 ) -> None:
     """Test that the manifest is created at the runpath in a realization context."""
@@ -86,7 +86,7 @@ def test_manifest_realization_context(
     casepath = fmurun_w_casemetadata.parent.parent
 
     ExportData(
-        config=globalconfig1,
+        config=mock_global_config,
         content="depth",
         name="test0",
     ).export(regsurf)
@@ -105,7 +105,7 @@ def test_manifest_realization_context(
 
 def test_manifest_multiple_exports_realization_context(
     fmurun_w_casemetadata: Path,
-    globalconfig1: dict[str, Any],
+    mock_global_config: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
 ) -> None:
     """Test that multiple exports creates and appends to a manifest at the runpath
@@ -115,7 +115,7 @@ def test_manifest_multiple_exports_realization_context(
 
     for idx in range(3):
         ExportData(
-            config=globalconfig1,
+            config=mock_global_config,
             content="depth",
             name=f"test{idx}",
         ).export(regsurf)
@@ -132,14 +132,16 @@ def test_manifest_multiple_exports_realization_context(
 
 
 def test_manifest_case_context(
-    fmurun_prehook: Path, globalconfig1: dict[str, Any], regsurf: xtgeo.RegularSurface
+    fmurun_prehook: Path,
+    mock_global_config: dict[str, Any],
+    regsurf: xtgeo.RegularSurface,
 ) -> None:
     """Test that the manifest is created at the casepath in a case context."""
 
     casepath = fmurun_prehook
 
     ExportData(
-        config=globalconfig1,
+        config=mock_global_config,
         content="depth",
         name="test0",
         casepath=casepath,
@@ -156,14 +158,16 @@ def test_manifest_case_context(
 
 
 def test_manifest_multiple_exports_case_context(
-    fmurun_prehook: Path, globalconfig1: dict[str, Any], regsurf: xtgeo.RegularSurface
+    fmurun_prehook: Path,
+    mock_global_config: dict[str, Any],
+    regsurf: xtgeo.RegularSurface,
 ) -> None:
     """Test that multiple exports creates and appends to a manifest at the casepath
     in a case context."""
     casepath = fmurun_prehook
     for idx in range(3):
         ExportData(
-            config=globalconfig1,
+            config=mock_global_config,
             content="depth",
             name=f"test{idx}",
             casepath=casepath,
@@ -181,7 +185,7 @@ def test_manifest_multiple_exports_case_context(
 @pytest.mark.usefixtures("inside_rms_interactive")
 def test_manifest_rms_interactive(
     tmp_path: Path,
-    globalconfig1: dict[str, Any],
+    mock_global_config: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
     monkeypatch: MonkeyPatch,
 ) -> None:
@@ -192,7 +196,7 @@ def test_manifest_rms_interactive(
     monkeypatch.chdir(rms_model_path)
 
     edata = ExportData(
-        config=globalconfig1,
+        config=mock_global_config,
         content="depth",
         name="test0",
     )
@@ -221,7 +225,7 @@ def test_load_export_manifest_file_not_exist(tmp_path: Path) -> None:
 
 def test_export_preprocessed_surface_appends_to_case_manifest(
     fmurun_prehook: Path,
-    globalconfig1: dict[str, Any],
+    mock_global_config: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
     monkeypatch: MonkeyPatch,
 ) -> None:
@@ -230,7 +234,7 @@ def test_export_preprocessed_surface_appends_to_case_manifest(
 
     remove_ert_env(monkeypatch)
     export_data = ExportData(
-        config=globalconfig1,
+        config=mock_global_config,
         preprocessed=True,
         name="TopVolantis",
         content="depth",

--- a/tests/test_units/test_metadata_class.py
+++ b/tests/test_units/test_metadata_class.py
@@ -241,10 +241,10 @@ def test_populate_meta_undef_is_zero(
 
 
 def test_metadata_populate_masterdata_is_empty(
-    globalconfig1: dict[str, Any], regsurf: xtgeo.RegularSurface
+    mock_global_config: dict[str, Any], regsurf: xtgeo.RegularSurface
 ) -> None:
     """Testing the masterdata part, first with no settings."""
-    config = deepcopy(globalconfig1)
+    config = deepcopy(mock_global_config)
     del config["masterdata"]  # to force missing masterdata
 
     with pytest.warns(UserWarning, match="The global config"):
@@ -276,11 +276,11 @@ def test_metadata_populate_masterdata_is_present_ok(
 
 
 def test_metadata_populate_access_miss_cfg_access(
-    globalconfig1: dict[str, Any], regsurf: xtgeo.RegularSurface
+    mock_global_config: dict[str, Any], regsurf: xtgeo.RegularSurface
 ) -> None:
     """Testing the access part, now with config missing access."""
 
-    cfg1_edited = deepcopy(globalconfig1)
+    cfg1_edited = deepcopy(mock_global_config)
     del cfg1_edited["access"]
     with pytest.warns(UserWarning, match="The global config"):
         edata = dio.ExportData(config=cfg1_edited, content="depth")
@@ -307,15 +307,15 @@ def test_metadata_populate_access_ok_config(
 
 
 def test_metadata_populate_from_argument(
-    globalconfig1: dict[str, Any], regsurf: xtgeo.RegularSurface
+    mock_global_config: dict[str, Any], regsurf: xtgeo.RegularSurface
 ) -> None:
     """Testing the access part, now with ok config and a change in access."""
 
     # test assumptions
-    assert globalconfig1["access"]["classification"] == "internal"
+    assert mock_global_config["access"]["classification"] == "internal"
 
     edata = dio.ExportData(
-        config=globalconfig1,
+        config=mock_global_config,
         classification="restricted",
         rep_include=True,
         content="depth",
@@ -331,16 +331,16 @@ def test_metadata_populate_from_argument(
 
 
 def test_metadata_populate_partial_access_ssdl(
-    globalconfig1: dict[str, Any], regsurf: xtgeo.RegularSurface
+    mock_global_config: dict[str, Any], regsurf: xtgeo.RegularSurface
 ) -> None:
     """Test what happens if ssdl_access argument is partial."""
 
     # test assumptions
-    assert globalconfig1["access"]["classification"] == "internal"
-    assert "ssdl" not in globalconfig1["access"]  # no ssdl.rep_include
+    assert mock_global_config["access"]["classification"] == "internal"
+    assert "ssdl" not in mock_global_config["access"]  # no ssdl.rep_include
 
     # rep_include only, but in config
-    edata = dio.ExportData(config=globalconfig1, rep_include=True, content="depth")
+    edata = dio.ExportData(config=mock_global_config, rep_include=True, content="depth")
 
     objdata = objectdata_provider_factory(regsurf, edata)
     mymeta = generate_export_metadata(objdata, edata)
@@ -351,7 +351,7 @@ def test_metadata_populate_partial_access_ssdl(
 
     # access_level only, but in config
     edata = dio.ExportData(
-        config=globalconfig1,
+        config=mock_global_config,
         classification="restricted",
         content="depth",
     )
@@ -364,12 +364,12 @@ def test_metadata_populate_partial_access_ssdl(
 
 
 def test_metadata_populate_wrong_config(
-    globalconfig1: dict[str, Any], regsurf: xtgeo.RegularSurface
+    mock_global_config: dict[str, Any], regsurf: xtgeo.RegularSurface
 ) -> None:
     """Test error in access_ssdl in config."""
 
     # test assumptions
-    _config = deepcopy(globalconfig1)
+    _config = deepcopy(mock_global_config)
     _config["access"]["classification"] = "wrong"
 
     with pytest.warns(UserWarning):
@@ -384,24 +384,24 @@ def test_metadata_populate_wrong_config(
     assert meta.access.classification == "internal"
 
 
-def test_metadata_populate_wrong_argument(globalconfig1: dict[str, Any]) -> None:
+def test_metadata_populate_wrong_argument(mock_global_config: dict[str, Any]) -> None:
     """Test error in access_ssdl in arguments."""
 
     with pytest.raises(ValueError, match="is not a valid Classification"):
         dio.ExportData(
-            config=globalconfig1,
+            config=mock_global_config,
             classification="wrong",
             content="depth",
         )
 
 
 def test_metadata_access_correct_input(
-    globalconfig1: dict[str, Any], regsurf: xtgeo.RegularSurface
+    mock_global_config: dict[str, Any], regsurf: xtgeo.RegularSurface
 ) -> None:
     """Test giving correct input."""
     # Input is "restricted" and False - correct use, shall work
     edata = dio.ExportData(
-        config=globalconfig1,
+        config=mock_global_config,
         content="depth",
         classification="restricted",
         rep_include=False,
@@ -415,7 +415,7 @@ def test_metadata_access_correct_input(
 
     # Input is "internal" and True - correct use, shall work
     edata = dio.ExportData(
-        config=globalconfig1,
+        config=mock_global_config,
         content="depth",
         classification="internal",
         rep_include=True,
@@ -429,7 +429,7 @@ def test_metadata_access_correct_input(
 
 
 def test_metadata_access_deprecated_input(
-    globalconfig1: dict[str, Any], regsurf: xtgeo.RegularSurface
+    mock_global_config: dict[str, Any], regsurf: xtgeo.RegularSurface
 ) -> None:
     """Test giving deprecated input."""
     # Input is "asset". Is deprecated, shall work with warning.
@@ -439,7 +439,7 @@ def test_metadata_access_deprecated_input(
         match="The value 'asset' for access.ssdl.access_level is deprec",
     ):
         edata = dio.ExportData(
-            config=globalconfig1,
+            config=mock_global_config,
             classification="asset",
             content="depth",
         )
@@ -452,13 +452,13 @@ def test_metadata_access_deprecated_input(
     assert mymeta.access.classification == "restricted"
 
 
-def test_metadata_access_illegal_input(globalconfig1: dict[str, Any]) -> None:
+def test_metadata_access_illegal_input(mock_global_config: dict[str, Any]) -> None:
     """Test giving illegal input, should provide empty access field"""
 
     # Input is "secret"
     with pytest.raises(ValueError, match="is not a valid Classification"):
         dio.ExportData(
-            config=globalconfig1,
+            config=mock_global_config,
             classification="secret",
             content="depth",
         )
@@ -466,22 +466,22 @@ def test_metadata_access_illegal_input(globalconfig1: dict[str, Any]) -> None:
     # Input is "open". Not allowed, shall fail.
     with pytest.raises(ValueError, match="is not a valid Classification"):
         dio.ExportData(
-            config=globalconfig1,
+            config=mock_global_config,
             classification="open",
             content="depth",
         )
 
 
 def test_metadata_access_no_input(
-    globalconfig1: dict[str, Any], regsurf: xtgeo.RegularSurface
+    mock_global_config: dict[str, Any], regsurf: xtgeo.RegularSurface
 ) -> None:
     """Test not giving any input arguments."""
 
     # test assumption, deprected access.ssdl not present in config
-    assert "ssdl" not in globalconfig1["access"]
+    assert "ssdl" not in mock_global_config["access"]
 
     # No input, revert to config
-    configcopy = deepcopy(globalconfig1)
+    configcopy = deepcopy(mock_global_config)
     configcopy["access"]["classification"] = "restricted"
     configcopy["access"]["ssdl"] = {"rep_include": True}
     # rep_include from config is deprecated
@@ -495,9 +495,9 @@ def test_metadata_access_no_input(
     assert mymeta.access.classification == "restricted"  # mirrored
 
     # No input, no config, shall default to "internal" and False
-    configcopy = deepcopy(globalconfig1)
+    configcopy = deepcopy(mock_global_config)
     del configcopy["access"]["classification"]
-    edata = dio.ExportData(config=globalconfig1, content="depth")
+    edata = dio.ExportData(config=mock_global_config, content="depth")
     objdata = objectdata_provider_factory(regsurf, edata)
     mymeta = generate_export_metadata(objdata, edata)
     assert mymeta.access is not None
@@ -507,10 +507,10 @@ def test_metadata_access_no_input(
 
 
 def test_metadata_rep_include_deprecation(
-    globalconfig1: dict[str, Any], regsurf: xtgeo.RegularSurface
+    mock_global_config: dict[str, Any], regsurf: xtgeo.RegularSurface
 ) -> None:
     """Test warnings for deprecated rep_include field in config."""
-    configcopy = deepcopy(globalconfig1)
+    configcopy = deepcopy(mock_global_config)
     # add rep_include to the config
     configcopy["access"]["ssdl"] = {"rep_include": True}
     with pytest.warns(FutureWarning, match="'rep_include' argument"):
@@ -530,7 +530,7 @@ def test_metadata_rep_include_deprecation(
 
     # check that default value is used if not present
     del configcopy["access"]["ssdl"]["rep_include"]
-    edata = dio.ExportData(config=globalconfig1, content="depth")
+    edata = dio.ExportData(config=mock_global_config, content="depth")
     objdata = objectdata_provider_factory(regsurf, edata)
     mymeta = generate_export_metadata(objdata, edata)
     assert mymeta.access is not None

--- a/tests/test_units/test_table.py
+++ b/tests/test_units/test_table.py
@@ -312,11 +312,11 @@ def test_table_index_rft_from_standard(drogon_global_config: dict[str, Any]) -> 
 
 
 def test_table_wellpicks(
-    wellpicks: pd.DataFrame, globalconfig1: dict[str, Any]
+    wellpicks: pd.DataFrame, mock_global_config: dict[str, Any]
 ) -> None:
     """Test export of wellpicks"""
 
-    exp = ExportData(config=globalconfig1, name="wellpicks", content="wellpicks")
+    exp = ExportData(config=mock_global_config, name="wellpicks", content="wellpicks")
 
     metadata = exp.generate_metadata(wellpicks)
 
@@ -326,7 +326,7 @@ def test_table_wellpicks(
     assert metadata["data"]["table_index"] == ["WELL", "HORIZON"]
 
 
-def test_production_network_index(globalconfig1: dict[str, Any]) -> None:
+def test_production_network_index(mock_global_config: dict[str, Any]) -> None:
     """Test that the table index is set correct for production network data"""
 
     mock_table = pd.DataFrame(
@@ -340,7 +340,9 @@ def test_production_network_index(globalconfig1: dict[str, Any]) -> None:
     )
 
     exp = ExportData(
-        config=globalconfig1, name="production_network", content="production_network"
+        config=mock_global_config,
+        name="production_network",
+        content="production_network",
     )
 
     metadata = exp.generate_metadata(mock_table)
@@ -351,7 +353,7 @@ def test_production_network_index(globalconfig1: dict[str, Any]) -> None:
     assert metadata["data"]["table_index"] == ["DATE", "CHILD", "PARENT", "KEYWORD"]
 
 
-def test_well_completions_index(globalconfig1: dict[str, Any]) -> None:
+def test_well_completions_index(mock_global_config: dict[str, Any]) -> None:
     """Test that the table index is set correct for well completions data"""
 
     mock_table = pd.DataFrame(
@@ -365,7 +367,7 @@ def test_well_completions_index(globalconfig1: dict[str, Any]) -> None:
     )
 
     exp = ExportData(
-        config=globalconfig1, name="well_completions", content="well_completions"
+        config=mock_global_config, name="well_completions", content="well_completions"
     )
 
     metadata = exp.generate_metadata(mock_table)


### PR DESCRIPTION
(No issue). Renames the 'globalconfig1' fixture. Parameters with numbers are almost never the best name.

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [ ] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [ ] Checked the boxes in this checklist ✅
