### PR TITLE
DOC: Temporarily stop producing data model docs

### DIFF
--- a/docs/src/datamodel/index.md
+++ b/docs/src/datamodel/index.md
@@ -15,27 +15,6 @@ means, in practice, that outgoing metadata from FMU needs to comply with the sch
 If data is uploaded to e.g. Sumo, validation will be done on the incoming data to ensure
 consistency.
 
-
-## Data model documentation
-
-There are two closely related data models represented here: metadata generated from
-an FMU realization and metadata generated on a case level. The structure and
-documentation of these two models can be inspected from here.
-
-```{eval-rst}
-.. autosummary::
-   :toctree: model/
-   :recursive:
-
-
-   .. toctree::
-      :maxdepth: -1
-
-      ~fmu.datamodels.fmu_results.fmu_results.ObjectMetadata
-      ~fmu.datamodels.fmu_results.fmu_results.CaseMetadata
-```
-
-
 ## About the data model
 
 ### Why is it made?


### PR DESCRIPTION
So far I haven't found a good way to increase the speed. Let's stop producing it for now until a better solution is found.

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
