### PR TITLE
ENH: Add codenames to GridProperty spec

### DIFF
--- a/src/fmu/dataio/providers/objectdata/_xtgeo.py
+++ b/src/fmu/dataio/providers/objectdata/_xtgeo.py
@@ -622,6 +622,7 @@ class CPGridPropertyDataProvider(ObjectDataProvider):
             nrow=self.obj.nrow,
             ncol=self.obj.ncol,
             nlay=self.obj.nlay,
+            codenames=self.obj.codes if self.obj.isdiscrete else None,
         )
 
     def get_geometry(self) -> Geometry | None:


### PR DESCRIPTION
Resolves #998 

PR to start adding codename information to the metadata for discrete properties.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
