### PR TITLE
ENH: Add functionality for creating fipnum and corresponding mappings

### DIFF
--- a/docs/src/simple_exports/simulator_fipregions_mapping.md
+++ b/docs/src/simple_exports/simulator_fipregions_mapping.md
@@ -1,0 +1,80 @@
+# Simulator fipregions mapping
+
+This creates a `FIPNUM` property within a grid model in RMS and exports the
+corresponding `zone / region` mappings as a standard result
+`simulator_fipregions_mapping`.
+
+The flow simulator uses `FIPNUM` as its standard region property to generate
+reports on volumes and pressures for each `FIPNUM` value. The `FIPNUM` property
+created by this functionality will have a unique value per `zone / region`
+combination, which is the recommended standard. Reporting at a fine resolution
+allows for combining data at coarser levels in analysis tools, while enabling
+detailed investigations at a finer level.
+
+:::{hint}
+Use the same zone and region properties as in your volumetrics job for easy comparison
+of initial volumes from the dynamic simulation against static inplace volumes.
+:::
+
+:::{note}
+ Many existing workflows may have a `FIPNUM` definition that does not conform to the
+ standard of having one unique value per `zone / region` combination. If you need to
+ retain the current `FIPNUM` definition also, it should be renamed to a different
+ `FIP` identifier (e.g., `FIPXXX`) and exported for the flow simulation.
+:::
+
+:::{table} Current
+:widths: auto
+:align: left
+
+| Field | Value |
+| --- | --- |
+| Version | NA |
+| Output | `share/results/tables/simulator_fipregions_mapping/fipnum.parquet` |
+| Security classification | 🟡 Internal |
+:::
+
+## Requirements
+
+- RMS
+- A grid model with a zone and region property
+
+The grid model in RMS must contain a discrete zone and a region property which will
+be used to assign `FIPNUM` values. The mappings between them will be automatically exported.
+
+## Usage
+
+```{eval-rst}
+.. autofunction:: fmu.dataio.export.rms.simulator_fipregions_mapping.create_fipnum_property
+```
+
+## Result
+
+The table mapping from a unique `FIPNUM` value to corresponding region and zone names will
+be exported to `share/results/tables/simulator_fipregions_mapping/fipnum.parquet`.
+
+
+## Standard result schema
+
+This standard result is made available with a validation schema that can be
+used by consumers. A reference to the URL where this schema is located is
+present within the `data.standard_result` key in its associated object
+metadata.
+
+| Field | Value |
+| --- | --- |
+| Version | {{ SimulatorFipregionsMappingSchema.VERSION }} |
+| Filename | {{ SimulatorFipregionsMappingSchema.FILENAME }} |
+| Path | {{ SimulatorFipregionsMappingSchema.PATH }} |
+| Prod URL | {{ '[{}]({}) 🔒'.format(SimulatorFipregionsMappingSchema.prod_url(), SimulatorFipregionsMappingSchema.prod_url()) }}
+| Dev URL | {{ '[{}]({}) 🔒'.format(SimulatorFipregionsMappingSchema.dev_url(), SimulatorFipregionsMappingSchema.dev_url()) }}
+
+### Changelog
+
+{{ SimulatorFipregionsMappingSchema.VERSION_CHANGELOG }}
+
+### JSON schema
+
+The current JSON schema is embedded here.
+
+{{ SimulatorFipregionsMappingSchema.literalinclude }}

--- a/src/fmu/dataio/export/rms/__init__.py
+++ b/src/fmu/dataio/export/rms/__init__.py
@@ -1,3 +1,4 @@
+from .create_fipnum_property import create_fipnum_property
 from .field_outline import export_field_outline
 from .fluid_contact_outlines import export_fluid_contact_outlines
 from .fluid_contact_surfaces import export_fluid_contact_surfaces
@@ -19,4 +20,5 @@ __all__ = [
     "export_field_outline",
     "export_fluid_contact_surfaces",
     "export_fluid_contact_outlines",
+    "create_fipnum_property",
 ]

