### PR TITLE
TST: Rename ExportData fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -385,15 +385,12 @@ def mock_global_config() -> dict[str, Any]:
 
 
 @pytest.fixture(scope="function")
-def edataobj1(
+def mock_exportdata(
     mock_global_config: dict[str, Any], tmp_path: Path, monkeypatch: MonkeyPatch
 ) -> ExportData:
-    """Combined globalconfig and settings to instance, for internal testing"""
-    logger.debug("Establish edataobj1")
-
+    """ExportData instance with a mock global configuration."""
     monkeypatch.chdir(tmp_path)
-
-    eobj = dio.ExportData(
+    return dio.ExportData(
         config=mock_global_config,
         name="TopWhatever",
         content="depth",
@@ -401,13 +398,27 @@ def edataobj1(
         is_observation=False,
     )
 
-    curr_frame = inspect.currentframe()
-    if curr_frame is not None and curr_frame.f_code is not None:
-        logger.debug("Ran %s returning %s", curr_frame.f_code.co_name, type(eobj))
-    else:
-        logger.debug("Ran unknown frame returning %s", type(eobj))
 
-    return eobj
+@pytest.fixture()
+def simulationtimeseries_exportdata(mock_global_config: dict[str, Any]) -> ExportData:
+    """ExportData instance with simulationtimeseries content type."""
+    return ExportData(
+        config=mock_global_config,
+        name="summary",
+        content="simulationtimeseries",
+        tagname="",
+    )
+
+
+@pytest.fixture
+def timeseries_exportdata(mock_global_config: dict[str, Any]) -> ExportData:
+    """Combined globalconfig and settings to instance, for internal testing"""
+    return ExportData(
+        config=mock_global_config,
+        name="some timeseries",
+        content="timeseries",
+        tagname="",
+    )
 
 
 @pytest.fixture(scope="function")
@@ -418,9 +429,9 @@ def drogon_global_config(drogon_global_config_path: Path) -> dict[str, Any]:
 
 
 @pytest.fixture(scope="function")
-def edataobj2(drogon_global_config: dict[str, Any]) -> ExportData:
-    """Combined globalconfig and other settings; NB for internal unit testing"""
-    eobj = dio.ExportData(
+def drogon_exportdata(drogon_global_config: dict[str, Any]) -> ExportData:
+    """ExportData instance with Drogon's global configuration."""
+    return dio.ExportData(
         config=drogon_global_config,
         content="depth",
         name="TopVolantis",
@@ -434,9 +445,6 @@ def edataobj2(drogon_global_config: dict[str, Any]) -> ExportData:
         fmu_context="realization",
         rep_include=True,
     )
-
-    logger.debug("Ran %s", _current_function_name())
-    return eobj
 
 
 # ======================================================================================
@@ -790,30 +798,6 @@ def aggr_surfs_mean(
     monkeypatch.chdir(origfolder)
 
     return (aggregated["mean"], metas)
-
-
-@pytest.fixture()
-def edataobj3(mock_global_config: dict[str, Any]) -> ExportData:
-    """Combined globalconfig and settings to instance, for internal testing"""
-
-    return ExportData(
-        config=mock_global_config,
-        name="summary",
-        content="simulationtimeseries",
-        tagname="",
-    )
-
-
-@pytest.fixture
-def export_data_obj_timeseries(mock_global_config: dict[str, Any]) -> ExportData:
-    """Combined globalconfig and settings to instance, for internal testing"""
-
-    return ExportData(
-        config=mock_global_config,
-        name="some timeseries",
-        content="timeseries",
-        tagname="",
-    )
 
 
 @pytest.fixture()

--- a/tests/test_units/test_metadata_class.py
+++ b/tests/test_units/test_metadata_class.py
@@ -28,17 +28,19 @@ logger = logging.getLogger(__name__)
 # --------------------------------------------------------------------------------------
 
 
-def test_metadata_dollars(edataobj1: ExportData, regsurf: xtgeo.RegularSurface) -> None:
+def test_metadata_dollars(
+    mock_exportdata: ExportData, regsurf: xtgeo.RegularSurface
+) -> None:
     """Testing the dollars part which is hard set."""
 
-    mymeta = edataobj1.generate_metadata(obj=regsurf)
+    mymeta = mock_exportdata.generate_metadata(obj=regsurf)
 
     assert mymeta["version"] == FmuResultsSchema.VERSION
     assert mymeta["$schema"] == FmuResultsSchema.url()
     assert mymeta["source"] == FmuResultsSchema.SOURCE
 
     # also check that it is preserved in the exported metadata
-    exportpath = edataobj1.export(regsurf)
+    exportpath = mock_exportdata.export(regsurf)
     exportmeta = read_metadata_from_file(exportpath)
 
     assert exportmeta["version"] == FmuResultsSchema.VERSION
@@ -52,10 +54,10 @@ def test_metadata_dollars(edataobj1: ExportData, regsurf: xtgeo.RegularSurface) 
 
 
 def test_generate_meta_tracklog_fmu_dataio_version(
-    regsurf: xtgeo.RegularSurface, edataobj1: ExportData
+    regsurf: xtgeo.RegularSurface, mock_exportdata: ExportData
 ) -> None:
-    objdata = objectdata_provider_factory(regsurf, edataobj1)
-    mymeta = generate_export_metadata(objdata, edataobj1)
+    objdata = objectdata_provider_factory(regsurf, mock_exportdata)
+    mymeta = generate_export_metadata(objdata, mock_exportdata)
     tracklog = mymeta.tracklog
 
     assert isinstance(tracklog.root, list)
@@ -76,13 +78,15 @@ def test_generate_meta_tracklog_fmu_dataio_version(
 
 
 def test_generate_meta_tracklog_komodo_version(
-    edataobj1: dio.ExportData, regsurf: xtgeo.RegularSurface, monkeypatch: MonkeyPatch
+    mock_exportdata: dio.ExportData,
+    regsurf: xtgeo.RegularSurface,
+    monkeypatch: MonkeyPatch,
 ) -> None:
     fake_komodo_release = "<FAKE_KOMODO_RELEASE_VERSION>"
     monkeypatch.setenv("KOMODO_RELEASE", fake_komodo_release)
 
-    objdata = objectdata_provider_factory(regsurf, edataobj1)
-    mymeta = generate_export_metadata(objdata, edataobj1)
+    objdata = objectdata_provider_factory(regsurf, mock_exportdata)
+    mymeta = generate_export_metadata(objdata, mock_exportdata)
     tracklog = mymeta.tracklog
 
     assert isinstance(tracklog.root, list)
@@ -105,15 +109,17 @@ def test_generate_meta_tracklog_komodo_version(
 
 
 def test_generate_meta_tracklog_backup_komodo_version(
-    edataobj1: dio.ExportData, regsurf: xtgeo.RegularSurface, monkeypatch: MonkeyPatch
+    mock_exportdata: dio.ExportData,
+    regsurf: xtgeo.RegularSurface,
+    monkeypatch: MonkeyPatch,
 ) -> None:
     """Tests that we read the Komodo version from KOMODO_RELEASE_BACKUP if it's set."""
     komodo_release = "2123.01.01"
     monkeypatch.delenv("KOMODO_RELEASE", raising=False)
     monkeypatch.setenv("KOMODO_RELEASE_BACKUP", komodo_release)
 
-    objdata = objectdata_provider_factory(regsurf, edataobj1)
-    metadata = generate_export_metadata(objdata, edataobj1)
+    objdata = objectdata_provider_factory(regsurf, mock_exportdata)
+    metadata = generate_export_metadata(objdata, mock_exportdata)
     tracklog = TracklogEvent.model_validate(metadata.tracklog[0])
     assert tracklog.sysinfo is not None
     assert tracklog.sysinfo.komodo is not None
@@ -123,7 +129,9 @@ def test_generate_meta_tracklog_backup_komodo_version(
 
 
 def test_generate_meta_tracklog_komodo_version_preferred_over_backup(
-    edataobj1: dio.ExportData, regsurf: xtgeo.RegularSurface, monkeypatch: MonkeyPatch
+    mock_exportdata: dio.ExportData,
+    regsurf: xtgeo.RegularSurface,
+    monkeypatch: MonkeyPatch,
 ) -> None:
     """Tests that we read the Komodo version from KOMODO_RELEASE.
 
@@ -137,8 +145,8 @@ def test_generate_meta_tracklog_komodo_version_preferred_over_backup(
     monkeypatch.setenv("KOMODO_RELEASE", komodo_release)
     monkeypatch.setenv("KOMODO_RELEASE_BACKUP", backup_komodo_release)
 
-    objdata = objectdata_provider_factory(regsurf, edataobj1)
-    metadata = generate_export_metadata(objdata, edataobj1)
+    objdata = objectdata_provider_factory(regsurf, mock_exportdata)
+    metadata = generate_export_metadata(objdata, mock_exportdata)
     tracklog = TracklogEvent.model_validate(metadata.tracklog[0])
     assert tracklog.sysinfo is not None
     assert tracklog.sysinfo.komodo is not None
@@ -148,10 +156,10 @@ def test_generate_meta_tracklog_komodo_version_preferred_over_backup(
 
 
 def test_generate_meta_tracklog_operating_system(
-    edataobj1: ExportData, regsurf: xtgeo.RegularSurface
+    mock_exportdata: ExportData, regsurf: xtgeo.RegularSurface
 ) -> None:
-    objdata = objectdata_provider_factory(regsurf, edataobj1)
-    mymeta = generate_export_metadata(objdata, edataobj1)
+    objdata = objectdata_provider_factory(regsurf, mock_exportdata)
+    mymeta = generate_export_metadata(objdata, mock_exportdata)
     tracklog = mymeta.tracklog
 
     assert isinstance(tracklog.root, list)
@@ -170,14 +178,14 @@ def test_generate_meta_tracklog_operating_system(
 
 
 def test_populate_meta_objectdata(
-    regsurf: xtgeo.RegularSurface, edataobj2: ExportData
+    regsurf: xtgeo.RegularSurface, drogon_exportdata: ExportData
 ) -> None:
-    objdata = objectdata_provider_factory(regsurf, edataobj2)
-    mymeta = generate_export_metadata(objdata, edataobj2)
+    objdata = objectdata_provider_factory(regsurf, drogon_exportdata)
+    mymeta = generate_export_metadata(objdata, drogon_exportdata)
 
     assert objdata.name == "VOLANTIS GP. Top"
     assert mymeta.display.name == objdata.name
-    assert edataobj2.name == "TopVolantis"
+    assert drogon_exportdata.name == "TopVolantis"
 
     # surfaces shall have data.spec
     assert mymeta.data
@@ -186,7 +194,7 @@ def test_populate_meta_objectdata(
 
 
 def test_bbox_zmin_zmax_presence(
-    polygons: xtgeo.Polygons, edataobj2: ExportData
+    polygons: xtgeo.Polygons, drogon_exportdata: ExportData
 ) -> None:
     """
     Test to ensure the zmin/zmax fields are present in the metadata for a
@@ -194,8 +202,8 @@ def test_bbox_zmin_zmax_presence(
     of the bbox types (2D/3D) inside the pydantic model. If 2D is first zmin/zmax
     will be ignored even if present.
     """
-    objdata = objectdata_provider_factory(polygons, edataobj2)
-    mymeta = generate_export_metadata(objdata, edataobj2)
+    objdata = objectdata_provider_factory(polygons, drogon_exportdata)
+    mymeta = generate_export_metadata(objdata, drogon_exportdata)
 
     # polygons shall have data.spec
     assert mymeta.data.root.bbox.zmin is not None
@@ -258,16 +266,18 @@ def test_metadata_populate_masterdata_is_empty(
 
 
 def test_metadata_populate_masterdata_is_present_ok(
-    edataobj1: ExportData, edataobj2: ExportData, regsurf: xtgeo.RegularSurface
+    mock_exportdata: ExportData,
+    drogon_exportdata: ExportData,
+    regsurf: xtgeo.RegularSurface,
 ) -> None:
     """Testing the masterdata part with OK metdata."""
-    objdata = objectdata_provider_factory(regsurf, edataobj1)
-    mymeta = generate_export_metadata(objdata, edataobj1)
-    assert mymeta.masterdata == edataobj1.config.masterdata
+    objdata = objectdata_provider_factory(regsurf, mock_exportdata)
+    mymeta = generate_export_metadata(objdata, mock_exportdata)
+    assert mymeta.masterdata == mock_exportdata.config.masterdata
 
-    objdata = objectdata_provider_factory(regsurf, edataobj2)
-    mymeta = generate_export_metadata(objdata, edataobj2)
-    assert mymeta.masterdata == edataobj2.config.masterdata
+    objdata = objectdata_provider_factory(regsurf, drogon_exportdata)
+    mymeta = generate_export_metadata(objdata, drogon_exportdata)
+    assert mymeta.masterdata == drogon_exportdata.config.masterdata
 
 
 # --------------------------------------------------------------------------------------
@@ -293,12 +303,12 @@ def test_metadata_populate_access_miss_cfg_access(
 
 
 def test_metadata_populate_access_ok_config(
-    edataobj2: ExportData, regsurf: xtgeo.RegularSurface
+    drogon_exportdata: ExportData, regsurf: xtgeo.RegularSurface
 ) -> None:
     """Testing the access part, now with config ok access."""
 
-    objdata = objectdata_provider_factory(regsurf, edataobj2)
-    mymeta = generate_export_metadata(objdata, edataobj2)
+    objdata = objectdata_provider_factory(regsurf, drogon_exportdata)
+    mymeta = generate_export_metadata(objdata, drogon_exportdata)
     assert mymeta.access.model_dump(mode="json", exclude_none=True) == {
         "asset": {"name": "Drogon"},
         "ssdl": {"access_level": "internal", "rep_include": True},
@@ -543,25 +553,25 @@ def test_metadata_rep_include_deprecation(
 
 
 def test_metadata_display_name_not_given(
-    regsurf: xtgeo.RegularSurface, edataobj2: ExportData
+    regsurf: xtgeo.RegularSurface, drogon_exportdata: ExportData
 ) -> None:
     """Test that display.name == data.name when not explicitly provided."""
 
-    objdata = objectdata_provider_factory(regsurf, edataobj2)
-    mymeta = generate_export_metadata(objdata, edataobj2)
+    objdata = objectdata_provider_factory(regsurf, drogon_exportdata)
+    mymeta = generate_export_metadata(objdata, drogon_exportdata)
 
     assert mymeta.display.name == objdata.name
 
 
 def test_metadata_display_name_given(
-    regsurf: xtgeo.RegularSurface, edataobj2: ExportData
+    regsurf: xtgeo.RegularSurface, drogon_exportdata: ExportData
 ) -> None:
     """Test that display.name is set when explicitly given."""
 
-    edataobj2.display_name = "My Display Name"
+    drogon_exportdata.display_name = "My Display Name"
 
-    objdata = objectdata_provider_factory(regsurf, edataobj2)
-    mymeta = generate_export_metadata(objdata, edataobj2)
+    objdata = objectdata_provider_factory(regsurf, drogon_exportdata)
+    mymeta = generate_export_metadata(objdata, drogon_exportdata)
 
     assert mymeta.display.name == "My Display Name"
     assert objdata.name == "VOLANTIS GP. Top"
@@ -573,12 +583,12 @@ def test_metadata_display_name_given(
 
 
 def test_generate_full_metadata(
-    regsurf: xtgeo.RegularSurface, edataobj2: ExportData
+    regsurf: xtgeo.RegularSurface, drogon_exportdata: ExportData
 ) -> None:
     """Generating the full metadata block for a xtgeo surface."""
 
-    objdata = objectdata_provider_factory(regsurf, edataobj2)
-    metadata_result = generate_export_metadata(objdata, edataobj2)
+    objdata = objectdata_provider_factory(regsurf, drogon_exportdata)
+    metadata_result = generate_export_metadata(objdata, drogon_exportdata)
 
     logger.debug("\n%s", prettyprint_dict(metadata_result))
 

--- a/tests/test_units/test_objectdataprovider_class.py
+++ b/tests/test_units/test_objectdataprovider_class.py
@@ -36,11 +36,11 @@ from ..conftest import remove_ert_env, set_ert_env_prehook
 
 
 def test_objectdata_regularsurface_derive_named_stratigraphy(
-    regsurf: xtgeo.RegularSurface, edataobj1: ExportData
+    regsurf: xtgeo.RegularSurface, mock_exportdata: ExportData
 ) -> None:
     """Get name and some stratigaphic keys for a valid RegularSurface object ."""
     # mimic the stripped parts of configurations for testing here
-    objdata = objectdata_provider_factory(regsurf, edataobj1)
+    objdata = objectdata_provider_factory(regsurf, mock_exportdata)
 
     res = objdata._get_stratigraphy_element()
 
@@ -50,11 +50,11 @@ def test_objectdata_regularsurface_derive_named_stratigraphy(
 
 
 def test_objectdata_regularsurface_get_stratigraphy_element_differ(
-    regsurf: xtgeo.RegularSurface, edataobj2: ExportData
+    regsurf: xtgeo.RegularSurface, drogon_exportdata: ExportData
 ) -> None:
     """Get name and some stratigaphic keys for a valid RegularSurface object ."""
     # mimic the stripped parts of configurations for testing here
-    objdata = objectdata_provider_factory(regsurf, edataobj2)
+    objdata = objectdata_provider_factory(regsurf, drogon_exportdata)
 
     res = objdata._get_stratigraphy_element()
 
@@ -64,7 +64,7 @@ def test_objectdata_regularsurface_get_stratigraphy_element_differ(
 
 
 def test_objectdata_faultroom_fault_juxtaposition_get_stratigraphy_differ(
-    faultroom_object: FaultRoomSurface, edataobj2: ExportData
+    faultroom_object: FaultRoomSurface, drogon_exportdata: ExportData
 ) -> None:
     """
     Fault juxtaposition is a list of formations on the footwall and hangingwall sides.
@@ -72,7 +72,7 @@ def test_objectdata_faultroom_fault_juxtaposition_get_stratigraphy_differ(
     in the global config.
     Also perform a few other tests to verify API and functionality.
     """
-    objdata = objectdata_provider_factory(faultroom_object, edataobj2)
+    objdata = objectdata_provider_factory(faultroom_object, drogon_exportdata)
     assert isinstance(objdata, FaultRoomSurfaceProvider)
 
     assert objdata.extension == ".json"
@@ -98,7 +98,7 @@ def test_objectdata_faultroom_fault_juxtaposition_get_stratigraphy_differ(
 
 
 def test_objectdata_triangulated_surface_validate_spec(
-    tsurf: TSurfData, edataobj2: ExportData
+    tsurf: TSurfData, drogon_exportdata: ExportData
 ) -> None:
     """
     Validate the specifications of the triangulated surface object represented
@@ -106,7 +106,7 @@ def test_objectdata_triangulated_surface_validate_spec(
     TSurf is a file format used in for example the GOCAD software. RMS can export
     triangulated surfaces in its structural model in the TSurf format.
     """
-    objdata = objectdata_provider_factory(tsurf, edataobj2)
+    objdata = objectdata_provider_factory(tsurf, drogon_exportdata)
     assert isinstance(objdata, TriangulatedSurfaceProvider)
 
     assert objdata.classname.value == "surface"
@@ -137,34 +137,34 @@ def test_objectdata_triangulated_surface_validate_spec(
 
 
 def test_objectdata_regularsurface_validate_extension(
-    regsurf: xtgeo.RegularSurface, edataobj1: ExportData
+    regsurf: xtgeo.RegularSurface, mock_exportdata: ExportData
 ) -> None:
     """Test a valid extension for RegularSurface object."""
 
-    objdata = objectdata_provider_factory(regsurf, edataobj1)
+    objdata = objectdata_provider_factory(regsurf, mock_exportdata)
 
     assert objdata.extension == ".gri"
 
 
 def test_objectdata_table_validate_extension_shall_fail(
-    dataframe: pd.DataFrame, edataobj1: ExportData
+    dataframe: pd.DataFrame, mock_exportdata: ExportData
 ) -> None:
     """Test an invalid extension for a table object."""
 
-    edataobj1.table_fformat = "roff"  # set to invalid format
+    mock_exportdata.table_fformat = "roff"  # set to invalid format
 
     with pytest.raises(ConfigurationError):
-        ext = objectdata_provider_factory(dataframe, edataobj1).extension
+        ext = objectdata_provider_factory(dataframe, mock_exportdata).extension
         assert ext == ".roff"
-    edataobj1.table_fformat = None  # reset to default
+    mock_exportdata.table_fformat = None  # reset to default
 
 
 def test_objectdata_regularsurface_spec_bbox(
-    regsurf: xtgeo.RegularSurface, edataobj1: ExportData
+    regsurf: xtgeo.RegularSurface, mock_exportdata: ExportData
 ) -> None:
     """Derive specs and bbox for RegularSurface object."""
 
-    objdata = objectdata_provider_factory(regsurf, edataobj1)
+    objdata = objectdata_provider_factory(regsurf, mock_exportdata)
     specs = objdata.get_spec()
     bbox = objdata.get_bbox()
 
@@ -174,30 +174,32 @@ def test_objectdata_regularsurface_spec_bbox(
 
 
 def test_objectdata_regularsurface_derive_objectdata(
-    regsurf: xtgeo.RegularSurface, edataobj1: ExportData
+    regsurf: xtgeo.RegularSurface, mock_exportdata: ExportData
 ) -> None:
     """Derive other properties."""
 
-    objdata = objectdata_provider_factory(regsurf, edataobj1)
+    objdata = objectdata_provider_factory(regsurf, mock_exportdata)
     assert isinstance(objdata, RegularSurfaceDataProvider)
     assert objdata.classname.value == "surface"
     assert objdata.extension == ".gri"
 
 
 def test_objectdata_regularsurface_derive_metadata(
-    regsurf: xtgeo.RegularSurface, edataobj1: ExportData
+    regsurf: xtgeo.RegularSurface, mock_exportdata: ExportData
 ) -> None:
     """Derive all metadata for the 'data' block in fmu-dataio."""
 
-    myobj = objectdata_provider_factory(regsurf, edataobj1)
+    myobj = objectdata_provider_factory(regsurf, mock_exportdata)
     metadata = myobj.get_metadata()
     assert metadata.root.content == "depth"
     assert metadata.root.alias
 
 
-def test_objectdata_provider_factory_raises_on_unknown(edataobj1: ExportData) -> None:
+def test_objectdata_provider_factory_raises_on_unknown(
+    mock_exportdata: ExportData,
+) -> None:
     with pytest.raises(NotImplementedError, match="not currently supported"):
-        objectdata_provider_factory(object(), edataobj1)
+        objectdata_provider_factory(object(), mock_exportdata)
 
 
 def test_regsurf_preprocessed_observation(
@@ -266,13 +268,13 @@ def test_regsurf_preprocessed_observation(
 
 
 def test_objectdata_compute_md5(
-    gridproperty: xtgeo.GridProperty, edataobj1: ExportData
+    gridproperty: xtgeo.GridProperty, mock_exportdata: ExportData
 ) -> None:
     """Test compute_md5 function works and gives same result as in the metadata"""
 
-    myobj = objectdata_provider_factory(gridproperty, edataobj1)
+    myobj = objectdata_provider_factory(gridproperty, mock_exportdata)
 
-    metadata = edataobj1.generate_metadata(gridproperty)
+    metadata = mock_exportdata.generate_metadata(gridproperty)
     checksum, size = myobj.compute_md5_and_size()
     assert metadata["file"]["checksum_md5"] == checksum
     assert metadata["file"]["size_bytes"] == size

--- a/tests/test_units/test_providers_utils_class.py
+++ b/tests/test_units/test_providers_utils_class.py
@@ -4,10 +4,10 @@ from fmu.dataio.dataio import ExportData
 from fmu.dataio.providers.objectdata._utils import Utils
 
 
-def test_stratigraphy(edataobj2: ExportData) -> None:
+def test_stratigraphy(drogon_exportdata: ExportData) -> None:
     """Test the stratigraphy."""
 
-    strat = edataobj2.config.stratigraphy
+    strat = drogon_exportdata.config.stratigraphy
 
     ###### Test get stratigraphic name ######
 

--- a/tests/test_units/test_table.py
+++ b/tests/test_units/test_table.py
@@ -265,28 +265,30 @@ def test_set_table_index_not_in_table(
 
 
 def test_table_index_timeseries(
-    export_data_obj_timeseries: ExportData, drogon_summary: pa.Table
+    timeseries_exportdata: ExportData, drogon_summary: pa.Table
 ) -> None:
     """Test setting of table_index in an arbitrary timeseries.
 
     Args:
-        edataobj3 (dict): metadata
+        simulationtimeseries_exportdata (dict): metadata
         drogon_summary (pa.Table): table with summary data from sumo
     """
-    objdata = objectdata_provider_factory(drogon_summary, export_data_obj_timeseries)
+    objdata = objectdata_provider_factory(drogon_summary, timeseries_exportdata)
     assert objdata.table_index == ["DATE"], "Incorrect table index "
 
 
 def test_table_index_real_summary(
-    edataobj3: ExportData, drogon_summary: pa.Table
+    simulationtimeseries_exportdata: ExportData, drogon_summary: pa.Table
 ) -> None:
     """Test setting of table_index in real summary file
 
     Args:
-        edataobj3 (dict): metadata
+        simulationtimeseries_exportdata (dict): metadata
         drogon_summary (pa.Table): table with summary data from sumo
     """
-    objdata = objectdata_provider_factory(drogon_summary, edataobj3)
+    objdata = objectdata_provider_factory(
+        drogon_summary, simulationtimeseries_exportdata
+    )
     assert objdata.table_index == ["DATE"], "Incorrect table index "
 
 


### PR DESCRIPTION
'edataobjx' is not descriptive. Final peeve while looking at #1470 (for now)

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [ ] Checked the boxes in this checklist ✅
