### PR TITLE
ENH: Add ExportConfig

### DIFF
--- a/src/fmu/dataio/_export_config.py
+++ b/src/fmu/dataio/_export_config.py
@@ -1,0 +1,396 @@
+"""
+Module for ExportConfig which contains the fully resolved export configuration.
+
+This is the interface used internally which has already processed user input and
+undergone input validation and transformations.
+"""
+
+from __future__ import annotations
+
+import warnings
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Final, Literal, Self
+
+from fmu.datamodels.common.enums import Classification
+from fmu.datamodels.fmu_results.enums import (
+    Content,
+    DomainReference,
+    FMUContext,
+    VerticalDomain,
+)
+from fmu.datamodels.fmu_results.fields import Display, Workflow
+from fmu.datamodels.fmu_results.global_configuration import GlobalConfiguration
+
+from ._fmu_context import resolve_fmu_context
+from ._logging import null_logger
+from ._runcontext import RunContext, get_fmu_context_from_environment
+
+logger: Final = null_logger(__name__)
+
+
+if TYPE_CHECKING:
+    from .dataio import ExportData
+
+
+@dataclass(frozen=True)
+class ExportConfig:
+    """Immutable configuration for export operations.
+
+    All values are resolved and validated at creation time.
+    """
+
+    # Content
+    content: Content | Literal["unset"]
+    content_metadata: dict[str, Any] | None
+
+    # File/path configuration
+    name: str
+    tagname: str
+    forcefolder: str
+    subfolder: str
+    parent: str
+    filename_timedata_reverse: bool
+    geometry: str | None
+
+    # Domain configuration
+    vertical_domain: VerticalDomain
+    domain_reference: DomainReference
+
+    # FMU context
+    fmu_context: FMUContext | None
+    display: Display
+    workflow: Workflow | None
+    description: list[str] | None
+
+    # Classification/access
+    classification: Classification
+    rep_include: bool
+
+    # Table configuration
+    table_index: list[str] | None
+    table_fformat: str
+    polygons_fformat: str
+    points_fformat: str
+
+    # Time configuration
+    timedata: list[str] | list[list[str]] | None
+
+    # Other
+    preprocessed: bool
+    is_prediction: bool
+    is_observation: bool
+    unit: str
+    undef_is_zero: bool
+
+    # Casepath
+    casepath: Path | None
+
+    # Global configuration
+    config: GlobalConfiguration | None
+    runcontext: RunContext
+
+    @classmethod
+    def from_export_data(cls, dataio: ExportData) -> Self:
+        """Create an ExportConfig from an ExportData instance.
+
+        Args:
+            dataio: The ExportData instance to create config from.
+
+        Returns:
+            An immutable ExportConfig with all resolved values.
+        """
+
+        vertical_domain, domain_reference = _resolve_vertical_domain(
+            dataio.vertical_domain, dataio.domain_reference
+        )
+        fmu_context, preprocessed = _resolve_fmu_context(
+            dataio.fmu_context, dataio.preprocessed
+        )
+        config = (
+            dataio.config if isinstance(dataio.config, GlobalConfiguration) else None
+        )
+        casepath = Path(dataio.casepath) if dataio.casepath else None
+
+        return cls(
+            # Content
+            content=_resolve_content_enum(dataio.content) or "unset",
+            content_metadata=_resolve_content_metadata(
+                dataio.content_metadata, dataio.content
+            ),
+            # File/path
+            name=dataio.name,
+            tagname=dataio.tagname,
+            forcefolder=dataio.forcefolder,
+            subfolder=dataio.subfolder,
+            parent=dataio.parent,
+            filename_timedata_reverse=dataio.filename_timedata_reverse,
+            geometry=dataio.geometry,
+            # Domain
+            vertical_domain=vertical_domain,
+            domain_reference=domain_reference,
+            # FMU context
+            fmu_context=fmu_context,
+            preprocessed=preprocessed,
+            display=Display(name=dataio.display_name),
+            workflow=_resolve_workflow(dataio.workflow),
+            # Classification/access
+            classification=_resolve_classification(
+                dataio.classification, dataio.access_ssdl, config
+            ),
+            rep_include=_resolve_rep_include(
+                dataio.rep_include, dataio.access_ssdl, config
+            ),
+            is_prediction=dataio.is_prediction,
+            is_observation=dataio.is_observation,
+            # Table
+            table_index=dataio.table_index,
+            table_fformat=dataio.table_fformat,
+            polygons_fformat=dataio.polygons_fformat,
+            points_fformat=dataio.points_fformat,
+            # Time
+            timedata=dataio.timedata,
+            # Other
+            unit=dataio.unit or "",
+            undef_is_zero=dataio.undef_is_zero,
+            description=_resolve_description(dataio.description),
+            # Casepath
+            casepath=casepath,
+            # Config
+            config=config,
+            runcontext=RunContext(casepath, fmu_context),
+        )
+
+
+def _resolve_content_enum(content: str | dict[str, Any] | None) -> Content | None:
+    """Resolve the content from raw input.
+
+    Args:
+        content: User-provided string, None, or (deprecated) dictionary.
+
+    Returns:
+        Resolved enum value or None.
+    """
+    if content is None:
+        logger.debug("content not set from input, returning None'")
+        return None
+
+    if isinstance(content, str):
+        logger.debug("content is set from string input")
+        return Content(content)
+
+    if isinstance(content, dict):
+        logger.debug("content is set from dict input")
+        return Content(next(iter(content)))
+
+    raise ValueError(
+        f"'{content}' is not a valid value for 'content'. Use one "
+        f"of: {', '.join([m.value for m in Content])}."
+    )
+
+
+def _resolve_vertical_domain(
+    vertical_domain: str | dict[str, Any], domain_reference: str
+) -> tuple[VerticalDomain, DomainReference]:
+    """Resolve vertical_domain and domain_reference from raw input.
+
+    Handles the deprecated dict format for vertical_domain by extracting the domain and
+    reference values.
+
+    Args:
+        vertical_domain: User-provided vertical_domain (string or deprecated dict).
+        domain_reference: User-provided domain_reference.
+
+    Returns:
+        Tuple of (vertical_domain, domain_reference) in resolved enum values.
+    """
+    if isinstance(vertical_domain, dict):
+        vert_domain_str, domain_ref_str = next(iter(vertical_domain.items()))
+    else:
+        vert_domain_str = vertical_domain
+        domain_ref_str = domain_reference
+
+    try:
+        vert_domain_enum = VerticalDomain(vert_domain_str)
+    except ValueError as e:
+        raise ValueError(
+            f"'{vert_domain_str}' is not a valid value for 'vertical_domain'. Use one "
+            f"of: {', '.join([m.value for m in VerticalDomain])}."
+        ) from e
+
+    try:
+        domain_ref_enum = DomainReference(domain_ref_str)
+    except ValueError as e:
+        raise ValueError(
+            f"'{domain_ref_str}' is not a valid value for 'domain_reference'. Use one "
+            f"of: {', '.join([m.value for m in DomainReference])}."
+        ) from e
+
+    return vert_domain_enum, domain_ref_enum
+
+
+def _resolve_content_metadata(
+    content_metadata: dict | None, content: str | dict | None
+) -> dict | None:
+    """
+    Get the content metadata if provided by as input, else return None.
+    Validation takes place in the objectdata provider.
+    """
+    if content_metadata:
+        logger.debug("content_metadata is set from content_metadata argument")
+        return content_metadata
+
+    if isinstance(content, dict):
+        logger.debug("content_metadata is set from content argument")
+        content_enum = _resolve_content_enum(content)
+        return content[content_enum]
+
+    logger.debug("Found no content_metadata, returning None")
+    return None
+
+
+def _resolve_fmu_context(
+    fmu_context_input: str | None, preprocessed_input: bool
+) -> tuple[FMUContext | None, bool]:
+    """Resolve FMU context from user input and environment.
+
+    Args:
+        fmu_context_input: User-provided fmu_context value.
+        preprocessed_input: User-provided preprocessed flag.
+
+    Returns:
+        Tuple of (resolved_fmu_context, resolved_preprocessed).
+    """
+    env_context = get_fmu_context_from_environment()
+    resolution = resolve_fmu_context(
+        fmu_context_input=fmu_context_input,
+        preprocessed_input=preprocessed_input,
+        env_context=env_context,
+    )
+
+    for message, category in resolution.warnings:
+        warnings.warn(message, category)
+
+    return resolution.context, resolution.preprocessed
+
+
+def _resolve_classification(
+    classification_input: str | None,
+    access_ssdl: dict[str, Any] | None,
+    config: GlobalConfiguration | None,
+) -> Classification:
+    """Resolve classification from multiple sources.
+
+    Resolution order:
+    1. from classification argument if present
+    2. from access_ssdl argument (deprecated) if present
+    3. from access.classification in config
+
+    Args:
+        classification_input: User-provided classification value.
+        access_ssdl: Deprecated access_ssdl dict.
+        config: Global configuration.
+
+    Returns:
+        Resolved Classification enum value.
+    """
+    if classification_input is not None:
+        logger.info("Classification is set from input")
+        classification = classification_input
+
+    elif access_ssdl and access_ssdl.get("access_level"):
+        logger.info("Classification is set from access_ssdl input")
+        classification = access_ssdl["access_level"]
+
+    elif isinstance(config, GlobalConfiguration):
+        logger.info("Classification is set from config")
+        assert config.access.classification
+        classification = config.access.classification
+    else:
+        # Default when config is invalid (no metadata will be produced anyway)
+        logger.info("Using default classification 'internal'")
+        classification = Classification.internal
+
+    # Handle deprecated 'asset' value
+    if Classification(classification) == Classification.asset:
+        warnings.warn(
+            "The value 'asset' for access.ssdl.access_level is deprecated. "
+            "Please use 'restricted' in input arguments or global variables "
+            "to silence this warning.",
+            FutureWarning,
+        )
+        return Classification.restricted
+
+    return Classification(classification)
+
+
+def _resolve_rep_include(
+    rep_include_input: bool | None,
+    access_ssdl: dict[str, Any] | None,
+    config: GlobalConfiguration | None,
+) -> bool:
+    """Resolve rep_include from multiple sources.
+
+    Resolution order:
+    1. from rep_include argument if present
+    2. from access_ssdl argument (deprecated) if present
+    3. from access.ssdl.rep_include in config
+    4. default to False if not found
+
+    Args:
+        rep_include_input: User-provided rep_include value.
+        access_ssdl: Deprecated access_ssdl dict.
+        config: Global configuration.
+
+    Returns:
+        Resolved rep_include boolean value.
+    """
+    if rep_include_input is not None:
+        logger.debug("rep_include is set from input")
+        return rep_include_input
+
+    if access_ssdl and access_ssdl.get("rep_include"):
+        logger.debug("rep_include is set from access_ssdl input")
+        return access_ssdl["rep_include"]
+
+    if (
+        isinstance(config, GlobalConfiguration)
+        and (ssdl := config.access.ssdl)
+        and ssdl.rep_include is not None
+    ):
+        warnings.warn(
+            "Setting 'rep_include' from the config is deprecated. Use the "
+            "'rep_include' argument instead (default value is False). To silence "
+            "this warning remove the 'access.ssdl.rep_include' from the config.",
+            FutureWarning,
+        )
+        logger.debug("rep_include is set from config")
+        return ssdl.rep_include
+
+    logger.debug("Using default 'rep_include'=False")
+    return False
+
+
+def _resolve_workflow(workflow: str | dict[str, str] | None) -> Workflow | None:
+    if workflow is None:
+        return None
+    if isinstance(workflow, dict):
+        return Workflow.model_validate(workflow)
+    return Workflow(reference=workflow)
+
+
+def _resolve_description(
+    description: str | list[str] | None = None,
+) -> list[str] | None:
+    """Resolve desciption input."""
+    if not description:
+        return None
+    if isinstance(description, str):
+        return [description]
+    if isinstance(description, list) and all(isinstance(s, str) for s in description):
+        return description
+
+    raise ValueError(
+        f"'{description}' is not a valid value for 'description'. Use one of: "
+        "string or list of strings."
+    )