--- a/src/fmu/dataio/export/rms/create_fipnum_property.py
+++ b/src/fmu/dataio/export/rms/create_fipnum_property.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Final
+
+import pyarrow as pa
+import xtgeo
+
+from fmu.dataio._export import export_with_metadata
+from fmu.dataio._export_config import ExportConfig
+from fmu.dataio._logging import null_logger
+from fmu.dataio.export._export_result import ExportResult, ExportResultItem
+from fmu.dataio.export.rms._base import SimpleExportRMSBase
+from fmu.datamodels import SimulatorFipregionsMappingResult
+from fmu.datamodels.common.enums import Classification
+from fmu.datamodels.fmu_results.enums import Content
+from fmu.datamodels.fmu_results.standard_result import (
+    SimulatorFipregionsMappingStandardResult,
+)
+from fmu.datamodels.standard_results.enums import (
+    SimulatorFipregionsMapping,
+    StandardResultName,
+)
+
+_logger: Final = null_logger(__name__)
+
+FIPNAME: Final = "FIPNUM"
+
+
+class _ExportFipZoneRegionMapping(SimpleExportRMSBase):
+    def __init__(self, mapping_table: pa.Table) -> None:
+        super().__init__()
+
+        self._mapping_table = mapping_table
+
+    @property
+    def _standard_result(self) -> SimulatorFipregionsMappingStandardResult:
+        """Standard result type for the exported data."""
+        return SimulatorFipregionsMappingStandardResult(
+            name=StandardResultName.simulator_fipregions_mapping
+        )
+
+    @property
+    def _content(self) -> Content:
+        """Get content for the exported data."""
+        return Content.mapping
+
+    @property
+    def _classification(self) -> Classification:
+        """Get default classification."""
+        return Classification.internal
+
+    @property
+    def _rep_include(self) -> bool:
+        """rep_include status"""
+        return False
+
+    def _export_data_as_standard_result(self) -> ExportResult:
+        export_config = (
+            ExportConfig.builder()
+            .content(self._content)
+            .file_config(
+                name=FIPNAME,
+                subfolder=self._subfolder,
+            )
+            .access(self._classification, self._rep_include)
+            .global_config(self._config)
+            .standard_result(StandardResultName.simulator_fipregions_mapping)
+            .table_config(table_index=SimulatorFipregionsMapping.index_columns())
+            .build()
+        )
+
+        absolute_export_path = export_with_metadata(export_config, self._mapping_table)
+        _logger.debug("Fip mapping table exported to: %s", absolute_export_path)
+
+        return ExportResult(
+            items=[ExportResultItem(absolute_path=Path(absolute_export_path))],
+        )
+
+    def _validate_data_pre_export(self) -> None:
+        """Data validations before export."""
+        SimulatorFipregionsMappingResult.model_validate(self._mapping_table.to_pylist())
+
+
+def _create_fipnum_from_region_and_zone(
+    zone: xtgeo.GridProperty, region: xtgeo.GridProperty
+) -> tuple[xtgeo.GridProperty, pa.Table]:
+    """
+    Create a FIPNUM property with a unique value per region / zone combination.
+    The mappings from FIPNUM value to corresponding zone and region names are
+    collected and returned as a table.
+    """
+
+    fipnum = xtgeo.GridProperty(zone, discrete=True, values=0)
+
+    mapping = []
+    fipvalue = 1
+    for zonecode, zonename in zone.codes.items():
+        for regcode, regname in region.codes.items():
+            cell_filter = (region.values == regcode) & (zone.values == zonecode)
+            fipnum.values[cell_filter] = fipvalue
+
+            fipnum.codes[fipvalue] = f"{regname}_{zonename}"
+
+            mapping.append({FIPNAME: fipvalue, "REGION": regname, "ZONE": zonename})
+
+            fipvalue += 1
+
+    return fipnum, pa.Table.from_pylist(mapping)
+
+
+def _load_discrete_gridproperty(
+    project: Any, grid_name: str, property_name: str
+) -> xtgeo.GridProperty:
+    """Load a grid property from RMS and validate that it is discrete."""
+    prop = xtgeo.gridproperty_from_roxar(project, grid_name, property_name)
+
+    if not prop.isdiscrete:
+        raise ValueError(f"The property {property_name} must be discrete.")
+
+    return prop
+
+
+def _create_fipnum_in_project(
+    project: Any, grid_name: str, region: str, zone: str
+) -> pa.Table:
+    """Create the FIPNUM property in the RMS project and return the mapping table."""
+    region = _load_discrete_gridproperty(project, grid_name, region)
+    zone = _load_discrete_gridproperty(project, grid_name, zone)
+
+    fipnum, mapping_table = _create_fipnum_from_region_and_zone(zone, region)
+
+    fipnum.to_roxar(project, grid_name, FIPNAME)
+
+    return mapping_table
+
+
+def create_fipnum_property(
+    project: Any, grid_name: str, region: str, zone: str
+) -> ExportResult:
+    """Simplified interface for creating a FIPNUM property in RMS and exporting
+    the corresponding zone / region mappings.
+
+    The FIPNUM property will have a unique value per region / zone combination
+    and the mapping between a FIPNUM value and the corresponding region and zone
+    names will be exported as a standard result 'simulator_fipregions_mapping'.
+
+    Args:
+        project: The 'magic' project variable in RMS.
+        grid_name: Name of the grid in RMS.
+        region: Name of the region property in the grid model.
+        zone: Name of the zone property in the grid model.
+
+    Examples:
+        Example usage in an RMS script::
+
+            from fmu.dataio.export.rms import create_fipnum_property
+
+            export_results = create_fipnum_property(
+                project,
+                grid_name="Simgrid",
+                region="Region",
+                zone="Zone"
+            )
+
+            for result in export_results.items:
+                print(f"Fipnum mappings are exported to {result.absolute_path}")
+
+    """
+
+    mapping_table = _create_fipnum_in_project(project, grid_name, region, zone)
+
+    return _ExportFipZoneRegionMapping(mapping_table).export()

