### PR TITLE
TST: Use same datetime for grid md5sum checks

### DIFF
--- a/src/fmu/dataio/_utils.py
+++ b/src/fmu/dataio/_utils.py
@@ -38,7 +38,7 @@ def casepath_has_metadata(casepath: Path) -> bool:
 
 
 def md5sum(file: Path | BytesIO) -> str:
-    if isinstance(file, Path):
+    if isinstance(file, (str, Path)):
         with open(file, "rb") as stream:
             return md5sum_stream(stream)
     return md5sum_stream(file)

--- a/tests/test_units/test_checksum_md5.py
+++ b/tests/test_units/test_checksum_md5.py
@@ -1,5 +1,7 @@
+from datetime import datetime
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 import pandas as pd
 import pyarrow as pa
@@ -47,16 +49,21 @@ def test_checksum_md5_for_gridproperty(
     """
     monkeypatch.chdir(tmp_path)
 
-    export_path = Path(
-        ExportData(
-            config=mock_global_config,
-            content="depth",
-            name="myname",
-        ).export(gridproperty)
-    )
+    # roffio writes a timestamp to the roff header which can mismatch if second
+    # increases between temp file write (for checksum) and export write
+    with patch("_roffio.writing.datetime") as mock_datetime:
+        mock_datetime.datetime.now = datetime.now()
 
-    meta = read_metadata(export_path)
-    assert meta["file"]["checksum_md5"] == md5sum(export_path)
+        export_path = Path(
+            ExportData(
+                config=mock_global_config,
+                content="depth",
+                name="myname",
+            ).export(gridproperty)
+        )
+
+        meta = read_metadata(export_path)
+        assert meta["file"]["checksum_md5"] == md5sum(export_path)
 
 
 def test_checksum_md5_for_grid(
@@ -71,16 +78,21 @@ def test_checksum_md5_for_grid(
     """
     monkeypatch.chdir(tmp_path)
 
-    export_path = Path(
-        ExportData(
-            config=mock_global_config,
-            content="depth",
-            name="myname",
-        ).export(grid)
-    )
+    # roffio writes a timestamp to the roff header which can mismatch if second
+    # increases between temp file write (for checksum) and export write
+    with patch("_roffio.writing.datetime") as mock_datetime:
+        mock_datetime.datetime.now = datetime.now()
 
-    meta = read_metadata(export_path)
-    assert meta["file"]["checksum_md5"] == md5sum(export_path)
+        export_path = Path(
+            ExportData(
+                config=mock_global_config,
+                content="depth",
+                name="myname",
+            ).export(grid)
+        )
+
+        meta = read_metadata(export_path)
+        assert meta["file"]["checksum_md5"] == md5sum(export_path)
 
 
 def test_checksum_md5_for_points(


### PR DESCRIPTION
Resolves #1613

Tested against 10,000 runs of the tests before and after the patch. About 4% fail rate before, 0% fail after.

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