--- a/tests/test_units/test_dataio.py
+++ b/tests/test_units/test_dataio.py
@@ -511,31 +511,6 @@ def test_content_given_init_or_later(
     assert mymeta["data"]["content"] == "depth"  # last content shall win
 
 
-def test_content_invalid_string(
-    mock_global_config: dict[str, Any], regsurf: xtgeo.RegularSurface
-) -> None:
-    eobj = ExportData(config=mock_global_config, content="not_valid")
-    with pytest.raises(ValueError, match="Invalid 'content' value='not_valid'"):
-        eobj.generate_metadata(regsurf)
-
-
-def test_content_invalid_dict(
-    mock_global_config: dict[str, Any], regsurf: xtgeo.RegularSurface
-) -> None:
-    eobj = ExportData(
-        config=mock_global_config, content={"not_valid": {"some_key": "some_value"}}
-    )
-    with pytest.raises(ValueError, match="Invalid 'content' value='not_valid'"):
-        eobj.generate_metadata(regsurf)
-
-    eobj = ExportData(
-        config=mock_global_config,
-        content={"seismic": "some_key", "extra": "some_value"},
-    )
-    with pytest.raises(ValueError):
-        eobj.generate_metadata(regsurf)
-
-
 def test_content_metadata_valid(
     mock_global_config: dict[str, Any], regsurf: xtgeo.RegularSurface
 ) -> None:
@@ -780,17 +755,26 @@ def test_vertical_domain(
     assert mymeta["data"]["domain_reference"] == "msl"  # default value
 
     # test invalid input
-    with pytest.raises(pydantic.ValidationError, match="vertical_domain"):
+    with pytest.raises(
+        ValueError, match="'wrong' is not a valid value for 'vertical_domain'"
+    ):
         ExportData(
             config=mock_global_config, vertical_domain="wrong", content="thickness"
         ).generate_metadata(regsurf)
-    with pytest.raises(pydantic.ValidationError, match="domain_reference"):
+
+    with pytest.raises(
+        ValueError, match="'wrong' is not a valid value for 'domain_reference'"
+    ):
         ExportData(
             config=mock_global_config, domain_reference="wrong", content="thickness"
         ).generate_metadata(regsurf)
+
     with (
         pytest.warns(FutureWarning, match="deprecated"),
-        pytest.raises(pydantic.ValidationError, match="2 validation errors"),
+        pytest.raises(
+            ValueError,
+            match="'invalid' is not a valid value for 'vertical_domain'",
+        ),
     ):
         ExportData(
             config=mock_global_config,

--- a/tests/test_units/test_export_config.py
+++ b/tests/test_units/test_export_config.py
@@ -1,0 +1,365 @@
+"""Tests for ExportConfig and its resolution/validation functions."""
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fmu.datamodels.common.enums import Classification
+from fmu.datamodels.fmu_results.enums import (
+    Content,
+    DomainReference,
+    VerticalDomain,
+)
+from fmu.datamodels.fmu_results.fields import Workflow
+from fmu.datamodels.fmu_results.global_configuration import GlobalConfiguration
+
+from fmu.dataio._export_config import (
+    ExportConfig,
+    _resolve_classification,
+    _resolve_content_enum,
+    _resolve_content_metadata,
+    _resolve_description,
+    _resolve_rep_include,
+    _resolve_vertical_domain,
+    _resolve_workflow,
+)
+
+
+@pytest.fixture
+def mock_config_internal() -> GlobalConfiguration:
+    """Mock internal classification."""
+    return MagicMock(
+        spec=GlobalConfiguration,
+        access=MagicMock(
+            classification=Classification.internal.value,
+            ssdl=MagicMock(rep_include=None),
+        ),
+    )
+
+
+@pytest.fixture
+def mock_export_data() -> MagicMock:
+    """Create a mock export data with all required attributes."""
+    mock = MagicMock()
+    mock.content = "depth"
+    mock.content_metadata = None
+    mock.name = "test_name"
+    mock.tagname = "test_tag"
+    mock.forcefolder = ""
+    mock.subfolder = ""
+    mock.parent = ""
+    mock.filename_timedata_reverse = False
+    mock.geometry = None
+    mock.vertical_domain = "depth"
+    mock.domain_reference = "msl"
+    mock.fmu_context = None
+    mock.preprocessed = False
+    mock.display_name = "Test Display"
+    mock.workflow = None
+    mock.description = None
+    mock.classification = "internal"
+    mock.access_ssdl = None
+    mock.rep_include = None
+    mock.is_prediction = True
+    mock.is_observation = False
+    mock.table_index = None
+    mock.table_fformat = "csv"
+    mock.polygons_fformat = "csv"
+    mock.points_fformat = "csv"
+    mock.timedata = None
+    mock.unit = "m"
+    mock.undef_is_zero = False
+    mock.casepath = None
+    mock.config = {}
+    return mock
+
+
+@pytest.mark.parametrize(
+    ("content", "expected"),
+    [
+        (None, None),
+        ("depth", Content.depth),
+        ("time", Content.time),
+        ("seismic", Content.seismic),
+        ({"seismic": {"attribute": "amplitude"}}, Content.seismic),
+        ({"depth": {}}, Content.depth),
+    ],
+)
+def test_resolve_content_enum(
+    content: str | dict[str, Any] | None,
+    expected: Content | None,
+) -> None:
+    """Resolves content to enum from possible formats."""
+    assert _resolve_content_enum(content) == expected
+
+
+@pytest.mark.parametrize(
+    ("content", "match"),
+    [
+        (123, "not a valid value for 'content'"),
+        ("not_a_content", None),
+    ],
+)
+def test_resolve_content_enum_invalid(content: Any, match: str | None) -> None:
+    """Raises ValueError for invalid content inputs."""
+    with pytest.raises(ValueError, match=match):
+        _resolve_content_enum(content)
+
+
+@pytest.mark.parametrize(
+    ("content_metadata", "content", "expected"),
+    [
+        ({"attribute": "amplitude"}, "seismic", {"attribute": "amplitude"}),
+        (
+            {"attribute": "custom"},
+            {"seismic": {"attribute": "from_dict"}},
+            {"attribute": "custom"},
+        ),
+        (
+            None,
+            {"seismic": {"attribute": "amplitude", "calculation": "mean"}},
+            {"attribute": "amplitude", "calculation": "mean"},
+        ),
+        (None, "depth", None),
+        (None, None, None),
+    ],
+)
+def test_resolve_content_metadata(
+    content_metadata: dict[str, Any] | None,
+    content: str | dict[str, Any] | None,
+    expected: dict[str, Any] | None,
+) -> None:
+    """Resolves content metadata from arg or dict."""
+    assert _resolve_content_metadata(content_metadata, content) == expected
+
+
+@pytest.mark.parametrize(
+    ("vertical_domain", "domain_reference", "expected_domain", "expected_ref"),
+    [
+        ("depth", "msl", VerticalDomain.depth, DomainReference.msl),
+        ("time", "sb", VerticalDomain.time, DomainReference.sb),
+        ("depth", "rkb", VerticalDomain.depth, DomainReference.rkb),
+        ({"time": "sb"}, "msl", VerticalDomain.time, DomainReference.sb),
+        ({"depth": "rkb"}, "ignored", VerticalDomain.depth, DomainReference.rkb),
+    ],
+)
+def test_resolve_vertical_domain(
+    vertical_domain: str | dict[str, str],
+    domain_reference: str,
+    expected_domain: VerticalDomain,
+    expected_ref: DomainReference,
+) -> None:
+    """Resolves vert domain and domain ref from string or dict inputs."""
+    vert, ref = _resolve_vertical_domain(vertical_domain, domain_reference)
+    assert vert == expected_domain
+    assert ref == expected_ref
+
+
+@pytest.mark.parametrize(
+    ("vertical_domain", "domain_reference", "match"),
+    [
+        ("invalid", "msl", "not a valid value for 'vertical_domain'"),
+        ("depth", "invalid", "not a valid value for 'domain_reference'"),
+        ({"invalid", "msl"}, "msl", "not a valid value for 'vertical_domain'"),
+    ],
+)
+def test_resolve_vertical_domain_invalid(
+    vertical_domain: str | dict[str, str], domain_reference: str, match: str
+) -> None:
+    """Raises ValueError for invalid domain or reference."""
+    with pytest.raises(ValueError, match=match):
+        _resolve_vertical_domain(vertical_domain, domain_reference)
+
+
+@pytest.mark.parametrize(
+    ("classification_input", "access_ssdl", "use_config", "expected"),
+    [
+        ("restricted", None, False, Classification.restricted),
+        ("restricted", {"access_level": "internal"}, True, Classification.restricted),
+        ("internal", None, True, Classification.internal),
+        (None, {"access_level": "restricted"}, False, Classification.restricted),
+        (None, {"access_level": "internal"}, False, Classification.internal),
+        (None, None, False, Classification.internal),
+    ],
+)
+def test_resolve_classification(
+    classification_input: str | None,
+    access_ssdl: dict[str, Any] | None,
+    use_config: bool,
+    expected: Classification,
+    mock_config_internal: GlobalConfiguration,
+) -> None:
+    """Resolves classification from different inputs."""
+    config = mock_config_internal if use_config else None
+    result = _resolve_classification(classification_input, access_ssdl, config)
+    assert result == expected
+
+
+def test_resolve_classification_asset_deprecated() -> None:
+    """Deprecated 'asset' value is converted to 'restricted' with a warning."""
+    with pytest.warns(FutureWarning, match="'asset'.*deprecated"):
+        result = _resolve_classification("asset", None, None)
+    assert result == Classification.restricted
+
+
+@pytest.mark.parametrize(
+    ("rep_include_input", "access_ssdl", "expected"),
+    [
+        (True, None, True),
+        (False, None, False),
+        (False, {"rep_include": True}, False),
+        (True, {"rep_include": False}, True),
+        (None, {"rep_include": True}, True),
+        (None, {"rep_include": False}, False),
+        (None, None, False),
+    ],
+)
+def test_resolve_rep_include(
+    rep_include_input: bool | None,
+    access_ssdl: dict[str, Any] | None,
+    expected: bool,
+) -> None:
+    """Resolves rep_include from input or access_ssdl."""
+    result = _resolve_rep_include(rep_include_input, access_ssdl, None)
+    assert result is expected
+
+
+def test_resolve_rep_include_from_config_with_warning() -> None:
+    """Falls back to config with derecation warning."""
+    config = MagicMock(
+        spec=GlobalConfiguration,
+        access=MagicMock(ssdl=MagicMock(rep_include=True)),
+    )
+    with pytest.warns(FutureWarning, match="deprecated"):
+        result = _resolve_rep_include(None, None, config)
+    assert result is True
+
+
+def test_resolve_rep_include_config_without_ssdl() -> None:
+    """Handles config without ssdl in it."""
+    config = MagicMock(spec=GlobalConfiguration, access=MagicMock(ssdl=None))
+    result = _resolve_rep_include(None, None, config)
+    assert result is False
+
+
+@pytest.mark.parametrize(
+    ("workflow", "expected_reference"),
+    [
+        (None, None),
+        ("cool workflow", "cool workflow"),
+        ({"reference": "workflow ref"}, "workflow ref"),
+    ],
+)
+def test_resolve_workflow(
+    workflow: str | dict[str, str] | None, expected_reference: str | None
+) -> None:
+    """Resolves workflow from string or dict."""
+    result = _resolve_workflow(workflow)
+    if expected_reference is None:
+        assert result is None
+    else:
+        assert isinstance(result, Workflow)
+        assert result.reference == expected_reference
+
+
+@pytest.mark.parametrize(
+    ("desc", "expected"),
+    [
+        (None, None),
+        ("", None),
+        ("My description", ["My description"]),
+        (["Line 1", "Line 2"], ["Line 1", "Line 2"]),
+    ],
+)
+def test_resolve_description(
+    desc: str | list[str] | None, expected: list[str] | None
+) -> None:
+    """Resolves description toa a list."""
+    assert _resolve_description(desc) == expected
+
+
+def test_resolve_description_invalid_type() -> None:
+    """Raises value error on bad type."""
+    with pytest.raises(ValueError, match="not a valid value for 'description'"):
+        _resolve_description(1)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="not a valid value for 'description'"):
+        _resolve_description(["foo", 1])  # type: ignore[list-item]
+
+
+def test_export_config_from_export_data_basic(mock_export_data: MagicMock) -> None:
+    """ExportConfig is created with resolved values from ExportData."""
+    with patch("fmu.dataio._export_config._resolve_fmu_context") as mock_fmu_ctx:
+        mock_fmu_ctx.return_value = (None, False)
+
+        config = ExportConfig.from_export_data(mock_export_data)
+
+        assert config.content == Content.depth
+        assert config.name == "test_name"
+        assert config.tagname == "test_tag"
+        assert config.vertical_domain == VerticalDomain.depth
+        assert config.domain_reference == DomainReference.msl
+        assert config.classification == Classification.internal
+        assert config.unit == "m"
+        assert config.is_prediction is True
+        assert config.is_observation is False
+
+
+@pytest.mark.parametrize(
+    ("attr", "value", "expected_attr", "expected_value"),
+    [
+        ("casepath", "/some/path", "casepath", Path("/some/path")),
+        ("casepath", None, "casepath", None),
+        ("content", None, "content", "unset"),
+        ("unit", None, "unit", ""),
+        ("unit", "m", "unit", "m"),
+    ],
+)
+def test_export_config_from_export_data_transformations(
+    mock_export_data: MagicMock,
+    attr: str,
+    value: Any,
+    expected_attr: str,
+    expected_value: Any,
+) -> None:
+    """ExportConfig applies correct transformations to input vals."""
+    setattr(mock_export_data, attr, value)
+
+    with patch("fmu.dataio._export_config._resolve_fmu_context") as mock_fmu_ctx:
+        mock_fmu_ctx.return_value = (None, False)
+
+        config = ExportConfig.from_export_data(mock_export_data)
+        assert getattr(config, expected_attr) == expected_value
+
+
+def test_export_config_from_export_data_with_global_config(
+    mock_export_data: MagicMock,
+) -> None:
+    """GlobalConfiguration is passed through, dict becomes None."""
+    mock_global_config = MagicMock(spec=GlobalConfiguration, access=MagicMock())
+    mock_export_data.config = mock_global_config
+
+    with patch("fmu.dataio._export_config._resolve_fmu_context") as mock_fmu_ctx:
+        mock_fmu_ctx.return_value = (None, False)
+
+        config = ExportConfig.from_export_data(mock_export_data)
+        assert config.config is mock_global_config
+
+    mock_export_data.config = {"some": "dict"}
+    with patch("fmu.dataio._export_config._resolve_fmu_context") as mock_fmu_ctx:
+        mock_fmu_ctx.return_value = (None, False)
+
+        config = ExportConfig.from_export_data(mock_export_data)
+        assert config.config is None
+
+
+def test_export_config_is_immutable(mock_export_data: MagicMock) -> None:
+    """ExportConfig is frozen."""
+
+    with patch("fmu.dataio._export_config._resolve_fmu_context") as mock_fmu_ctx:
+        mock_fmu_ctx.return_value = (None, False)
+
+        config = ExportConfig.from_export_data(mock_export_data)
+
+        with pytest.raises(AttributeError):
+            config.name = "new_name"  # type: ignore[misc]


### PR DESCRIPTION
Resolves #1493

Adding or changing functionality has been very difficult because ExportData is a mega-class that users can mutate, mutates itself, parses, validates, and passes itself back to other areas of the code so that its attributes can be accessed by them. This happens for many reasons, but key among them is the 40+ properties on the class, many of which are partially deprecated.

More validation and some parsing is applied deeper in providers and at export time as well. Making any sort of change is an extreme headache trying to account for the state of things.

The ExportConfig class will put a trap-door on user input and state mutations. It is not done in this PR, but the purpose is to separate what users provide and what we use internally. What we use internally will be the ExportConfig class, which contains only and exactly the attributes we need to export metadata and objects. It will be re-created and cache when users mutate state variables.

This means we only need to access one property from the ExportData class internally, which is the cached ExportConfig class. It also means, that as a long term goal, we will not even need the ExportData class to generate metadata and exports, but can just provide an ExportConfig that export functions understand.

Then, we can focus on improving the code behind the scenes, and worry much, much less about user input: only in terms of transforming that input into an ExportConfig value.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