--- a/tests/test_export_rms/test_create_fipnum_property.py
+++ b/tests/test_export_rms/test_create_fipnum_property.py
@@ -1,0 +1,341 @@
+"""Test the dataio running RMS specific utility function for field outline"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest import mock
+from unittest.mock import MagicMock
+
+import jsonschema
+import numpy as np
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+import xtgeo
+from fmu.datamodels.standard_results import (
+    SimulatorFipregionsMappingResult,
+    SimulatorFipregionsMappingSchema,
+)
+from fmu.datamodels.standard_results.enums import StandardResultName
+from pytest import MonkeyPatch
+
+from fmu import dataio
+from fmu.dataio._logging import null_logger
+
+if TYPE_CHECKING:
+    from fmu.dataio.export.rms.create_fipnum_property import _ExportFipZoneRegionMapping
+
+
+logger = null_logger(__name__)
+
+
+@pytest.fixture
+def mapping_table() -> pa.Table:
+    return pa.table(
+        {
+            "FIPNUM": [1, 2, 3, 4],
+            "REGION": ["reg1", "reg2", "reg1", "reg2"],
+            "ZONE": ["upper", "upper", "lower", "lower"],
+        }
+    )
+
+
+@pytest.fixture
+def region_property() -> xtgeo.GridProperty:
+    prop = xtgeo.GridProperty(
+        ncol=2,
+        nrow=2,
+        nlay=2,
+        values=1,
+        codes={1: "reg1", 2: "reg2"},
+        discrete=True,
+    )
+    prop.values[1, :, :] = 2  # Set the second region to value 2
+    return prop
+
+
+@pytest.fixture
+def zone_property() -> xtgeo.GridProperty:
+    prop = xtgeo.GridProperty(
+        ncol=2,
+        nrow=2,
+        nlay=2,
+        values=1,
+        codes={1: "upper", 2: "lower"},
+        discrete=True,
+    )
+    prop.values[:, :, 1] = 2  # Set the second layer to value 2
+    return prop
+
+
+@pytest.fixture
+def mock_export_class(
+    monkeypatch: MonkeyPatch,
+    rmssetup_with_fmuconfig: Path,
+    mapping_table: pa.Table,
+) -> Generator[_ExportFipZoneRegionMapping]:
+    # needed to find the global config at correct place
+    monkeypatch.chdir(rmssetup_with_fmuconfig)
+
+    from fmu.dataio.export.rms.create_fipnum_property import (
+        _ExportFipZoneRegionMapping,
+    )
+
+    yield _ExportFipZoneRegionMapping(mapping_table)
+
+
+@pytest.mark.usefixtures("inside_rms_interactive")
+def test_create_fipnum_from_region_and_zone(
+    zone_property: xtgeo.GridProperty,
+    region_property: xtgeo.GridProperty,
+    mapping_table: pa.Table,
+) -> None:
+    """Test that the FIPNUM property is created with correct values and mapping."""
+
+    from fmu.dataio.export.rms.create_fipnum_property import (
+        _create_fipnum_from_region_and_zone,
+    )
+
+    expected_mapping_table = mapping_table
+
+    fipnum, mapping_table = _create_fipnum_from_region_and_zone(
+        zone_property, region_property
+    )
+
+    expected_fipnum_values = np.array([[[1, 3], [1, 3]], [[2, 4], [2, 4]]])
+    assert np.array_equal(fipnum.values, expected_fipnum_values)
+
+    assert mapping_table == expected_mapping_table
+
+    # check that codenames are set on the fipnum property
+    assert fipnum.codes == {
+        1: "reg1_upper",
+        2: "reg2_upper",
+        3: "reg1_lower",
+        4: "reg2_lower",
+    }
+
+
+@pytest.mark.usefixtures("inside_rms_interactive")
+def test_create_fipnum_from_region_and_zone_with_non_sequential_region_numbers(
+    zone_property: xtgeo.GridProperty, mapping_table: pa.Table
+) -> None:
+    """
+    Test the FIPNUM property is correctly created for a region with non-sequential
+    region numbers.
+    """
+
+    from fmu.dataio.export.rms.create_fipnum_property import (
+        _create_fipnum_from_region_and_zone,
+    )
+
+    region_property = xtgeo.GridProperty(
+        ncol=2,
+        nrow=2,
+        nlay=2,
+        values=1,
+        codes={1: "reg1", 10: "reg2"},
+        discrete=True,
+    )
+    region_property.values[1, :, :] = 10  # Set the second region to value 10
+
+    expected_mapping_table = mapping_table
+
+    fipnum, mapping_table = _create_fipnum_from_region_and_zone(
+        zone_property, region_property
+    )
+
+    expected_fipnum_values = np.array([[[1, 3], [1, 3]], [[2, 4], [2, 4]]])
+    assert np.array_equal(fipnum.values, expected_fipnum_values)
+
+    assert mapping_table == expected_mapping_table
+
+
+def test_load_discrete_gridproperty_raises_on_continuous_property(
+    mock_project_variable: MagicMock, region_property: xtgeo.GridProperty
+) -> None:
+    """Test that an exception is raised if the region/zone property is not discrete."""
+
+    from fmu.dataio.export.rms.create_fipnum_property import (
+        _load_discrete_gridproperty,
+    )
+
+    continuous_property = region_property.copy()
+    continuous_property.discrete_to_continuous()
+
+    with (
+        mock.patch(
+            "fmu.dataio.export.rms.create_fipnum_property.xtgeo.gridproperty_from_roxar",
+            return_value=continuous_property,
+        ),
+        pytest.raises(ValueError, match="must be discrete"),
+    ):
+        _load_discrete_gridproperty(mock_project_variable, "Simgrid", "Region")
+
+
+def test_create_fipnum_in_project(
+    mock_project_variable: MagicMock,
+    zone_property: xtgeo.GridProperty,
+    region_property: xtgeo.GridProperty,
+    mapping_table: pa.Table,
+) -> None:
+    """Test that the to_roxar method is called with correct arguments."""
+
+    from fmu.dataio.export.rms.create_fipnum_property import _create_fipnum_in_project
+
+    expected_mapping_table = mapping_table
+
+    with (
+        mock.patch(
+            "fmu.dataio.export.rms.create_fipnum_property.xtgeo.gridproperty_from_roxar",
+            side_effect=[region_property, zone_property],
+        ),
+        mock.patch(
+            "fmu.dataio.export.rms.create_fipnum_property.xtgeo.GridProperty.to_roxar"
+        ) as mock_to_roxar,
+    ):
+        mapping_table = _create_fipnum_in_project(
+            mock_project_variable, "Simgrid", "Region", "Zone"
+        )
+        mock_to_roxar.assert_called_once_with(
+            mock_project_variable, "Simgrid", "FIPNUM"
+        )
+
+        assert mapping_table == expected_mapping_table
+
+
+@pytest.mark.usefixtures("inside_rms_interactive")
+def test_mapping_file_is_exported_with_metadata(
+    mock_export_class: _ExportFipZoneRegionMapping,
+    rmssetup_with_fmuconfig: Path,
+) -> None:
+    """Test that the mapping is exported to disk with metadata"""
+    mock_export_class.export()
+
+    export_folder = (
+        rmssetup_with_fmuconfig
+        / "../../share/results/tables/simulator_fipregions_mapping"
+    )
+    assert export_folder.exists()
+
+    assert (export_folder / "fipnum.parquet").exists()
+    assert (export_folder / ".fipnum.parquet.yml").exists()
+
+
+@pytest.mark.usefixtures("inside_rms_interactive")
+def test_standard_result_in_metadata(
+    mock_export_class: _ExportFipZoneRegionMapping,
+) -> None:
+    """Test that the standard_result is set correctly in the metadata"""
+
+    out = mock_export_class.export()
+    metadata = dataio.read_metadata(out.items[0].absolute_path)
+
+    assert "standard_result" in metadata["data"]
+    assert (
+        metadata["data"]["standard_result"]["name"]
+        == StandardResultName.simulator_fipregions_mapping
+    )
+    assert (
+        metadata["data"]["standard_result"]["file_schema"]["version"]
+        == SimulatorFipregionsMappingSchema.VERSION
+    )
+    assert (
+        metadata["data"]["standard_result"]["file_schema"]["url"]
+        == SimulatorFipregionsMappingSchema.url()
+    )
+
+
+@pytest.mark.usefixtures("inside_rms_interactive")
+def test_public_export_function(
+    mock_project_variable: MagicMock,
+    mock_export_class: _ExportFipZoneRegionMapping,
+    mapping_table: pa.Table,
+) -> None:
+    """Test that the export function works and metadata is correctly set"""
+
+    from fmu.dataio.export.rms import create_fipnum_property
+
+    with (
+        mock.patch(
+            "fmu.dataio.export.rms.create_fipnum_property._create_fipnum_in_project",
+            return_value=mapping_table,
+        ),
+    ):
+        out = create_fipnum_property(mock_project_variable, "Simgrid", "Region", "Zone")
+
+        assert len(out.items) == 1
+
+        metadata = dataio.read_metadata(out.items[0].absolute_path)
+
+        assert metadata["data"]["content"] == "mapping"
+        assert metadata["access"]["classification"] == "internal"
+        assert (
+            metadata["data"]["standard_result"]["name"]
+            == StandardResultName.simulator_fipregions_mapping
+        )
+        assert metadata["data"]["format"] == "parquet"
+        assert metadata["data"]["table_index"] == ["FIPNUM", "ZONE", "REGION"]
+
+
+@pytest.mark.usefixtures("inside_rms_interactive")
+def test_config_missing(
+    mock_project_variable: MagicMock,
+    # mock_export_class: _ExportFipZoneRegionMapping,
+    mapping_table: pa.Table,
+    rmssetup_with_fmuconfig: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Test that an exception is raised if the config is missing."""
+
+    from fmu.dataio.export.rms import create_fipnum_property
+
+    # move up one directory to trigger not finding the config
+    monkeypatch.chdir(rmssetup_with_fmuconfig.parent)
+
+    with (
+        mock.patch(
+            "fmu.dataio.export.rms.create_fipnum_property._create_fipnum_in_project",
+            return_value=mapping_table,
+        ),
+        pytest.raises(FileNotFoundError, match="Could not detect"),
+    ):
+        create_fipnum_property(mock_project_variable, "Simgrid", "Region", "Zone")
+
+
+@pytest.mark.usefixtures("inside_rms_interactive")
+def test_payload_validates_against_model(
+    mock_export_class: _ExportFipZoneRegionMapping,
+) -> None:
+    """Tests that the table exported is validated against the payload result
+    model."""
+
+    out = mock_export_class.export()
+    df = (
+        pq.read_table(out.items[0].absolute_path)
+        .to_pandas()
+        .replace(np.nan, None)
+        .to_dict(orient="records")
+    )
+    SimulatorFipregionsMappingResult.model_validate(df)  # Throws if invalid
+
+
+@pytest.mark.usefixtures("inside_rms_interactive")
+def test_payload_validates_against_schema(
+    mock_export_class: _ExportFipZoneRegionMapping,
+) -> None:
+    """Tests that the table exported is validated against the payload result
+    schema."""
+
+    out = mock_export_class.export()
+    df = (
+        pq.read_table(out.items[0].absolute_path)
+        .to_pandas()
+        .replace(np.nan, None)
+        .to_dict(orient="records")
+    )
+    jsonschema.validate(
+        instance=df, schema=SimulatorFipregionsMappingSchema.dump()
+    )  # Throws if invalid

