### PR TITLE
MAINT: Refactor resolving FMU context

### DIFF
--- a/src/fmu/dataio/_fmu_context.py
+++ b/src/fmu/dataio/_fmu_context.py
@@ -1,0 +1,180 @@
+"""
+Module for resolving and validating FMU context configuration.
+"""
+
+from dataclasses import dataclass, field
+from typing import Final
+
+from fmu.datamodels.fmu_results.enums import FMUContext
+
+from ._logging import null_logger
+
+logger: Final = null_logger(__name__)
+
+
+@dataclass(frozen=True)
+class FMUContextResolution:
+    """Result of resovling FMU context from inputs and environment."""
+
+    context: FMUContext | None
+    preprocessed: bool
+    warnings: list[tuple[str, type[Warning]]] = field(default_factory=list)
+
+
+class FMUContextError(ValueError):
+    """Raised when FMU context configuration is invalid."""
+
+
+def resolve_fmu_context(
+    fmu_context_input: str | None,
+    preprocessed_input: bool,
+    env_context: FMUContext | None,
+) -> FMUContextResolution:
+    """Resolves the effective FMU context from explicit input and environment.
+
+    Returns the resolved context, preprocessed flag, and any warnings to emit.
+
+    Args:
+        fmu_context_input: Explicit fmu_context from user (e.g. "realization", "case").
+        preprocessed_input: Whether the preprocessed flag was set by user.
+        env_context: The FMU context detected from environment variables.
+
+    Returns:
+        FMUContextResolution with the resolved context, preprocessed flag, and any
+          warnings that should be emitted.
+
+    Raises:
+        FMUContextError: If the configuration is invalid (e.g., removed options,
+          incompatible combinations, etc.).
+    """
+    warnings_to_emit: list[tuple[str, type[Warning]]] = []
+    preprocessed = preprocessed_input
+
+    _check_removed_options(fmu_context_input)
+
+    fmu_context_input, preprocessed, deprecation_warnings = _handle_deprecations(
+        fmu_context_input, preprocessed_input
+    )
+    warnings_to_emit.extend(deprecation_warnings)
+
+    effective_context, context_warnings = _determine_effective_context(
+        fmu_context_input, env_context
+    )
+    warnings_to_emit.extend(context_warnings)
+
+    _validate_context_combination(effective_context, preprocessed)
+
+    return FMUContextResolution(
+        context=effective_context,
+        preprocessed=preprocessed,
+        warnings=warnings_to_emit,
+    )
+
+
+def _check_removed_options(fmu_context_input: str | None) -> None:
+    if fmu_context_input and fmu_context_input.lower() == "case_symlink_realization":
+        raise FMUContextError(
+            "fmu_context is set to 'case_symlink_realization', which is no longer a "
+            "supported option. Recommended workflow is to export your data as "
+            "preprocessed ouside of FMU, and re-export the data with "
+            "fmu_context='case' using a PRE_SIMULATION ERT workflow. If needed, "
+            "forward_models in ERT can be set-up to create symlinks out into the "
+            "individual realizations.",
+        )
+
+
+def _handle_deprecations(
+    fmu_context_input: str | None,
+    preprocessed_input: bool,
+) -> tuple[str | None, bool, list[tuple[str, type[Warning]]]]:
+    """
+    Handle deprecated input patterns.
+
+    Returns: tuple of (fmu_context, preprocessed, warnings).
+    """
+    warnings_to_emit: list[tuple[str, type[Warning]]] = []
+
+    if fmu_context_input == "preprocessed":
+        warnings_to_emit.append(
+            (
+                "Using the 'fmu_context' argument with value 'preprocessed' is "
+                "deprecated and will be removed in the future. Use the more explicit "
+                "'preprocessed' argument instead: ExportData(preprocessed=True)",
+                FutureWarning,
+            )
+        )
+        return None, True, warnings_to_emit
+
+    if fmu_context_input and fmu_context_input.lower() == "iteration":
+        return "ensemble", preprocessed_input, warnings_to_emit
+
+    return fmu_context_input, preprocessed_input, warnings_to_emit
+
+
+def _determine_effective_context(
+    explicit_context: str | None,
+    env_context: FMUContext | None,
+) -> tuple[FMUContext | None, list[tuple[str, type[Warning]]]]:
+    """
+    Determine the effective FMU context from explicit input and environment.
+
+    Returns:
+        Tuple of (effective_context, warnings)
+    """
+    warnings_to_emit: list[tuple[str, type[Warning]]] = []
+
+    if explicit_context is None:
+        logger.info(f"fmu_context from environment: {env_context}")
+
+        if env_context == FMUContext.iteration:
+            return FMUContext.ensemble, warnings_to_emit
+
+        return env_context, warnings_to_emit
+
+    if env_context is None:
+        # Explicit context requested, but we're not in an FMU env
+        logger.warning(
+            f"Requested fmu_context={explicit_context} but not running in FMU "
+            "environment; context will be None."
+        )
+        return None, warnings_to_emit
+
+    explicit_enum = FMUContext(explicit_context.lower())
+
+    if explicit_enum == FMUContext.realization and env_context == FMUContext.case:
+        warnings_to_emit.append(
+            (
+                "fmu_context is set to 'realization', but unable to detect ERT "
+                "runpath from environment variable. Did you mean fmu_context='case'?",
+                UserWarning,
+            )
+        )
+
+    if explicit_enum == FMUContext.ensemble and env_context == FMUContext.realization:
+        warnings_to_emit.append(
+            (
+                "fmu_context is set to 'ensemble', but a realization environment "
+                "was detected. Did you mean fmu_context='realization'?",
+                UserWarning,
+            )
+        )
+
+    logger.info(f"fmu_context set explicitly to {explicit_enum}")
+    return explicit_enum, warnings_to_emit
+
+
+def _validate_context_combination(
+    context: FMUContext | None, preprocessed: bool
+) -> None:
+    """Validate that the resolved context combination is allowed.
+
+    Raises:
+        FMUContextError: If the combination is invalid.
+    """
+    if preprocessed and context == FMUContext.realization:
+        raise FMUContextError(
+            "Can't export preprocessed data in a fmu_context='realization'. "
+            "Preprocessed data should be exported with fmu_context='case' or "
+            "outside of FMU entirely, and then re-exported using "
+            "ExportPreprocessedData."
+        )

