### PR TITLE
ENH: Populate 'ert.ensemble'

### DIFF
--- a/src/fmu/dataio/providers/_fmu.py
+++ b/src/fmu/dataio/providers/_fmu.py
@@ -88,7 +88,7 @@ class FmuProvider(Provider):
         self._casemeta = runcontext.case_metadata
         self._fmu_context = runcontext.fmu_context
         self._env = FMUEnvironment.from_env()
-        self._realization_id = self._env.realization_number or 0
+        self._realization_number = self._env.realization_number or 0
         self._iteration_number = self._env.iteration_number or 0
         self._ensemble_name = runcontext.paths.ensemble_name or ""
         self._realization_name = runcontext.paths.realization_name or ""
@@ -197,13 +197,13 @@ class FmuProvider(Provider):
     def _get_ensemble_and_real_uuid(self, case_uuid: UUID) -> tuple[UUID, UUID]:
         ensemble_uuid = _utils.uuid_from_string(f"{case_uuid}{self._ensemble_name}")
         real_uuid = _utils.uuid_from_string(
-            f"{case_uuid}{ensemble_uuid}{self._realization_id}"
+            f"{case_uuid}{ensemble_uuid}{self._realization_number}"
         )
         return ensemble_uuid, real_uuid
 
     def _get_realization_meta(self, real_uuid: UUID) -> fields.Realization:
         return fields.Realization(
-            id=self._realization_id,
+            id=self._realization_number,
             name=self._realization_name,
             uuid=real_uuid,
         )

--- a/tests/test_units/test_fmuprovider_class.py
+++ b/tests/test_units/test_fmuprovider_class.py
@@ -94,7 +94,7 @@ def test_fmuprovider_ert_provider_missing_parameter_txt(
     assert myfmu._casepath is not None
     assert myfmu._casepath.name == "ertrun1"
     assert myfmu._realization_name == "realization-0"
-    assert myfmu._realization_id == 0
+    assert myfmu._realization_number == 0
 
 
 def test_fmuprovider_arbitrary_iter_name(
@@ -110,7 +110,7 @@ def test_fmuprovider_arbitrary_iter_name(
     assert myfmu._casepath is not None
     assert myfmu._casepath.name == "ertrun1"
     assert myfmu._realization_name == "realization-0"
-    assert myfmu._realization_id == 0
+    assert myfmu._realization_number == 0
     assert myfmu._ensemble_name == "pred"
     # iter_id should have the default value
     assert myfmu._iteration_number == 0
@@ -131,7 +131,7 @@ def test_fmuprovider_get_real_and_iter_from_env(
     assert myfmu._casepath is not None
     assert myfmu._casepath.name == "ertrun1"
     assert myfmu._realization_name == "realization-1"
-    assert myfmu._realization_id == 1
+    assert myfmu._realization_number == 1
     assert myfmu._ensemble_name == "iter-0"
     assert myfmu._iteration_number == 0
 
@@ -150,7 +150,7 @@ def test_fmuprovider_no_iter_folder(
     assert myfmu._casepath == fmurun_no_iter_folder.parent
     assert myfmu._casepath.name == "ertrun1_no_iter"
     assert myfmu._realization_name == "realization-1"
-    assert myfmu._realization_id == 1
+    assert myfmu._realization_number == 1
     assert myfmu._ensemble_name == "iter-0"
     assert myfmu._iteration_number == 0
 


### PR DESCRIPTION
Resolves #1536

This will help connect ensembles disconnected by Ert ensemble uuid, vs case ensemble uuid.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