--- a/uv.lock
+++ b/uv.lock
@@ -1094,14 +1094,14 @@ provides-extras = ["dev", "docs"]
 
 [[package]]
 name = "fmu-datamodels"
-version = "0.19.1"
+version = "0.19.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7e/8f/22513cbc89e73881a392c162347ac39f04940848a887a68a4329694f9a61/fmu_datamodels-0.19.1.tar.gz", hash = "sha256:e56aa3f3f40ceaf2dde421b070a0efde20e63df2a20ba41ba0916a0e40900f24", size = 391404, upload-time = "2026-02-13T07:45:06.713Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/7b/b73807b855ea50fa23981d1d277bcafde1037d4339f228a43bad757ec53a/fmu_datamodels-0.19.2.tar.gz", hash = "sha256:cba16a32a11f98f2b871693da58a35079844d25ec07a4d2a7304caeadf5f08bb", size = 367509, upload-time = "2026-02-19T14:18:42.659Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/a3/b8ed3134cf2aebe4716efd8854a78fcb9e0c56fe8f06c7f1eb30822f282f/fmu_datamodels-0.19.1-py3-none-any.whl", hash = "sha256:c760c4eda96b49307d2b6a78fe10c604c2967d1df260ac1df2ef5343ec4986f5", size = 48881, upload-time = "2026-02-13T07:45:05.275Z" },
+    { url = "https://files.pythonhosted.org/packages/82/b3/952b0c4d6d1c5596d4c63eb2868ca6c040aa0645ce224710be4e71b2edb2/fmu_datamodels-0.19.2-py3-none-any.whl", hash = "sha256:9f4c8c6574bc6bd8dd010a9795e1cd6f723828072b01d26ddfd38a7e7ff28a3f", size = 50415, upload-time = "2026-02-19T14:18:40.797Z" },
 ]
 
 [[package]]