--- a/src/fmu/dataio/_metadata.py
+++ b/src/fmu/dataio/_metadata.py
@@ -131,5 +131,5 @@ def generate_export_metadata(
         file=_get_meta_filedata(dataio._runcontext, objdata),
         tracklog=Tracklog.initialize(__version__),
         display=_get_meta_display(dataio, objdata),
-        preprocessed=dataio.preprocessed,
+        preprocessed=dataio._resolved_preprocessed,
     )

--- a/src/fmu/dataio/providers/_filedata.py
+++ b/src/fmu/dataio/providers/_filedata.py
@@ -44,7 +44,7 @@ class SharePathConstructor:
 
     def _get_share_root(self) -> Path:
         """Get the main share root location as a path e.g. share/results."""
-        if self.dataio.preprocessed:
+        if self.dataio._resolved_preprocessed:
             return Path(ShareFolder.PREPROCESSED.value)
         if self.dataio.is_observation:
             return Path(ShareFolder.OBSERVATIONS.value)

--- a/tests/test_units/test_fmu_context.py
+++ b/tests/test_units/test_fmu_context.py
@@ -1,0 +1,231 @@
+"""Tests for FMU context resolution."""
+
+from pathlib import Path
+
+import pytest
+from fmu.datamodels.fmu_results.enums import FMUContext
+
+from fmu.dataio._fmu_context import (
+    FMUContextError,
+    FMUContextResolution,
+    resolve_fmu_context,
+)
+from fmu.dataio._runcontext import get_fmu_context_from_environment
+
+
+def test_no_input_no_env_returns_none_context() -> None:
+    """When no input and no environment, context should be None."""
+    resolution = resolve_fmu_context(
+        fmu_context_input=None,
+        preprocessed_input=False,
+        env_context=None,
+    )
+
+    assert resolution.context is None
+    assert resolution.preprocessed is False
+    assert resolution.warnings == []
+
+
+@pytest.mark.parametrize("explicit_context", [str(c.value) for c in FMUContext])
+def test_explicit_content_without_env_returns_none(explicit_context: str) -> None:
+    """Explicit context is ignored when not in FMU environment."""
+    resolution = resolve_fmu_context(
+        fmu_context_input=explicit_context,
+        preprocessed_input=False,
+        env_context=None,
+    )
+    assert resolution.context is None
+
+
+@pytest.mark.parametrize(
+    ("env_context", "expected"),
+    [(c, c if c != FMUContext.iteration else FMUContext.ensemble) for c in FMUContext],
+)
+def test_no_explicit_uses_env_context(
+    env_context: FMUContext,
+    expected: FMUContext,
+) -> None:
+    """When no explicit context, environment context is used."""
+    resolution = resolve_fmu_context(
+        fmu_context_input=None,
+        preprocessed_input=False,
+        env_context=env_context,
+    )
+    assert resolution.context == expected
+    assert resolution.warnings == []
+
+
+@pytest.mark.parametrize(
+    ("explicit", "env", "expected"),
+    [
+        ("realization", FMUContext.realization, FMUContext.realization),
+        ("case", FMUContext.case, FMUContext.case),
+        ("case", FMUContext.realization, FMUContext.case),
+    ],
+)
+def test_explicit_context_takes_precedence(
+    explicit: str,
+    env: FMUContext,
+    expected: FMUContext,
+) -> None:
+    """Explicit content overrides environment when both present."""
+    resolution = resolve_fmu_context(
+        fmu_context_input=explicit,
+        preprocessed_input=False,
+        env_context=env,
+    )
+    assert resolution.context == expected
+
+
+def test_realization_request_in_case_env_emits_warning() -> None:
+    """Requesting realization when env is case emits a helpful warning."""
+    resolution = resolve_fmu_context(
+        fmu_context_input="realization",
+        preprocessed_input=False,
+        env_context=FMUContext.case,
+    )
+
+    assert resolution.context == FMUContext.realization
+    assert len(resolution.warnings) == 1
+
+    message, category = resolution.warnings[0]
+    assert "Did you mean fmu_context='case'?" in message
+    assert category is UserWarning
+
+
+def test_fmu_context_preprocessed_emits_deprecation_warning() -> None:
+    """Using fmu_context="preprocessed" triggers deprecation warning."""
+    resolution = resolve_fmu_context(
+        fmu_context_input="preprocessed",
+        preprocessed_input=False,
+        env_context=None,
+    )
+
+    assert resolution.preprocessed is True
+    assert len(resolution.warnings) == 1
+
+    message, category = resolution.warnings[0]
+    assert "deprecated" in message.lower()
+    assert "preprocessed=True" in message
+    assert category is FutureWarning
+
+
+def test_fmu_context_preprocessed_with_case_env() -> None:
+    """Deprecated fmu_context="preprocessed" works with case environment."""
+    resolution = resolve_fmu_context(
+        fmu_context_input="preprocessed",
+        preprocessed_input=False,
+        env_context=FMUContext.case,
+    )
+
+    assert resolution.preprocessed is True
+    assert resolution.context == FMUContext.case
+
+
+@pytest.mark.parametrize("iteration_variant", ["iteration", "ITERATION", "Iteration"])
+def test_iteration_converted_to_ensemble(iteration_variant: str) -> None:
+    """Using "iteration" context is converted to "ensemble"."""
+    resolution = resolve_fmu_context(
+        fmu_context_input=iteration_variant,
+        preprocessed_input=False,
+        env_context=FMUContext.ensemble,
+    )
+
+    assert resolution.context == FMUContext.ensemble
+
+
+def test_case_symlink_realization_raises_error() -> None:
+    """Using removed "case_symlink_realization" raises FMUContextError."""
+    with pytest.raises(FMUContextError, match="no longer a supported"):
+        resolve_fmu_context(
+            fmu_context_input="case_symlink_realization",
+            preprocessed_input=False,
+            env_context=None,
+        )
+
+
+def test_preprocessed_with_realization_raises_error() -> None:
+    """Cannot export preprocessed data in realization context."""
+    with pytest.raises(FMUContextError, match="[Pp]reprocessed.*realization"):
+        resolve_fmu_context(
+            fmu_context_input="realization",
+            preprocessed_input=True,
+            env_context=FMUContext.realization,
+        )
+
+
+def test_preprocessed_with_case_is_allowed() -> None:
+    """Preprocessed data can be exported in case context."""
+    resolution = resolve_fmu_context(
+        fmu_context_input="case",
+        preprocessed_input=True,
+        env_context=FMUContext.case,
+    )
+
+    assert resolution.context == FMUContext.case
+    assert resolution.preprocessed is True
+    assert resolution.warnings == []
+
+
+def test_preprocessed_outside_fmu_is_allowed() -> None:
+    """Preprocessed export outside FMU context is valid."""
+    resolution = resolve_fmu_context(
+        fmu_context_input=None,
+        preprocessed_input=True,
+        env_context=None,
+    )
+
+    assert resolution.context is None
+    assert resolution.preprocessed is True
+
+
+def test_resolution_is_immutable() -> None:
+    """FMUContextResolution should be frozen (immutable)."""
+    resolution = FMUContextResolution(
+        context=FMUContext.realization,
+        preprocessed=False,
+    )
+
+    with pytest.raises(AttributeError):
+        resolution.context = FMUContext.case  # type: ignore[misc]
+
+
+def test_resolution_warnings_default_to_empty_list() -> None:
+    """Warnings should default to empty list."""
+    resolution = FMUContextResolution(context=None, preprocessed=False)
+    assert resolution.warnings == []
+
+
+def test_realization_context_from_env(
+    fmurun_w_casemetadata: Path,
+) -> None:
+    """Test resolution with Ert environment variables."""
+    env_context = get_fmu_context_from_environment()
+    resolution = resolve_fmu_context(
+        fmu_context_input=None,
+        preprocessed_input=False,
+        env_context=env_context,
+    )
+    assert resolution.context == FMUContext.realization
+
+
+def test_case_context_from_env(fmurun_prehook: Path) -> None:
+    """Test resolution when only case environment is set."""
+    env_context = get_fmu_context_from_environment()
+    resolution = resolve_fmu_context(
+        fmu_context_input=None,
+        preprocessed_input=False,
+        env_context=env_context,
+    )
+    assert resolution.context == FMUContext.case
+
+
+def test_ensemble_context_when_case_context_from_env(fmurun_prehook: Path) -> None:
+    """Test resolution when case environment is set, but ensemble given."""
+    env_context = get_fmu_context_from_environment()
+    resolution = resolve_fmu_context(
+        fmu_context_input="ensemble",
+        preprocessed_input=False,
+        env_context=env_context,
+    )
+    assert resolution.context == FMUContext.ensemble

--- a/tests/test_units/test_rms_context.py
+++ b/tests/test_units/test_rms_context.py
@@ -416,7 +416,7 @@ def test_cube_export_as_case(
     # use forcefolder to apply share/observations/seismic
     output = edata.export(cube)
     logger.info("Output %s", output)
-    assert edata.fmu_context is None
+    assert edata._resolved_fmu_context is None
     assert str(output) == str(
         (
             edata._runcontext.exportroot / "share/observations/cubes/mycube.segy"


### PR DESCRIPTION
Part of #1485 

This pulls the logic handling resolution of the FMU context to its own module. It also adds initial support for the ensemble context.

This also changes user input to the ExportData class to be immutable in the case of 'fmu_context' and 'preprocessed'. The resolved values are stored separately.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