@@ -3310,16 +3310,16 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.13.0"
+version = "2.13.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/96/a1/ae859ffac5a3338a66b74c5e29e244fd3a3cc483c89feaf9f56c39898d75/pydantic_settings-2.13.0.tar.gz", hash = "sha256:95d875514610e8595672800a5c40b073e99e4aae467fa7c8f9c263061ea2e1fe", size = 222450, upload-time = "2026-02-15T12:11:23.476Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/6d/fffca34caecc4a3f97bda81b2098da5e8ab7efc9a66e819074a11955d87e/pydantic_settings-2.13.1.tar.gz", hash = "sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025", size = 223826, upload-time = "2026-02-19T13:45:08.055Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/1a/dd1b9d7e627486cf8e7523d09b70010e05a4bc41414f4ae6ce184cf0afb6/pydantic_settings-2.13.0-py3-none-any.whl", hash = "sha256:d67b576fff39cd086b595441bf9c75d4193ca9c0ed643b90360694d0f1240246", size = 58429, upload-time = "2026-02-15T12:11:22.133Z" },
+    { url = "https://files.pythonhosted.org/packages/00/4b/ccc026168948fec4f7555b9164c724cf4125eac006e176541483d2c959be/pydantic_settings-2.13.1-py3-none-any.whl", hash = "sha256:d56fd801823dbeae7f0975e1f8c8e25c258eb75d278ea7abb5d9cebb01b56237", size = 58929, upload-time = "2026-02-19T13:45:06.034Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Resolves #1570
Resolves #828 

PR which adds a new function `create_fipnum_property` to be used inside RMS to create a `FIPNUM` property with a unique value per `zone / region` combination and export the mapping between them as a `simulator_fipregions_mapping` standard result.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
