### PR TITLE
TST: Rename runpath fixtures, separate non-dot-fmu

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,17 +79,16 @@ def inside_rms_interactive(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setenv("RUNRMS_EXEC_MODE", "interactive")
 
 
-def _fmu_run1_env_variables(
-    monkeypatch: MonkeyPatch, usepath: str = "", case_only: bool = False
+def _set_fmurun_env_variables(
+    monkeypatch: MonkeyPatch,
+    runpath: Path = Path(""),
+    case_only: bool = False,
 ) -> None:
-    """Helper function for fixtures below.
-
-    Will here monkeypatch the ENV variables, with a particular setting for RUNPATH
-    (trough `usepath`) which may vary dynamically due to pytest tmp area rotation.
-    """
+    """Set Ert environment variables based upon the path and stage."""
     env = ERTRUN_ENV_FULLRUN if not case_only else ERTRUN_ENV_PREHOOK
+
     for key, value in env.items():
-        env_value = str(usepath) if "RUNPATH" in key else value
+        env_value = str(runpath) if "RUNPATH" in key else value
         monkeypatch.setenv(key, env_value)
         logger.debug("Setting env %s as %s", key, env_value)
 
@@ -122,111 +121,101 @@ def set_ert_env_prehook(monkeypatch: MonkeyPatch) -> Callable[[], None]:
 
 
 @pytest.fixture(scope="function")
-def fmurun(
-    tmp_path_factory: pytest.TempPathFactory, monkeypatch: MonkeyPatch, rootpath: Path
-) -> Path:
-    """A tmp folder structure for testing; here a new fmurun without case metadata."""
-    tmppath = tmp_path_factory.mktemp("data")
-    newpath = tmppath / ERTRUN_REAL0_ITER0
-    shutil.copytree(rootpath / ERTRUN_REAL0_ITER0, newpath)
-
-    _fmu_run1_env_variables(monkeypatch, usepath=str(newpath), case_only=False)
-
-    logger.debug("Ran %s", _current_function_name())
-    return newpath
-
-
-@pytest.fixture(scope="function")
-def fmurun_prehook(
-    tmp_path_factory: pytest.TempPathFactory, monkeypatch: MonkeyPatch, rootpath: Path
-) -> Path:
-    """A tmp folder structure for testing; here a new fmurun without case metadata."""
-    tmppath = tmp_path_factory.mktemp("data")
-    newpath = tmppath / ERTRUN
-    shutil.copytree(rootpath / ERTRUN, newpath)
-
-    _fmu_run1_env_variables(monkeypatch, usepath=str(newpath), case_only=True)
-
-    logger.debug("Ran %s", _current_function_name())
-    return newpath
-
-
-@pytest.fixture(scope="function")
-def fmurun_w_casemetadata(
+def runpath_no_case_metadata(
     tmp_path: Path, monkeypatch: MonkeyPatch, rootpath: Path
 ) -> Path:
-    """Create a tmp folder structure for testing; here existing fmurun w/ case meta!"""
-    newpath = tmp_path / ERTRUN
-    shutil.copytree(rootpath / ERTRUN, newpath)
-    iter_path = newpath / "realization-0/iter-0"
+    """A standard runpath without metadata exported in the case path."""
+    runpath = tmp_path / ERTRUN_REAL0_ITER0
+    shutil.copytree(rootpath / ERTRUN_REAL0_ITER0, runpath)
 
-    _fmu_run1_env_variables(monkeypatch, usepath=str(iter_path), case_only=False)
+    _set_fmurun_env_variables(monkeypatch, runpath=runpath)
 
-    logger.debug("Ran %s", _current_function_name())
+    monkeypatch.chdir(runpath)
+    return runpath
+
+
+@pytest.fixture(scope="function")
+def runpath_prehook(tmp_path: Path, monkeypatch: MonkeyPatch, rootpath: Path) -> Path:
+    """Runpath mocking a prehook context."""
+    runpath = tmp_path / ERTRUN
+    shutil.copytree(rootpath / ERTRUN, runpath)
+
+    _set_fmurun_env_variables(monkeypatch, runpath=runpath, case_only=True)
+
+    monkeypatch.chdir(runpath)
+    return runpath
+
+
+@pytest.fixture(scope="function")
+def runpath_no_dotfmu(tmp_path: Path, monkeypatch: MonkeyPatch, rootpath: Path) -> Path:
+    """Runpath mocking an FMU run without a .fmu/ directory."""
+    runpath = tmp_path / ERTRUN
+    shutil.copytree(rootpath / ERTRUN, runpath)
+    iter_path = runpath / "realization-0/iter-0"
+
+    _set_fmurun_env_variables(monkeypatch, runpath=iter_path)
+
     monkeypatch.chdir(iter_path)
     return iter_path
 
 
 @pytest.fixture(scope="function")
-def fmurun_non_equal_real_and_iter(
-    tmp_path_factory: pytest.TempPathFactory, monkeypatch: MonkeyPatch, rootpath: Path
+def runpath_non_equal_real_and_iter(
+    tmp_path: Path, monkeypatch: MonkeyPatch, rootpath: Path
 ) -> Path:
-    """Create a tmp folder structure for testing; with non equal real and iter num!"""
-    tmppath = tmp_path_factory.mktemp("data3")
-    newpath = tmppath / ERTRUN
-    shutil.copytree(rootpath / ERTRUN, newpath)
-    rootpath = newpath / "realization-1/iter-0"
+    """Runpath with non-equal real and iter num."""
+    runpath = tmp_path / ERTRUN
+    shutil.copytree(rootpath / ERTRUN, runpath)
+    rootpath = runpath / "realization-1/iter-0"
 
     monkeypatch.setenv("_ERT_ITERATION_NUMBER", "0")
     monkeypatch.setenv("_ERT_REALIZATION_NUMBER", "1")
     monkeypatch.setenv("_ERT_RUNPATH", str(rootpath))
 
-    logger.debug("Ran %s", _current_function_name())
+    monkeypatch.chdir(rootpath)
     return rootpath
 
 
 @pytest.fixture(scope="function")
-def fmurun_no_iter_folder(
-    tmp_path_factory: pytest.TempPathFactory, monkeypatch: MonkeyPatch, rootpath: Path
+def runpath_no_iter_dir(
+    tmp_path: Path, monkeypatch: MonkeyPatch, rootpath: Path
 ) -> Path:
-    """Create a tmp folder structure for testing; with no iter folder!"""
-    tmppath = tmp_path_factory.mktemp("data3")
-    newpath = tmppath / ERTRUN_NO_ITER
-    shutil.copytree(rootpath / ERTRUN_NO_ITER, newpath)
-    rootpath = newpath / "realization-1"
+    """Runpath without an iter dir."""
+    runpath = tmp_path / ERTRUN_NO_ITER
+    shutil.copytree(rootpath / ERTRUN_NO_ITER, runpath)
+    rootpath = runpath / "realization-1"
 
     monkeypatch.setenv("_ERT_ITERATION_NUMBER", "0")
     monkeypatch.setenv("_ERT_REALIZATION_NUMBER", "1")
     monkeypatch.setenv("_ERT_RUNPATH", str(rootpath))
 
-    logger.debug("Ran %s", _current_function_name())
+    monkeypatch.chdir(rootpath)
     return rootpath
 
 
 @pytest.fixture(scope="function")
-def fmurun_w_casemetadata_pred(
-    tmp_path_factory: pytest.TempPathFactory, monkeypatch: MonkeyPatch, rootpath: Path
+def runpath_no_dotfmu_pred(
+    tmp_path: Path, monkeypatch: MonkeyPatch, rootpath: Path
 ) -> Path:
-    """Create a tmp folder structure for testing; here existing fmurun w/ case meta!"""
-    tmppath = tmp_path_factory.mktemp("data3")
-    newpath = tmppath / ERTRUN
-    shutil.copytree(rootpath / ERTRUN, newpath)
-    rootpath = newpath / "realization-0/pred"
+    """Prediction runpath with no .fmu/ dir."""
+    runpath = tmp_path / ERTRUN
+    shutil.copytree(rootpath / ERTRUN, runpath)
+    rootpath = runpath / "realization-0/pred"
 
-    _fmu_run1_env_variables(monkeypatch, usepath=str(rootpath), case_only=False)
+    _set_fmurun_env_variables(monkeypatch, runpath=rootpath)
 
-    logger.debug("Ran %s", _current_function_name())
+    monkeypatch.chdir(rootpath)
     return rootpath
 
 
-@pytest.fixture(scope="session")
-def fmurun_pred(tmp_path_factory: pytest.TempPathFactory, rootpath: Path) -> Path:
-    """Create a tmp folder structure for testing; here a new fmurun for prediction."""
-    tmppath = tmp_path_factory.mktemp("data_pred")
-    newpath = tmppath / ERTRUN_PRED
-    shutil.copytree(rootpath / ERTRUN_PRED, newpath)
-    logger.debug("Ran %s", _current_function_name())
-    return newpath
+@pytest.fixture(scope="function")
+def runpath_pred_files(tmp_path: Path, rootpath: Path) -> Path:
+    """Copies prediction run files into the tmp path.
+
+    Typically used in combination with another runpath fixture."""
+    runpath = tmp_path / ERTRUN_PRED
+    shutil.copytree(rootpath / ERTRUN_PRED, runpath, dirs_exist_ok=True)
+    return runpath
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_ert_integration/test_wf_create_case_metadata.py
+++ b/tests/test_ert_integration/test_wf_create_case_metadata.py
@@ -87,29 +87,29 @@ def mock_ert_ensemble() -> MagicMock:
 
 
 @pytest.fixture
-def mock_ert_runpaths(fmurun_prehook: Path) -> MagicMock:
+def mock_ert_runpaths(runpath_prehook: Path) -> MagicMock:
     """Create a mock Ert Runpaths object."""
     runpaths = MagicMock()
-    runpaths.get_paths.return_value = [str(fmurun_prehook / "realization-0/iter-0")]
+    runpaths.get_paths.return_value = [str(runpath_prehook / "realization-0/iter-0")]
     return runpaths
 
 
 @pytest.fixture
-def mock_ert_pred_runpaths(fmurun_prehook: Path) -> MagicMock:
+def mock_ert_pred_runpaths(runpath_prehook: Path) -> MagicMock:
     """Create a mock Ert Runpaths object for a pred run."""
     runpaths = MagicMock()
-    runpaths.get_paths.return_value = [str(fmurun_prehook / "realization-0/pred-dg3")]
+    runpaths.get_paths.return_value = [str(runpath_prehook / "realization-0/pred-dg3")]
     return runpaths
 
 
 @pytest.fixture
 def workflow_config(
-    fmurun_prehook: Path,
+    runpath_prehook: Path,
     mock_global_config_validated: GlobalConfiguration,
 ) -> CaseWorkflowConfig:
     """Create a mock CaseWorkflowConfig."""
     return CaseWorkflowConfig(
-        casepath=fmurun_prehook,
+        casepath=runpath_prehook,
         ert_config_path=Path("../../ert/model/"),
         register_on_sumo=True,
         verbosity="WARNING",
@@ -566,7 +566,7 @@ def test_distribution_models_one_to_one_with_ert() -> None:
 
 
 def test_get_ert_parameters_table(
-    fmurun_prehook: Path,
+    runpath_prehook: Path,
     monkeypatch: MonkeyPatch,
     mock_ert_ensemble: MagicMock,
     mock_ert_runpaths: MagicMock,
@@ -583,7 +583,7 @@ def test_get_ert_parameters_table(
 
 
 def test_get_ert_parameters_table_empty_scalars(
-    fmurun_prehook: Path,
+    runpath_prehook: Path,
     mock_ert_runpaths: MagicMock,
     workflow_config: CaseWorkflowConfig,
 ) -> None:
@@ -600,7 +600,7 @@ def test_get_ert_parameters_table_empty_scalars(
 
 
 def test_get_ert_parameters_table_subset_realizations(
-    fmurun_prehook: Path,
+    runpath_prehook: Path,
     monkeypatch: MonkeyPatch,
     mock_ert_ensemble: MagicMock,
     mock_ert_runpaths: MagicMock,
@@ -628,7 +628,7 @@ def test_get_ert_parameters_table_subset_realizations(
 
 
 def test_get_ert_parameters_table_schema_columns(
-    fmurun_prehook: Path,
+    runpath_prehook: Path,
     mock_ert_ensemble: MagicMock,
     mock_ert_runpaths: MagicMock,
     workflow_config: CaseWorkflowConfig,
@@ -653,7 +653,7 @@ def test_get_ert_parameters_table_schema_columns(
 
 
 def test_get_ert_parameters_table_missing_config(
-    fmurun_prehook: Path,
+    runpath_prehook: Path,
     mock_ert_runpaths: MagicMock,
     workflow_config: CaseWorkflowConfig,
 ) -> None:
@@ -682,7 +682,7 @@ def test_get_ert_parameters_table_missing_config(
 
 
 def test_get_ert_parameters_table_non_genkw_config_skipped(
-    fmurun_prehook: Path,
+    runpath_prehook: Path,
     mock_ert_runpaths: MagicMock,
     workflow_config: CaseWorkflowConfig,
 ) -> None:

--- a/tests/test_export_rms/test_export_grid_extracted_depth_surfaces.py
+++ b/tests/test_export_rms/test_export_grid_extracted_depth_surfaces.py
@@ -70,14 +70,14 @@ def test_files_exported_with_metadata(
 
 
 def test_files_exported_inside_fmu(
-    mock_export_class: _ExportGridExtractedDepthSurfaces, fmurun_w_casemetadata: Path
+    mock_export_class: _ExportGridExtractedDepthSurfaces, runpath_no_dotfmu: Path
 ) -> None:
     """Test that files are exported correctly inside an FMU run"""
 
     mock_export_class.export()
 
     export_folder = (
-        fmurun_w_casemetadata / "share/results/maps/grid_extracted_depth_surface/"
+        runpath_no_dotfmu / "share/results/maps/grid_extracted_depth_surface/"
     )
     assert export_folder.exists()
 
@@ -90,7 +90,7 @@ def test_files_exported_inside_fmu(
     assert (export_folder / ".topvolon.gri.yml").exists()
 
     # check that the manifest is created correctly
-    assert (fmurun_w_casemetadata / MANIFEST_FILENAME).exists()
+    assert (runpath_no_dotfmu / MANIFEST_FILENAME).exists()
     manifest = load_export_manifest()
     assert len(manifest) == 3
     assert manifest[0].absolute_path == export_folder / "topvolantis.gri"

--- a/tests/test_export_rms/test_export_structure_depth_surfaces.py
+++ b/tests/test_export_rms/test_export_structure_depth_surfaces.py
@@ -69,13 +69,13 @@ def test_files_exported_with_metadata(
 
 
 def test_files_exported_inside_fmu(
-    mock_export_class: _ExportStructureDepthSurfaces, fmurun_w_casemetadata: Path
+    mock_export_class: _ExportStructureDepthSurfaces, runpath_no_dotfmu: Path
 ) -> None:
     """Test that files are exported correctly inside an FMU run"""
 
     mock_export_class.export()
 
-    export_folder = fmurun_w_casemetadata / "share/results/maps/structure_depth_surface"
+    export_folder = runpath_no_dotfmu / "share/results/maps/structure_depth_surface"
     assert export_folder.exists()
 
     assert (export_folder / "topvolantis.gri").exists()
@@ -87,7 +87,7 @@ def test_files_exported_inside_fmu(
     assert (export_folder / ".topvolon.gri.yml").exists()
 
     # check that the manifest is created correctly
-    assert (fmurun_w_casemetadata / MANIFEST_FILENAME).exists()
+    assert (runpath_no_dotfmu / MANIFEST_FILENAME).exists()
     manifest = load_export_manifest()
     assert len(manifest) == 3
     assert manifest[0].absolute_path == export_folder / "topvolantis.gri"

--- a/tests/test_units/test_dataio.py
+++ b/tests/test_units/test_dataio.py
@@ -132,7 +132,7 @@ def test_wrong_config_exports_correctly_ouside_fmu(
 
 def test_wrong_config_exports_correctly_in_fmu(
     monkeypatch: MonkeyPatch,
-    fmurun_w_casemetadata: Path,
+    runpath_no_dotfmu: Path,
     mock_global_config: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
 ) -> None:
@@ -162,7 +162,7 @@ def test_wrong_config_exports_correctly_in_fmu(
 
     assert (
         Path(objpath_cfg_invalid)
-        == fmurun_w_casemetadata / f"share/results/maps/{name}.gri"
+        == runpath_no_dotfmu / f"share/results/maps/{name}.gri"
     )
     assert Path(objpath_cfg_invalid).exists()
     assert Path(objpath_cfg_valid).exists()
@@ -770,7 +770,7 @@ def test_surfaces_with_non_finite_values(
 
 
 def test_workflow_as_string(
-    fmurun_w_casemetadata: Path,
+    runpath_no_dotfmu: Path,
     monkeypatch: MonkeyPatch,
     mock_global_config: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
@@ -945,15 +945,15 @@ def test_fmurun_attribute_outside_fmu(rmsglobalconfig: dict[str, Any]) -> None:
     assert edata._export_config.runcontext.inside_fmu is False
 
 
-def test_exportdata_no_iter_folder(
-    fmurun_no_iter_folder: Path,
+def test_exportdata_no_iter_dir(
+    runpath_no_iter_dir: Path,
     rmsglobalconfig: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
     monkeypatch: MonkeyPatch,
 ) -> None:
     """Test that the fmuprovider works without a iteration folder"""
 
-    monkeypatch.chdir(fmurun_no_iter_folder)
+    monkeypatch.chdir(runpath_no_iter_dir)
     edata = ExportData(config=rmsglobalconfig, content="depth")
     assert edata._export_config.runcontext.inside_fmu is True
 
@@ -970,7 +970,7 @@ def test_exportdata_no_iter_folder(
 
 
 def test_fmucontext_case_casepath(
-    fmurun_prehook: Path,
+    runpath_prehook: Path,
     rmsglobalconfig: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
 ) -> None:
@@ -996,13 +996,13 @@ def test_fmucontext_case_casepath(
     # no warning when casepath is provided and metadata is valid
     # should however issue a warning to move it to initialization
     with pytest.warns(FutureWarning, match="move them up to initialization"):
-        meta = edata.generate_metadata(regsurf, casepath=fmurun_prehook)
+        meta = edata.generate_metadata(regsurf, casepath=runpath_prehook)
     assert "fmu" in meta
     assert meta["fmu"]["case"]["name"] == "somecasename"
 
 
 def test_fmurun_attribute_inside_fmu(
-    fmurun_w_casemetadata: Path, rmsglobalconfig: dict[str, Any]
+    runpath_no_dotfmu: Path, rmsglobalconfig: dict[str, Any]
 ) -> None:
     """Test that _fmurun attribute is True when in fmu"""
 
@@ -1016,7 +1016,7 @@ def test_fmurun_attribute_inside_fmu(
 
 
 def test_fmu_context_not_given_fetch_from_env_realization(
-    fmurun_w_casemetadata: Path, rmsglobalconfig: dict[str, Any]
+    runpath_no_dotfmu: Path, rmsglobalconfig: dict[str, Any]
 ) -> None:
     """
     Test fmu_context not explicitly given, should be set to "realization" when
@@ -1034,7 +1034,7 @@ def test_fmu_context_not_given_fetch_from_env_realization(
 
 
 def test_fmu_context_not_given_fetch_from_env_case(
-    fmurun_prehook: Path, rmsglobalconfig: dict[str, Any]
+    runpath_prehook: Path, rmsglobalconfig: dict[str, Any]
 ) -> None:
     """
     Test fmu_context not explicitly given, should be set to "case" when
@@ -1050,11 +1050,13 @@ def test_fmu_context_not_given_fetch_from_env_case(
         edata = ExportData(config=rmsglobalconfig, content="depth")
 
     # test that it runs properly when casepath is provided
-    edata = ExportData(config=rmsglobalconfig, content="depth", casepath=fmurun_prehook)
+    edata = ExportData(
+        config=rmsglobalconfig, content="depth", casepath=runpath_prehook
+    )
     assert edata._export_config.runcontext.inside_fmu is True
     assert edata.fmu_context is None
     assert edata._export_config.fmu_context == FMUContext.case
-    assert edata._export_config.runcontext.exportroot == fmurun_prehook
+    assert edata._export_config.runcontext.exportroot == runpath_prehook
 
 
 def test_fmu_context_not_given_fetch_from_env_nonfmu(
@@ -1125,7 +1127,9 @@ def test_fmu_context_preprocessed_deprecation_outside_fmu(
 
 
 def test_fmu_context_preprocessed_deprecation_inside_fmu(
-    fmurun_prehook: Path, rmsglobalconfig: dict[str, Any], regsurf: xtgeo.RegularSurface
+    runpath_prehook: Path,
+    rmsglobalconfig: dict[str, Any],
+    regsurf: xtgeo.RegularSurface,
 ) -> None:
     """
     Test the deprecated fmu_context="preprocessed" inside fmu.
@@ -1138,7 +1142,7 @@ def test_fmu_context_preprocessed_deprecation_inside_fmu(
             config=rmsglobalconfig,
             content="depth",
             fmu_context="preprocessed",
-            casepath=fmurun_prehook,
+            casepath=runpath_prehook,
         )
     assert edata.preprocessed is False
     assert edata._export_config.preprocessed is True
@@ -1164,7 +1168,7 @@ def test_preprocessed_outside_fmu(
 
 
 def test_preprocessed_inside_fmu(
-    fmurun_w_casemetadata: Path,
+    runpath_no_dotfmu: Path,
     rmsglobalconfig: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
 ) -> None:
@@ -1424,7 +1428,7 @@ def test_standard_result_not_present_in_generated_metadata(
 
 
 def test_ert_experiment_id_present_in_generated_metadata(
-    fmurun_w_casemetadata: Path,
+    runpath_no_dotfmu: Path,
     monkeypatch: MonkeyPatch,
     mock_global_config: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
@@ -1439,7 +1443,7 @@ def test_ert_experiment_id_present_in_generated_metadata(
 
 
 def test_ert_experiment_id_present_in_exported_metadata(
-    fmurun_w_casemetadata: Path,
+    runpath_no_dotfmu: Path,
     monkeypatch: MonkeyPatch,
     mock_global_config: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
@@ -1456,7 +1460,7 @@ def test_ert_experiment_id_present_in_exported_metadata(
 
 
 def test_ert_simulation_mode_present_in_generated_metadata(
-    fmurun_w_casemetadata: Path,
+    runpath_no_dotfmu: Path,
     monkeypatch: MonkeyPatch,
     mock_global_config: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
@@ -1470,7 +1474,7 @@ def test_ert_simulation_mode_present_in_generated_metadata(
 
 
 def test_ert_simulation_mode_present_in_exported_metadata(
-    fmurun_w_casemetadata: Path,
+    runpath_no_dotfmu: Path,
     monkeypatch: MonkeyPatch,
     mock_global_config: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
@@ -1648,7 +1652,7 @@ def test_timedata_wrong_format(
 
 
 def test_export_with_standard_result_valid_config(
-    fmurun_w_casemetadata: Path,
+    runpath_no_dotfmu: Path,
     monkeypatch: MonkeyPatch,
     mock_global_config: dict[str, Any],
     mock_volumes: pd.DataFrame,
@@ -1700,7 +1704,7 @@ def test_export_with_standard_result_invalid_config(mock_volumes: pd.DataFrame) 
 
 
 def test_export_with_standard_result_custom_export_config(
-    fmurun_prehook: Path,
+    runpath_prehook: Path,
     monkeypatch: MonkeyPatch,
     mock_global_config: dict[str, Any],
     mock_volumes: pd.DataFrame,
@@ -1710,7 +1714,7 @@ def test_export_with_standard_result_custom_export_config(
         config=mock_global_config,
         content="volumes",
         name="TopWhatever",
-        casepath=fmurun_prehook,
+        casepath=runpath_prehook,
         fmu_context="ensemble",
     )
 
@@ -1724,11 +1728,11 @@ def test_export_with_standard_result_custom_export_config(
     outpath = export_with_metadata(export_config, mock_volumes)
 
     assert "pred-dg3" in str(outpath)
-    assert fmurun_prehook / "share" / "ensemble" / "pred-dg3" in Path(outpath).parents
+    assert runpath_prehook / "share" / "ensemble" / "pred-dg3" in Path(outpath).parents
 
 
 def test_file_paths_realization_context(
-    fmurun_w_casemetadata: Path,
+    runpath_no_dotfmu: Path,
     drogon_global_config: dict[str, Any],
     monkeypatch: MonkeyPatch,
     regsurf: xtgeo.RegularSurface,
@@ -1746,11 +1750,11 @@ def test_file_paths_realization_context(
 
     assert meta["file"]["runpath_relative_path"] == share_location
     assert meta["file"]["relative_path"] == "realization-0/iter-0/" + share_location
-    assert meta["file"]["absolute_path"] == str(fmurun_w_casemetadata / share_location)
+    assert meta["file"]["absolute_path"] == str(runpath_no_dotfmu / share_location)
 
 
 def test_file_paths_case_context(
-    fmurun_w_casemetadata: Path,
+    runpath_no_dotfmu: Path,
     drogon_global_config: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
 ) -> None:
@@ -1759,7 +1763,7 @@ def test_file_paths_case_context(
     Here the file.runpath_relative_path should not be present.
     """
 
-    casepath = fmurun_w_casemetadata.parent.parent
+    casepath = runpath_no_dotfmu.parent.parent
 
     meta = ExportData(
         config=drogon_global_config,
@@ -1777,13 +1781,13 @@ def test_file_paths_case_context(
 
 
 def test_export_file_paths_ensemble_context(
-    fmurun_w_casemetadata: Path,
+    runpath_no_dotfmu: Path,
     drogon_global_config: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
 ) -> None:
     """Ensemble context resolves to correct path."""
 
-    casepath = fmurun_w_casemetadata.parent.parent
+    casepath = runpath_no_dotfmu.parent.parent
 
     with pytest.warns(UserWarning, match="Did you mean fmu_context='realization'"):
         export_data = ExportData(
@@ -1803,13 +1807,13 @@ def test_export_file_paths_ensemble_context(
 
 
 def test_export_file_paths_ensemble_context_pred(
-    fmurun_w_casemetadata_pred: Path,
+    runpath_no_dotfmu_pred: Path,
     drogon_global_config: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
 ) -> None:
     """Ensemble context resolves to correct path with a prediction ensemble."""
 
-    casepath = fmurun_w_casemetadata_pred.parent.parent
+    casepath = runpath_no_dotfmu_pred.parent.parent
 
     with pytest.warns(UserWarning, match="Did you mean fmu_context='realization'"):
         export_data = ExportData(
@@ -1829,7 +1833,7 @@ def test_export_file_paths_ensemble_context_pred(
 
 
 def test_element_id_realization_context(
-    fmurun_w_casemetadata: Path,
+    runpath_no_dotfmu: Path,
     drogon_global_config: dict[str, Any],
     monkeypatch: MonkeyPatch,
     regsurf: xtgeo.RegularSurface,
@@ -1844,7 +1848,7 @@ def test_element_id_realization_context(
     assert meta["file"]["runpath_relative_path"] == share_path
     assert meta["file"]["relative_path"] == "realization-0/iter-0/" + share_path
 
-    casefilepath = fmurun_w_casemetadata.parent.parent / ERT_RELATIVE_CASE_METADATA_FILE
+    casefilepath = runpath_no_dotfmu.parent.parent / ERT_RELATIVE_CASE_METADATA_FILE
     with open(casefilepath, encoding="utf-8") as stream:
         casemeta = yaml.safe_load(stream)
 
@@ -1857,12 +1861,12 @@ def test_element_id_realization_context(
 
 
 def test_element_id_case_context(
-    fmurun_w_casemetadata: Path,
+    runpath_no_dotfmu: Path,
     drogon_global_config: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
 ) -> None:
     """Test that the entity.uuid is not set in the metadata for a case context."""
-    casepath = fmurun_w_casemetadata.parent.parent
+    casepath = runpath_no_dotfmu.parent.parent
 
     meta = ExportData(
         config=drogon_global_config,

--- a/tests/test_units/test_dictionary.py
+++ b/tests/test_units/test_dictionary.py
@@ -26,31 +26,31 @@ def _fixture_simple() -> dict:
 
 
 @pytest.fixture(name="json_dict", scope="function")
-def _fixture_json(fmurun_w_casemetadata: Path, monkeypatch: MonkeyPatch) -> dict:
+def _fixture_json(runpath_no_dotfmu: Path, monkeypatch: MonkeyPatch) -> dict:
     """Return dictionary read from json file
 
     Args:
-        fmurun_w_casemetadata (pathlib.Path): path to single fmu realization
+        runpath_no_dotfmu (pathlib.Path): path to single fmu realization
 
     Returns:
         dict: The parameters read from json file
     """
-    print(fmurun_w_casemetadata)
-    with open(fmurun_w_casemetadata / "parameters.json", encoding="utf-8") as stream:
+    print(runpath_no_dotfmu)
+    with open(runpath_no_dotfmu / "parameters.json", encoding="utf-8") as stream:
         return json.load(stream)
 
 
 @pytest.fixture(name="simple_parameters", scope="function")
-def _fixture_simple_parameters(fmurun_w_casemetadata: Path) -> dict:
+def _fixture_simple_parameters(runpath_no_dotfmu: Path) -> dict:
     """Return dictionary read from parameters.txt
 
     Args:
-        fmurun_w_casemetadata (pathlib.Path): path to single fmu realization
+        runpath_no_dotfmu (pathlib.Path): path to single fmu realization
 
     Returns:
         dict: The parameters read directly from parameters.txt
     """
-    return dict(read_parameters_txt(fmurun_w_casemetadata / "parameters.txt"))
+    return dict(read_parameters_txt(runpath_no_dotfmu / "parameters.txt"))
 
 
 def assert_dict_correct(result_dict: dict, meta: dict, name: str) -> None:

--- a/tests/test_units/test_ert_context.py
+++ b/tests/test_units/test_ert_context.py
@@ -29,19 +29,19 @@ logger = logging.getLogger(__name__)
 
 
 def test_regsurf_generate_metadata(
-    fmurun_w_casemetadata: Path,
+    runpath_no_dotfmu: Path,
     rmsglobalconfig: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
     monkeypatch: MonkeyPatch,
 ) -> None:
     """Test generating metadata for a surface pretend ERT job"""
-    logger.info("Active folder is %s", fmurun_w_casemetadata)
+    logger.info("Active folder is %s", runpath_no_dotfmu)
 
     edata = dataio.ExportData(config=rmsglobalconfig, content="depth")
 
     meta = edata.generate_metadata(regsurf)
     assert str(edata._export_config.runcontext.casepath) == str(
-        fmurun_w_casemetadata.parent.parent.resolve()
+        runpath_no_dotfmu.parent.parent.resolve()
     )
     assert meta["file"]["relative_path"].startswith("realization-0/iter-0/share")
     assert "jobs" not in meta["fmu"]["realization"]
@@ -61,7 +61,7 @@ def test_incl_jobs_warning(rmsglobalconfig: dict[str, Any]) -> None:
 
 
 def test_regsurf_metadata_with_timedata(
-    fmurun_w_casemetadata: Path,
+    runpath_no_dotfmu: Path,
     rmsglobalconfig: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
     monkeypatch: MonkeyPatch,
@@ -95,7 +95,7 @@ def test_regsurf_metadata_with_timedata(
 
 
 def test_regsurf_export_file_fmurun(
-    fmurun_w_casemetadata: Path,
+    runpath_no_dotfmu: Path,
     rmsglobalconfig: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
     monkeypatch: MonkeyPatch,
@@ -105,7 +105,7 @@ def test_regsurf_export_file_fmurun(
     Export the regular surface to file with correct metadata and name.
     """
 
-    logger.info("Active folder is %s", fmurun_w_casemetadata)
+    logger.info("Active folder is %s", runpath_no_dotfmu)
 
     edata = dataio.ExportData(
         config=rmsglobalconfig,
@@ -140,7 +140,7 @@ def test_regsurf_export_file_fmurun(
     assert metadata["data"]["unit"] == "forthnite"
 
     # check that the two exported files have been written to the manifest
-    assert (fmurun_w_casemetadata / MANIFEST_FILENAME).exists()
+    assert (runpath_no_dotfmu / MANIFEST_FILENAME).exists()
     manifest = load_export_manifest()
     assert len(manifest) == 2
     assert manifest[0].absolute_path == Path(output)
@@ -153,14 +153,14 @@ def test_regsurf_export_file_fmurun(
 
 
 def test_polys_export_file_set_name(
-    fmurun_w_casemetadata: Path,
+    runpath_no_dotfmu: Path,
     rmsglobalconfig: dict[str, Any],
     polygons: xtgeo.Polygons,
     monkeypatch: MonkeyPatch,
 ) -> None:
     """Export the polygon to file with correct metadata and name."""
 
-    logger.info("Active folder is %s", fmurun_w_casemetadata)
+    logger.info("Active folder is %s", runpath_no_dotfmu)
 
     edata = dataio.ExportData(
         config=rmsglobalconfig, content="depth", name="TopVolantis"
@@ -183,14 +183,14 @@ def test_polys_export_file_set_name(
 
 
 def test_polys_export_file_use_xtgeo_names(
-    fmurun_w_casemetadata: Path,
+    runpath_no_dotfmu: Path,
     rmsglobalconfig: dict[str, Any],
     polygons: xtgeo.Polygons,
     monkeypatch: MonkeyPatch,
 ) -> None:
     """Export the polygon to file with correct metadata and name."""
 
-    logger.info("Active folder is %s", fmurun_w_casemetadata)
+    logger.info("Active folder is %s", runpath_no_dotfmu)
 
     edata = dataio.ExportData(
         config=rmsglobalconfig,
@@ -212,14 +212,14 @@ def test_polys_export_file_use_xtgeo_names(
 
 
 def test_polys_export_file_as_parquet(
-    fmurun_w_casemetadata: Path,
+    runpath_no_dotfmu: Path,
     rmsglobalconfig: dict[str, Any],
     polygons: xtgeo.Polygons,
     monkeypatch: MonkeyPatch,
 ) -> None:
     """Export the polygon to file with correct metadata and name."""
 
-    logger.info("Active folder is %s", fmurun_w_casemetadata)
+    logger.info("Active folder is %s", runpath_no_dotfmu)
 
     edata = dataio.ExportData(
         config=rmsglobalconfig,
@@ -251,14 +251,14 @@ def test_polys_export_file_as_parquet(
 
 
 def test_polys_export_file_as_parquet_no_table_index(
-    fmurun_w_casemetadata: Path,
+    runpath_no_dotfmu: Path,
     rmsglobalconfig: dict[str, Any],
     polygons: xtgeo.Polygons,
     monkeypatch: MonkeyPatch,
 ) -> None:
     """Export the polygon to file without table index."""
 
-    logger.info("Active folder is %s", fmurun_w_casemetadata)
+    logger.info("Active folder is %s", runpath_no_dotfmu)
 
     edata = dataio.ExportData(
         config=rmsglobalconfig, content="depth", name="TopVolantis"
@@ -275,14 +275,14 @@ def test_polys_export_file_as_parquet_no_table_index(
 
 
 def test_polys_export_file_as_irap_ascii(
-    fmurun_w_casemetadata: Path,
+    runpath_no_dotfmu: Path,
     rmsglobalconfig: dict[str, Any],
     polygons: xtgeo.Polygons,
     monkeypatch: MonkeyPatch,
 ) -> None:
     """Export the polygon to file with correct metadata and name."""
 
-    logger.info("Active folder is %s", fmurun_w_casemetadata)
+    logger.info("Active folder is %s", runpath_no_dotfmu)
 
     edata = dataio.ExportData(
         config=rmsglobalconfig,
@@ -308,14 +308,14 @@ def test_polys_export_file_as_irap_ascii(
 
 
 def test_points_export_file_set_name(
-    fmurun_w_casemetadata: Path,
+    runpath_no_dotfmu: Path,
     rmsglobalconfig: dict[str, Any],
     points: xtgeo.Points,
     monkeypatch: MonkeyPatch,
 ) -> None:
     """Export the points to file with correct metadata and name."""
 
-    logger.info("Active folder is %s", fmurun_w_casemetadata)
+    logger.info("Active folder is %s", runpath_no_dotfmu)
 
     edata = dataio.ExportData(
         config=rmsglobalconfig,
@@ -344,14 +344,14 @@ def test_points_export_file_set_name(
 
 
 def test_points_export_file_set_name_xtgeoheaders(
-    fmurun_w_casemetadata: Path,
+    runpath_no_dotfmu: Path,
     rmsglobalconfig: dict[str, Any],
     points: xtgeo.Points,
     monkeypatch: MonkeyPatch,
 ) -> None:
     """Export the points to file with correct metadata and name but here xtgeo var."""
 
-    logger.info("Active folder is %s", fmurun_w_casemetadata)
+    logger.info("Active folder is %s", runpath_no_dotfmu)
 
     dataio.ExportData.points_fformat = "csv"
     edata = dataio.ExportData(
@@ -380,14 +380,14 @@ def test_points_export_file_set_name_xtgeoheaders(
 
 
 def test_points_export_file_as_parquet_no_table_index(
-    fmurun_w_casemetadata: Path,
+    runpath_no_dotfmu: Path,
     rmsglobalconfig: dict[str, Any],
     points: xtgeo.Points,
     monkeypatch: MonkeyPatch,
 ) -> None:
     """Export the points to file without table index."""
 
-    logger.info("Active folder is %s", fmurun_w_casemetadata)
+    logger.info("Active folder is %s", runpath_no_dotfmu)
 
     edata = dataio.ExportData(
         config=rmsglobalconfig, content="depth", name="TopVolantis"
@@ -404,14 +404,14 @@ def test_points_export_file_as_parquet_no_table_index(
 
 
 def test_points_export_file_as_irap_ascii(
-    fmurun_w_casemetadata: Path,
+    runpath_no_dotfmu: Path,
     rmsglobalconfig: dict[str, Any],
     points: xtgeo.Points,
     monkeypatch: MonkeyPatch,
 ) -> None:
     """Export the polygon to file with correct metadata and name."""
 
-    logger.info("Active folder is %s", fmurun_w_casemetadata)
+    logger.info("Active folder is %s", runpath_no_dotfmu)
 
     edata = dataio.ExportData(
         config=rmsglobalconfig,
@@ -438,14 +438,14 @@ def test_points_export_file_as_irap_ascii(
 
 
 def test_points_export_file_as_parquet(
-    fmurun_w_casemetadata: Path,
+    runpath_no_dotfmu: Path,
     rmsglobalconfig: dict[str, Any],
     points: xtgeo.Points,
     monkeypatch: MonkeyPatch,
 ) -> None:
     """Export the polygon to file with correct metadata and name."""
 
-    logger.info("Active folder is %s", fmurun_w_casemetadata)
+    logger.info("Active folder is %s", runpath_no_dotfmu)
 
     edata = dataio.ExportData(
         config=rmsglobalconfig, content="depth", name="TopVolantis"
@@ -483,7 +483,7 @@ def test_points_export_file_as_parquet(
 def test_exported_points_spec_table_format(
     fformat: Literal["parquet", "csv|xtgeo", "csv"],
     expected_columns: list[str],
-    fmurun_w_casemetadata: Path,
+    runpath_no_dotfmu: Path,
     drogon_global_config: dict[str, Any],
     monkeypatch: MonkeyPatch,
     points: xtgeo.Points,
@@ -507,7 +507,7 @@ def test_exported_points_spec_table_format(
 
 
 def test_exported_points_spec_irap_ascii(
-    fmurun_w_casemetadata: Path,
+    runpath_no_dotfmu: Path,
     drogon_global_config: dict[str, Any],
     monkeypatch: MonkeyPatch,
     points: xtgeo.Points,
@@ -541,7 +541,7 @@ def test_exported_points_spec_irap_ascii(
 def test_exported_polygon_spec_table_format(
     fformat: Literal["parquet", "csv|xtgeo", "csv"],
     expected_columns: list[str],
-    fmurun_w_casemetadata: Path,
+    runpath_no_dotfmu: Path,
     drogon_global_config: dict[str, Any],
     monkeypatch: MonkeyPatch,
     polygons: xtgeo.Polygons,
@@ -564,7 +564,7 @@ def test_exported_polygon_spec_table_format(
 
 
 def test_exported_polygon_spec_irap_ascii(
-    fmurun_w_casemetadata: Path,
+    runpath_no_dotfmu: Path,
     drogon_global_config: dict[str, Any],
     monkeypatch: MonkeyPatch,
     polygons: xtgeo.Polygons,
@@ -593,14 +593,14 @@ def test_exported_polygon_spec_irap_ascii(
 
 
 def test_cube_export_file_set_name(
-    fmurun_w_casemetadata: Path,
+    runpath_no_dotfmu: Path,
     rmsglobalconfig: dict[str, Any],
     cube: xtgeo.Cube,
     monkeypatch: MonkeyPatch,
 ) -> None:
     """Export the cube to file with correct metadata and name."""
 
-    logger.info("Active folder is %s", fmurun_w_casemetadata)
+    logger.info("Active folder is %s", runpath_no_dotfmu)
 
     edata = dataio.ExportData(config=rmsglobalconfig, content="depth", name="MyCube")
 
@@ -617,14 +617,14 @@ def test_cube_export_file_set_name(
 
 
 def test_cube_export_file_is_observation(
-    fmurun_w_casemetadata: Path,
+    runpath_no_dotfmu: Path,
     rmsglobalconfig: dict[str, Any],
     cube: xtgeo.Cube,
     monkeypatch: MonkeyPatch,
 ) -> None:
     """Export the cube to file with correct metadata..., with is_observation flag."""
 
-    logger.info("Active folder is %s", fmurun_w_casemetadata)
+    logger.info("Active folder is %s", runpath_no_dotfmu)
 
     edata = dataio.ExportData(
         config=rmsglobalconfig,
@@ -647,14 +647,14 @@ def test_cube_export_file_is_observation(
 
 
 def test_cube_export_file_is_case_observation(
-    fmurun_w_casemetadata: Path,
+    runpath_no_dotfmu: Path,
     rmsglobalconfig: dict[str, Any],
     cube: xtgeo.Cube,
     monkeypatch: MonkeyPatch,
 ) -> None:
     """Export the cube..., with is_observation flag and fmu_context is case."""
 
-    logger.info("Active folder is %s", fmurun_w_casemetadata)
+    logger.info("Active folder is %s", runpath_no_dotfmu)
 
     edata = dataio.ExportData(
         config=rmsglobalconfig,
@@ -677,14 +677,14 @@ def test_cube_export_file_is_case_observation(
 
 
 def test_cube_export_file_is_observation_forcefolder(
-    fmurun_w_casemetadata: Path,
+    runpath_no_dotfmu: Path,
     rmsglobalconfig: dict[str, Any],
     cube: xtgeo.Cube,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Export the cube to file..., with is_observation flag and forcefolder."""
 
-    logger.info("Active folder is %s", fmurun_w_casemetadata)
+    logger.info("Active folder is %s", runpath_no_dotfmu)
 
     edata = dataio.ExportData(
         config=rmsglobalconfig,
@@ -709,7 +709,7 @@ def test_cube_export_file_is_observation_forcefolder(
 
 @pytest.mark.skipif("win" in sys.platform, reason="Windows tests have no /tmp")
 def test_cube_export_file_is_observation_forcefolder_abs(
-    fmurun_w_casemetadata: Path,
+    runpath_no_dotfmu: Path,
     rmsglobalconfig: dict[str, Any],
     cube: xtgeo.Cube,
     monkeypatch: MonkeyPatch,
@@ -719,7 +719,7 @@ def test_cube_export_file_is_observation_forcefolder_abs(
     Using an absolute path requires class property allow_forcefolder_absolute = True
     """
 
-    logger.info("Active folder is %s", fmurun_w_casemetadata)
+    logger.info("Active folder is %s", runpath_no_dotfmu)
 
     dataio.ExportData.allow_forcefolder_absolute = True
     with pytest.warns(UserWarning, match="deprecated"):
@@ -745,14 +745,14 @@ def test_cube_export_file_is_observation_forcefolder_abs(
 
 
 def test_grid_export_file_set_name(
-    fmurun_w_casemetadata: Path,
+    runpath_no_dotfmu: Path,
     rmsglobalconfig: dict[str, Any],
     grid: xtgeo.Grid,
     monkeypatch: MonkeyPatch,
 ) -> None:
     """Export the grid to file with correct metadata and name."""
 
-    logger.info("Active folder is %s", fmurun_w_casemetadata)
+    logger.info("Active folder is %s", runpath_no_dotfmu)
 
     edata = dataio.ExportData(config=rmsglobalconfig, content="depth", name="MyGrid")
 
@@ -770,14 +770,14 @@ def test_grid_export_file_set_name(
 
 
 def test_gridproperty_export_file_set_name(
-    fmurun_w_casemetadata: Path,
+    runpath_no_dotfmu: Path,
     rmsglobalconfig: dict[str, Any],
     gridproperty: xtgeo.GridProperty,
     monkeypatch: MonkeyPatch,
 ) -> None:
     """Export the gridprop to file with correct metadata and name."""
 
-    logger.info("Active folder is %s", fmurun_w_casemetadata)
+    logger.info("Active folder is %s", runpath_no_dotfmu)
 
     edata = dataio.ExportData(
         config=rmsglobalconfig, content="depth", name="MyGridProperty"
@@ -802,14 +802,14 @@ def test_gridproperty_export_file_set_name(
 
 
 def test_dataframe_export_file_set_name(
-    fmurun_w_casemetadata: Path,
+    runpath_no_dotfmu: Path,
     rmsglobalconfig: dict[str, Any],
     dataframe: pd.DataFrame,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Export the dataframe to file with correct metadata and name."""
 
-    logger.info("Active folder is %s", fmurun_w_casemetadata)
+    logger.info("Active folder is %s", runpath_no_dotfmu)
 
     edata = dataio.ExportData(
         config=rmsglobalconfig, content="depth", name="MyDataframe"
@@ -834,14 +834,14 @@ def test_dataframe_export_file_set_name(
 
 
 def test_pyarrow_export_file_set_name(
-    fmurun_w_casemetadata: Path,
+    runpath_no_dotfmu: Path,
     rmsglobalconfig: dict[str, Any],
     arrowtable: pa.Table,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Export the arrow to file with correct metadata and name."""
 
-    logger.info("Active folder is %s", fmurun_w_casemetadata)
+    logger.info("Active folder is %s", runpath_no_dotfmu)
 
     edata = dataio.ExportData(
         config=rmsglobalconfig, content="depth", name="MyArrowtable"

--- a/tests/test_units/test_export_config.py
+++ b/tests/test_units/test_export_config.py
@@ -422,7 +422,7 @@ def test_builder_run_context_ensemble(mock_resolve_fmu_context: MagicMock) -> No
 
 
 def test_builder_run_context_ensemble_export_root(
-    fmurun_w_casemetadata: Path,
+    runpath_no_dotfmu: Path,
 ) -> None:
     """run_context() with FMUContext.ensemble sets correct export root."""
     config = (

--- a/tests/test_units/test_fmu_context.py
+++ b/tests/test_units/test_fmu_context.py
@@ -157,7 +157,7 @@ def test_preprocessed_outside_fmu_is_allowed() -> None:
 
 
 def test_realization_context_from_env(
-    fmurun_w_casemetadata: Path,
+    runpath_no_dotfmu: Path,
 ) -> None:
     """Test resolution with Ert environment variables."""
     env = FMUEnvironment.from_env()
@@ -168,7 +168,7 @@ def test_realization_context_from_env(
     assert context == FMUContext.realization
 
 
-def test_case_context_from_env(fmurun_prehook: Path) -> None:
+def test_case_context_from_env(runpath_prehook: Path) -> None:
     """Test resolution when only case environment is set."""
     env = FMUEnvironment.from_env()
     context = _determine_effective_fmu_context(
@@ -178,7 +178,7 @@ def test_case_context_from_env(fmurun_prehook: Path) -> None:
     assert context == FMUContext.case
 
 
-def test_ensemble_context_when_case_context_from_env(fmurun_prehook: Path) -> None:
+def test_ensemble_context_when_case_context_from_env(runpath_prehook: Path) -> None:
     """Test resolution when case environment is set, but ensemble given."""
     env = FMUEnvironment.from_env()
     context = _determine_effective_fmu_context(

--- a/tests/test_units/test_fmuprovider_class.py
+++ b/tests/test_units/test_fmuprovider_class.py
@@ -35,7 +35,7 @@ def test_fmuprovider_no_provider() -> None:
         myfmu.get_metadata()
 
 
-def test_fmuprovider_model_info_in_metadata(fmurun_w_casemetadata: Path) -> None:
+def test_fmuprovider_model_info_in_metadata(runpath_no_dotfmu: Path) -> None:
     """Test that the model info is stored and preserved in the metadata."""
     runcontext = RunContext()
     myfmu = FmuProvider(
@@ -47,7 +47,7 @@ def test_fmuprovider_model_info_in_metadata(fmurun_w_casemetadata: Path) -> None
     assert meta.model.model_dump(mode="json", exclude_none=True) == GLOBAL_CONFIG_MODEL
 
 
-def test_fmuprovider_no_model_info_use_case(fmurun_w_casemetadata: Path) -> None:
+def test_fmuprovider_no_model_info_use_case(runpath_no_dotfmu: Path) -> None:
     """Test that if no model info it is picking up from the case metadata."""
     runcontext = RunContext()
     myfmu = FmuProvider(
@@ -64,13 +64,12 @@ def test_fmuprovider_no_model_info_use_case(fmurun_w_casemetadata: Path) -> None
 
 
 def test_fmuprovider_ert_provider_guess_casemeta_path(
-    fmurun: Path, monkeypatch: MonkeyPatch
+    runpath_no_case_metadata: Path, monkeypatch: MonkeyPatch
 ) -> None:
     """The casepath input is empty, but try guess from ERT RUNPATH without success.
 
     Since there are no metadata here, this will issue a warning
     """
-    monkeypatch.chdir(fmurun)
     with pytest.warns(UserWarning, match="case metadata"):
         runcontext = RunContext(casepath_proposed=None)
 
@@ -82,14 +81,14 @@ def test_fmuprovider_ert_provider_guess_casemeta_path(
 
 
 def test_fmuprovider_ert_provider_missing_parameter_txt(
-    fmurun_w_casemetadata: Path, monkeypatch: MonkeyPatch
+    runpath_no_dotfmu: Path, monkeypatch: MonkeyPatch
 ) -> None:
     """Test for an ERT case, when missing file parameter.txt runs ok"""
 
     runcontext = RunContext()
 
     # delete the file for this test
-    (fmurun_w_casemetadata / "parameters.txt").unlink()
+    (runpath_no_dotfmu / "parameters.txt").unlink()
     myfmu = FmuProvider(runcontext)
 
     assert myfmu._casepath is not None
@@ -99,11 +98,11 @@ def test_fmuprovider_ert_provider_missing_parameter_txt(
 
 
 def test_fmuprovider_arbitrary_iter_name(
-    fmurun_w_casemetadata_pred: Path, monkeypatch: MonkeyPatch
+    runpath_no_dotfmu_pred: Path, monkeypatch: MonkeyPatch
 ) -> None:
     """Test iteration block is correctly set, also with arbitrary iteration names."""
 
-    monkeypatch.chdir(fmurun_w_casemetadata_pred)
+    monkeypatch.chdir(runpath_no_dotfmu_pred)
 
     runcontext = RunContext()
     myfmu = FmuProvider(runcontext)
@@ -120,15 +119,15 @@ def test_fmuprovider_arbitrary_iter_name(
 
 
 def test_fmuprovider_get_real_and_iter_from_env(
-    fmurun_non_equal_real_and_iter: Path, monkeypatch: MonkeyPatch
+    runpath_non_equal_real_and_iter: Path, monkeypatch: MonkeyPatch
 ) -> None:
     """Test that iter and real number is picked up correctly from env"""
-    monkeypatch.chdir(fmurun_non_equal_real_and_iter)
+    monkeypatch.chdir(runpath_non_equal_real_and_iter)
 
     runcontext = RunContext()
     myfmu = FmuProvider(runcontext)
 
-    assert myfmu._runpath == fmurun_non_equal_real_and_iter
+    assert myfmu._runpath == runpath_non_equal_real_and_iter
     assert myfmu._casepath is not None
     assert myfmu._casepath.name == "ertrun1"
     assert myfmu._realization_name == "realization-1"
@@ -137,18 +136,18 @@ def test_fmuprovider_get_real_and_iter_from_env(
     assert myfmu._iteration_number == 0
 
 
-def test_fmuprovider_no_iter_folder(
-    fmurun_no_iter_folder: Path, monkeypatch: MonkeyPatch
+def test_fmuprovider_no_iter_dir(
+    runpath_no_iter_dir: Path, monkeypatch: MonkeyPatch
 ) -> None:
     """Test that the fmuprovider works without a iteration folder"""
 
-    monkeypatch.chdir(fmurun_no_iter_folder)
+    monkeypatch.chdir(runpath_no_iter_dir)
 
     runcontext = RunContext()
     myfmu = FmuProvider(runcontext)
 
-    assert myfmu._runpath == fmurun_no_iter_folder
-    assert myfmu._casepath == fmurun_no_iter_folder.parent
+    assert myfmu._runpath == runpath_no_iter_dir
+    assert myfmu._casepath == runpath_no_iter_dir.parent
     assert myfmu._casepath.name == "ertrun1_no_iter"
     assert myfmu._realization_name == "realization-1"
     assert myfmu._realization_number == 1
@@ -168,7 +167,7 @@ def test_fmuprovider_no_iter_folder(
 def test_fmuprovider_prehook_case(
     tmp_path: Path,
     drogon_global_config: dict[str, Any],
-    fmurun_prehook: Path,
+    runpath_prehook: Path,
     monkeypatch: MonkeyPatch,
 ) -> None:
     """The fmu run case metadata is created with Create case; then get provider.
@@ -197,7 +196,7 @@ def test_fmuprovider_prehook_case(
     assert casemetafile.is_file()
     assert exp == str(casemetafile.resolve())
 
-    monkeypatch.chdir(fmurun_prehook)
+    monkeypatch.chdir(runpath_prehook)
     logger.debug("Case root proposed is: %s", caseroot)
     runcontext = RunContext(casepath_proposed=caseroot, fmu_context=FMUContext.case)
     myfmu = FmuProvider(runcontext)
@@ -208,14 +207,12 @@ def test_fmuprovider_prehook_case(
 
 
 def test_fmuprovider_detect_no_case_metadata(
-    fmurun: Path, monkeypatch: MonkeyPatch
+    runpath_no_case_metadata: Path, monkeypatch: MonkeyPatch
 ) -> None:
     """Testing the case metadata file which is not found here.
 
     That will still provide a file path but the metadata will be {} i.e. empty
     """
-    monkeypatch.chdir(fmurun)
-
     with pytest.warns(UserWarning, match="case metadata"):
         runcontext = RunContext()
         myfmu = FmuProvider(runcontext)
@@ -223,14 +220,14 @@ def test_fmuprovider_detect_no_case_metadata(
         myfmu.get_metadata()
 
 
-def test_fmuprovider_case_run(fmurun_prehook: Path, monkeypatch: MonkeyPatch) -> None:
+def test_fmuprovider_case_run(runpath_prehook: Path, monkeypatch: MonkeyPatch) -> None:
     """
     When fmu_context="case" and no runpath can be detected from environment
     an error should be raised if no casepath is provided.
     """
-    logger.info("Active folder is %s", fmurun_prehook)
+    logger.info("Active folder is %s", runpath_prehook)
 
-    monkeypatch.chdir(fmurun_prehook)
+    monkeypatch.chdir(runpath_prehook)
 
     env = FMUEnvironment.from_env()
     # make sure that no runpath environment value is present
@@ -242,17 +239,17 @@ def test_fmuprovider_case_run(fmurun_prehook: Path, monkeypatch: MonkeyPatch) ->
 
     # providing the casepath is the solution, and no error is thrown
     runcontext = RunContext(
-        fmu_context=FMUContext.case, casepath_proposed=fmurun_prehook
+        fmu_context=FMUContext.case, casepath_proposed=runpath_prehook
     )
     myfmu = FmuProvider(runcontext)
     meta = myfmu.get_metadata()
     assert meta.realization is None
     assert myfmu._casepath is not None
-    assert myfmu._casepath.name == fmurun_prehook.name
+    assert myfmu._casepath.name == runpath_prehook.name
 
 
 def test_fmuprovider_valid_restart_env(
-    monkeypatch: MonkeyPatch, fmurun_w_casemetadata: Path, fmurun_pred: Path
+    monkeypatch: MonkeyPatch, runpath_no_dotfmu: Path, runpath_pred_files: Path
 ) -> None:
     """Testing the scenario given a valid RESTART_FROM_PATH environment variable
 
@@ -262,9 +259,9 @@ def test_fmuprovider_valid_restart_env(
     fmu_restart_from = FmuProvider(runcontext)
     meta_restart_from = fmu_restart_from.get_metadata()
 
-    monkeypatch.setenv(RESTART_PATH_ENVNAME, str(fmurun_w_casemetadata))
+    monkeypatch.setenv(RESTART_PATH_ENVNAME, str(runpath_no_dotfmu))
 
-    monkeypatch.chdir(fmurun_pred)
+    monkeypatch.chdir(runpath_pred_files)
     runcontext = RunContext()
     fmu_restart = FmuProvider(runcontext)
 
@@ -276,7 +273,7 @@ def test_fmuprovider_valid_restart_env(
 
 
 def test_fmuprovider_valid_relative_restart_env(
-    monkeypatch: MonkeyPatch, fmurun_w_casemetadata: Path, fmurun_pred: Path
+    monkeypatch: MonkeyPatch, runpath_no_dotfmu: Path, runpath_pred_files: Path
 ) -> None:
     """
     Test giving a valid RESTART_FROM_PATH environment variable that contains
@@ -288,7 +285,7 @@ def test_fmuprovider_valid_relative_restart_env(
     # using a relative path as input
     monkeypatch.setenv(RESTART_PATH_ENVNAME, "../iter-0")
 
-    monkeypatch.chdir(fmurun_pred)
+    monkeypatch.chdir(runpath_pred_files)
     runcontext = RunContext()
     meta_restart = FmuProvider(runcontext).get_metadata()
 
@@ -298,23 +295,23 @@ def test_fmuprovider_valid_relative_restart_env(
     assert meta_restart.iteration.restart_from == meta_restart_from.iteration.uuid
 
 
-def test_fmuprovider_restart_env_no_iter_folder(
-    monkeypatch: MonkeyPatch, fmurun_no_iter_folder: Path, fmurun_pred: Path
+def test_fmuprovider_restart_env_no_iter_dir(
+    monkeypatch: MonkeyPatch, runpath_no_iter_dir: Path, runpath_pred_files: Path
 ) -> None:
     """
     Test giving a valid RESTART_FROM_PATH environment variable
     for a fmu run without iteration folders
     """
-    monkeypatch.chdir(fmurun_no_iter_folder)
+    monkeypatch.chdir(runpath_no_iter_dir)
     runcontext = RunContext()
     meta_restart_from = FmuProvider(runcontext).get_metadata()
     assert meta_restart_from.iteration is not None
     assert meta_restart_from.iteration.name == DEFAULT_ENSMEBLE_NAME
 
     # using a relative path as input
-    monkeypatch.setenv(RESTART_PATH_ENVNAME, str(fmurun_no_iter_folder))
+    monkeypatch.setenv(RESTART_PATH_ENVNAME, str(runpath_no_iter_dir))
 
-    monkeypatch.chdir(fmurun_pred)
+    monkeypatch.chdir(runpath_pred_files)
     runcontext = RunContext()
     meta_restart = FmuProvider(runcontext).get_metadata()
     assert meta_restart.iteration is not None
@@ -324,7 +321,7 @@ def test_fmuprovider_restart_env_no_iter_folder(
 
 
 def test_fmuprovider_invalid_restart_env(
-    monkeypatch: MonkeyPatch, fmurun_w_casemetadata: Path, fmurun_pred: Path
+    monkeypatch: MonkeyPatch, runpath_no_dotfmu: Path, runpath_pred_files: Path
 ) -> None:
     """Testing the scenario given invalid RESTART_FROM_PATH environment variable
 
@@ -336,7 +333,7 @@ def test_fmuprovider_invalid_restart_env(
 
     monkeypatch.setenv(RESTART_PATH_ENVNAME, "/path/to/somewhere/invalid")
 
-    monkeypatch.chdir(fmurun_pred)
+    monkeypatch.chdir(runpath_pred_files)
     with pytest.warns(UserWarning, match="non existing"):
         runcontext = RunContext()
         meta = FmuProvider(runcontext).get_metadata()
@@ -345,7 +342,7 @@ def test_fmuprovider_invalid_restart_env(
 
 
 def test_fmuprovider_no_restart_env(
-    monkeypatch: MonkeyPatch, fmurun_w_casemetadata: Path, fmurun_pred: Path
+    monkeypatch: MonkeyPatch, runpath_no_dotfmu: Path, runpath_pred_files: Path
 ) -> None:
     """Testing the scenario without RESTART_FROM_PATH environment variable
 
@@ -358,7 +355,7 @@ def test_fmuprovider_no_restart_env(
     monkeypatch.setenv(RESTART_PATH_ENVNAME, "/path/to/somewhere/invalid")
     monkeypatch.delenv(RESTART_PATH_ENVNAME)
 
-    monkeypatch.chdir(fmurun_pred)
+    monkeypatch.chdir(runpath_pred_files)
     runcontext = RunContext()
     restart_meta = FmuProvider(runcontext).get_metadata()
     assert restart_meta.iteration is not None
@@ -366,7 +363,7 @@ def test_fmuprovider_no_restart_env(
 
 
 def test_fmuprovider_workflow_reference(
-    fmurun_w_casemetadata: Path,
+    runpath_no_dotfmu: Path,
     drogon_global_config: dict[str, Any],
     monkeypatch: MonkeyPatch,
 ) -> None:
@@ -449,10 +446,10 @@ def test_ert_simulation_modes_one_to_one() -> None:
     assert ert_modes == dataio_known_modes
 
 
-def test_fmu_provider_ert_metadata_pre_simulation_case(fmurun_prehook: Path) -> None:
+def test_fmu_provider_ert_metadata_pre_simulation_case(runpath_prehook: Path) -> None:
     """Ert metadata is filled as expected under PRE_SIMULATION case context."""
     runcontext = RunContext(
-        fmu_context=FMUContext.case, casepath_proposed=fmurun_prehook
+        fmu_context=FMUContext.case, casepath_proposed=runpath_prehook
     )
     fmu = FmuProvider(runcontext)
     metadata = fmu.get_metadata()
@@ -462,11 +459,11 @@ def test_fmu_provider_ert_metadata_pre_simulation_case(fmurun_prehook: Path) -> 
 
 
 def test_fmu_provider_ert_metadata_pre_simulation_ensemble(
-    fmurun_prehook: Path,
+    runpath_prehook: Path,
 ) -> None:
     """Ert metadata is filled as expected under PRE_SIMULATION ensemble context."""
     runcontext = RunContext(
-        fmu_context=FMUContext.ensemble, casepath_proposed=fmurun_prehook
+        fmu_context=FMUContext.ensemble, casepath_proposed=runpath_prehook
     )
     fmu = FmuProvider(runcontext)
     metadata = fmu.get_metadata()
@@ -477,7 +474,7 @@ def test_fmu_provider_ert_metadata_pre_simulation_ensemble(
 
 
 def test_fmu_provider_ert_metadata_realization_context(
-    fmurun_w_casemetadata: Path,
+    runpath_no_dotfmu: Path,
 ) -> None:
     """Ert metadata is filled as expected under realization context."""
     runcontext = RunContext()

--- a/tests/test_units/test_manifest.py
+++ b/tests/test_units/test_manifest.py
@@ -49,40 +49,40 @@ def test_export_manifest_from_file_not_exist(tmp_path: Path) -> None:
         ExportManifest.from_file(tmp_path / MANIFEST_FILENAME)
 
 
-def test_get_manifest_path_realization_context(fmurun_w_casemetadata: Path) -> None:
+def test_get_manifest_path_realization_context(runpath_no_dotfmu: Path) -> None:
     """Test that the manifest path is correctly derived in a realization context."""
     # check test assumption that the fixture points to the runpath
-    assert fmurun_w_casemetadata.name == "iter-0"
+    assert runpath_no_dotfmu.name == "iter-0"
 
     manifest_path = get_manifest_path()
     # check that the manifest path is correct
-    assert manifest_path == fmurun_w_casemetadata / MANIFEST_FILENAME
+    assert manifest_path == runpath_no_dotfmu / MANIFEST_FILENAME
 
 
-def test_get_manifest_path_case_context(fmurun_prehook: Path) -> None:
+def test_get_manifest_path_case_context(runpath_prehook: Path) -> None:
     """Test that the manifest path is correctly derived in a case context."""
     # check test assumption that the fixture points to the casepath
-    assert fmurun_prehook.name == "ertrun1"
+    assert runpath_prehook.name == "ertrun1"
 
-    manifest_path = get_manifest_path(casepath=fmurun_prehook)
+    manifest_path = get_manifest_path(casepath=runpath_prehook)
     # check that the manifest path is correct
-    assert manifest_path == fmurun_prehook / MANIFEST_FILENAME
+    assert manifest_path == runpath_prehook / MANIFEST_FILENAME
 
 
-def test_get_manifest_path_case_context_no_casepath(fmurun_prehook: Path) -> None:
+def test_get_manifest_path_case_context_no_casepath(runpath_prehook: Path) -> None:
     """Test that an error is raised when no casepath is provided in case context."""
     with pytest.raises(ValueError):
         get_manifest_path(casepath=None)
 
 
 def test_manifest_realization_context(
-    fmurun_w_casemetadata: Path,
+    runpath_no_dotfmu: Path,
     mock_global_config: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
 ) -> None:
     """Test that the manifest is created at the runpath in a realization context."""
-    runpath = fmurun_w_casemetadata
-    casepath = fmurun_w_casemetadata.parent.parent
+    runpath = runpath_no_dotfmu
+    casepath = runpath_no_dotfmu.parent.parent
 
     ExportData(
         config=mock_global_config,
@@ -103,14 +103,14 @@ def test_manifest_realization_context(
 
 
 def test_manifest_multiple_exports_realization_context(
-    fmurun_w_casemetadata: Path,
+    runpath_no_dotfmu: Path,
     mock_global_config: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
 ) -> None:
     """Test that multiple exports creates and appends to a manifest at the runpath
     in a realization context."""
-    runpath = fmurun_w_casemetadata
-    casepath = fmurun_w_casemetadata.parent.parent
+    runpath = runpath_no_dotfmu
+    casepath = runpath_no_dotfmu.parent.parent
 
     for idx in range(3):
         ExportData(
@@ -131,13 +131,13 @@ def test_manifest_multiple_exports_realization_context(
 
 
 def test_manifest_case_context(
-    fmurun_prehook: Path,
+    runpath_prehook: Path,
     mock_global_config: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
 ) -> None:
     """Test that the manifest is created at the casepath in a case context."""
 
-    casepath = fmurun_prehook
+    casepath = runpath_prehook
 
     ExportData(
         config=mock_global_config,
@@ -157,13 +157,13 @@ def test_manifest_case_context(
 
 
 def test_manifest_multiple_exports_case_context(
-    fmurun_prehook: Path,
+    runpath_prehook: Path,
     mock_global_config: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
 ) -> None:
     """Test that multiple exports creates and appends to a manifest at the casepath
     in a case context."""
-    casepath = fmurun_prehook
+    casepath = runpath_prehook
     for idx in range(3):
         ExportData(
             config=mock_global_config,
@@ -223,14 +223,14 @@ def test_load_export_manifest_file_not_exist(tmp_path: Path) -> None:
 
 
 def test_export_preprocessed_surface_appends_to_case_manifest(
-    fmurun_prehook: Path,
+    runpath_prehook: Path,
     mock_global_config: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
     monkeypatch: MonkeyPatch,
     remove_ert_env: Callable[[], None],
     set_ert_env_prehook: Callable[[], None],
 ) -> None:
-    casepath = fmurun_prehook
+    casepath = runpath_prehook
     monkeypatch.chdir(casepath)
 
     remove_ert_env()

--- a/tests/test_units/test_objectdataprovider_class.py
+++ b/tests/test_units/test_objectdataprovider_class.py
@@ -398,7 +398,7 @@ def test_compute_md5_and_size(
 
 
 def test_preprocessed_observation_workflow(
-    fmurun_prehook: Path,
+    runpath_prehook: Path,
     rmssetup: Path,
     rmsglobalconfig: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
@@ -432,7 +432,7 @@ def test_preprocessed_observation_workflow(
         return edata, edata.export(regsurf)
 
     def _run_case_fmu(
-        fmurun_prehook: Path, surfacepath: Path, monkeypatch: MonkeyPatch
+        runpath_prehook: Path, surfacepath: Path, monkeypatch: MonkeyPatch
     ) -> dict[str, Any]:
         """Run FMU workflow, using the preprocessed data as case data.
 
@@ -444,9 +444,9 @@ def test_preprocessed_observation_workflow(
         But it requires that valid metadata for that file is found. The rule for
         merging is currently defaulted to "preprocessed".
         """
-        monkeypatch.chdir(fmurun_prehook)
+        monkeypatch.chdir(runpath_prehook)
 
-        casepath = fmurun_prehook
+        casepath = runpath_prehook
         edata = dataio.ExportPreprocessedData(is_observation=True, casepath=casepath)
         return edata.generate_metadata(surfacepath)
 
@@ -456,7 +456,7 @@ def test_preprocessed_observation_workflow(
         rmssetup, rmsglobalconfig, regsurf, monkeypatch
     )
     set_ert_env_prehook()
-    case_meta = _run_case_fmu(fmurun_prehook, mysurf, monkeypatch)
+    case_meta = _run_case_fmu(runpath_prehook, mysurf, monkeypatch)
 
     out = Path(mysurf)
     with open(out.parent / f".{out.name}.yml", encoding="utf-8") as f:

--- a/tests/test_units/test_prerealization_surfaces.py
+++ b/tests/test_units/test_prerealization_surfaces.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 
 def test_regsurf_case_observation(
-    fmurun_prehook: Path,
+    runpath_prehook: Path,
     rmsglobalconfig: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
     monkeypatch: MonkeyPatch,
@@ -35,14 +35,14 @@ def test_regsurf_case_observation(
 
     Notice the difference between this use-case and the 'preprocessed' example later!
     """
-    logger.info("Active folder is %s", fmurun_prehook)
+    logger.info("Active folder is %s", runpath_prehook)
 
-    monkeypatch.chdir(fmurun_prehook)
+    monkeypatch.chdir(runpath_prehook)
 
     edata = dataio.ExportData(
         config=rmsglobalconfig,  # read from global config
         fmu_context="case",
-        casepath=fmurun_prehook,
+        casepath=runpath_prehook,
         name="mymap",
         content="depth",
         is_observation=True,
@@ -59,7 +59,7 @@ def test_regsurf_case_observation(
 
 
 def test_regsurf_preprocessed_observation(
-    fmurun_prehook: Path,
+    runpath_prehook: Path,
     rmssetup: Path,
     rmsglobalconfig: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
@@ -105,7 +105,7 @@ def test_regsurf_preprocessed_observation(
         return edata.export(regsurf)
 
     def _run_case_fmu(
-        fmurun_prehook: Path, surfacepath: Path, monkeypatch: MonkeyPatch
+        runpath_prehook: Path, surfacepath: Path, monkeypatch: MonkeyPatch
     ) -> None:
         """Run FMU workflow, using the preprocessed data as case data.
 
@@ -117,10 +117,10 @@ def test_regsurf_preprocessed_observation(
         But it requires that valid metadata for that file is found. The rule for
         merging is currently defaulted to "preprocessed".
         """
-        monkeypatch.chdir(fmurun_prehook)
-        logger.info("Active folder is %s", fmurun_prehook)
+        monkeypatch.chdir(runpath_prehook)
+        logger.info("Active folder is %s", runpath_prehook)
 
-        casepath = fmurun_prehook
+        casepath = runpath_prehook
 
         edata = dataio.ExportPreprocessedData(is_observation=True, casepath=casepath)
         metadata = edata.generate_metadata(surfacepath)
@@ -151,7 +151,7 @@ def test_regsurf_preprocessed_observation(
     remove_ert_env()
     mysurf = _export_data_from_rms(rmssetup, rmsglobalconfig, regsurf, monkeypatch)
     set_ert_env_prehook()
-    _run_case_fmu(fmurun_prehook, mysurf, monkeypatch)
+    _run_case_fmu(runpath_prehook, mysurf, monkeypatch)
 
     logger.info("Preprocessed surface is %s", mysurf)
 
@@ -172,7 +172,7 @@ def test_regsurf_preprocessed_observation(
     ],
 )
 def test_regsurf_preprocessed_filename_retained(
-    fmurun_prehook: Path,
+    runpath_prehook: Path,
     rmssetup: Path,
     rmsglobalconfig: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
@@ -226,19 +226,19 @@ def test_regsurf_preprocessed_filename_retained(
         return edata.export(regsurf)
 
     def _run_case_fmu(
-        fmurun_prehook: Path,
+        runpath_prehook: Path,
         surfacepath: Path,
         exproot: str,
         monkeypatch: MonkeyPatch,
     ) -> None:
         """Run FMU workflow, using the preprocessed data on a subfolder."""
 
-        monkeypatch.chdir(fmurun_prehook)
-        logger.info("Active folder is %s", fmurun_prehook)
+        monkeypatch.chdir(runpath_prehook)
+        logger.info("Active folder is %s", runpath_prehook)
 
         edata = dataio.ExportPreprocessedData(
             is_observation=True,
-            casepath=fmurun_prehook,
+            casepath=runpath_prehook,
         )
         prefix = "share/observations/maps"
         dates = "20240802_20200909"
@@ -251,11 +251,11 @@ def test_regsurf_preprocessed_filename_retained(
         rmssetup, rmsglobalconfig, regsurf, parent, name, tagname, exproot, monkeypatch
     )
     set_ert_env_prehook()
-    _run_case_fmu(fmurun_prehook, mysurf, exproot, monkeypatch)
+    _run_case_fmu(runpath_prehook, mysurf, exproot, monkeypatch)
 
 
 def test_regsurf_preprocessed_observation_subfolder(
-    fmurun_prehook: Path,
+    runpath_prehook: Path,
     rmssetup: Path,
     rmsglobalconfig: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
@@ -303,15 +303,15 @@ def test_regsurf_preprocessed_observation_subfolder(
         return edata.export(regsurf)
 
     def _run_case_fmu(
-        fmurun_prehook: Path, surfacepath: Path, monkeypatch: MonkeyPatch
+        runpath_prehook: Path, surfacepath: Path, monkeypatch: MonkeyPatch
     ) -> None:
         """Run FMU workflow, using the preprocessed data on a subfolder."""
 
-        monkeypatch.chdir(fmurun_prehook)
-        logger.info("Active folder is %s", fmurun_prehook)
+        monkeypatch.chdir(runpath_prehook)
+        logger.info("Active folder is %s", runpath_prehook)
 
         edata = dataio.ExportPreprocessedData(
-            casepath=fmurun_prehook, is_observation=True
+            casepath=runpath_prehook, is_observation=True
         )
         metadata = edata.generate_metadata(surfacepath)
         # check that the relative path is identical to existing except the share folder
@@ -326,7 +326,7 @@ def test_regsurf_preprocessed_observation_subfolder(
     mysurf = _export_data_from_rms(rmssetup, rmsglobalconfig, regsurf, monkeypatch)
 
     set_ert_env_prehook()
-    _run_case_fmu(fmurun_prehook, mysurf, monkeypatch)
+    _run_case_fmu(runpath_prehook, mysurf, monkeypatch)
 
 
 @pytest.mark.usefixtures("inside_rms_interactive")
@@ -380,7 +380,7 @@ def test_preprocessed_with_rel_forcefolder_ok(
 
 
 def test_access_settings_retained(
-    fmurun_prehook: Path,
+    runpath_prehook: Path,
     rmssetup: Path,
     rmsglobalconfig: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
@@ -424,14 +424,14 @@ def test_access_settings_retained(
         return edata.export(regsurf)
 
     def _run_case_fmu(
-        fmurun_prehook: Path, surfacepath: Path, monkeypatch: MonkeyPatch
+        runpath_prehook: Path, surfacepath: Path, monkeypatch: MonkeyPatch
     ) -> None:
         """Run FMU workflow, test that access is retained from preprocessed."""
 
-        monkeypatch.chdir(fmurun_prehook)
-        logger.info("Active folder is %s", fmurun_prehook)
+        monkeypatch.chdir(runpath_prehook)
+        logger.info("Active folder is %s", runpath_prehook)
 
-        edata = dataio.ExportPreprocessedData(casepath=fmurun_prehook)
+        edata = dataio.ExportPreprocessedData(casepath=runpath_prehook)
         metadata = edata.generate_metadata(surfacepath)
 
         # access shall be inherited from preprocessed data
@@ -441,4 +441,4 @@ def test_access_settings_retained(
     remove_ert_env()
     surfacepath = _export_data_from_rms(rmssetup, rmsglobalconfig, regsurf, monkeypatch)
     set_ert_env_prehook()
-    _run_case_fmu(fmurun_prehook, surfacepath, monkeypatch)
+    _run_case_fmu(runpath_prehook, surfacepath, monkeypatch)

--- a/tests/test_units/test_run_context.py
+++ b/tests/test_units/test_run_context.py
@@ -62,7 +62,7 @@ def test_runcontext_rms_interactive(monkeypatch: MonkeyPatch) -> None:
 
 
 def test_runcontext_rms_batch_inside_fmu(
-    monkeypatch: MonkeyPatch, fmurun_w_casemetadata: Path
+    monkeypatch: MonkeyPatch, runpath_no_dotfmu: Path
 ) -> None:
     """Test the RunContext inside FMU realization context with RMS in batch."""
     monkeypatch.setenv("RUNRMS_EXEC_MODE", "batch")
@@ -73,8 +73,8 @@ def test_runcontext_rms_batch_inside_fmu(
     assert runcontext.fmu_context == FMUContext.realization
     assert runcontext.rms_context == RMSExecutionMode.batch
 
-    assert runcontext.runpath == fmurun_w_casemetadata
-    assert runcontext.casepath == fmurun_w_casemetadata.parent.parent
+    assert runcontext.runpath == runpath_no_dotfmu
+    assert runcontext.casepath == runpath_no_dotfmu.parent.parent
     assert runcontext.case_metadata is not None
     assert runcontext.case_metadata.fmu.case.name == "somecasename"
 
@@ -83,7 +83,7 @@ def test_runcontext_rms_batch_inside_fmu(
 
 
 def test_runcontext_outside_rms_inside_fmu(
-    monkeypatch: MonkeyPatch, fmurun_w_casemetadata: Path
+    monkeypatch: MonkeyPatch, runpath_no_dotfmu: Path
 ) -> None:
     """Test the RunContext inside FMU in a realization context outside of RMS."""
     monkeypatch.delenv("RUNRMS_EXEC_MODE", raising=False)
@@ -94,8 +94,8 @@ def test_runcontext_outside_rms_inside_fmu(
     assert runcontext.fmu_context == FMUContext.realization
     assert runcontext.rms_context is None
 
-    assert runcontext.runpath == fmurun_w_casemetadata
-    assert runcontext.casepath == fmurun_w_casemetadata.parent.parent
+    assert runcontext.runpath == runpath_no_dotfmu
+    assert runcontext.casepath == runpath_no_dotfmu.parent.parent
     assert runcontext.case_metadata is not None
     assert runcontext.case_metadata.fmu.case.name == "somecasename"
 
@@ -104,13 +104,13 @@ def test_runcontext_outside_rms_inside_fmu(
 
 
 def test_runcontext_inside_fmu_prehook(
-    monkeypatch: MonkeyPatch, fmurun_prehook: Path
+    monkeypatch: MonkeyPatch, runpath_prehook: Path
 ) -> None:
     """Test the RunContext inside FMU in a case context, outside of RMS."""
     monkeypatch.delenv("RUNRMS_EXEC_MODE", raising=False)
 
     # first test with casepath_proposed
-    runcontext = RunContext(casepath_proposed=fmurun_prehook)
+    runcontext = RunContext(casepath_proposed=runpath_prehook)
 
     assert runcontext.inside_rms is False
     assert runcontext.inside_fmu is True
@@ -118,7 +118,7 @@ def test_runcontext_inside_fmu_prehook(
     assert runcontext.rms_context is None
 
     assert runcontext.runpath is None
-    assert runcontext.casepath == fmurun_prehook
+    assert runcontext.casepath == runpath_prehook
     assert runcontext.case_metadata is not None
     assert runcontext.case_metadata.fmu.case.name == "somecasename"
 
@@ -127,7 +127,7 @@ def test_runcontext_inside_fmu_prehook(
 
 
 def test_runcontext_inside_fmu_prehook_no_casepath(
-    monkeypatch: MonkeyPatch, fmurun_prehook: Path
+    monkeypatch: MonkeyPatch, runpath_prehook: Path
 ) -> None:
     """
     Test the RunContext inside FMU in a case context, outside of RMS.
@@ -153,7 +153,7 @@ def test_runcontext_inside_fmu_prehook_no_casepath(
 
 
 def test_runcontext_inside_fmu_prehook_invalid_casepath(
-    monkeypatch: MonkeyPatch, fmurun_prehook: Path
+    monkeypatch: MonkeyPatch, runpath_prehook: Path
 ) -> None:
     """
     Test the RunContext inside FMU in a case context, outside of RMS.
@@ -206,7 +206,7 @@ def test_runcontext_outside(monkeypatch: MonkeyPatch) -> None:
 )
 def test_runcontext_explicit_fmu_context_override(
     monkeypatch: MonkeyPatch,
-    fmurun_w_casemetadata: Path,
+    runpath_no_dotfmu: Path,
     context_override: FMUContext,
     export_root: str,
 ) -> None:
@@ -219,7 +219,7 @@ def test_runcontext_explicit_fmu_context_override(
 
 
 def test_runcontext_ensemble_name_standard(
-    monkeypatch: MonkeyPatch, fmurun_w_casemetadata: Path
+    monkeypatch: MonkeyPatch, runpath_no_dotfmu: Path
 ) -> None:
     """Ensemble name extraction for standard iter-N paths."""
     runcontext = RunContext()
@@ -232,7 +232,7 @@ def test_runcontext_ensemble_name_standard(
 
 
 def test_runcontext_ensemble_name_prediction(
-    monkeypatch: MonkeyPatch, fmurun_w_casemetadata_pred: Path
+    monkeypatch: MonkeyPatch, runpath_no_dotfmu_pred: Path
 ) -> None:
     """Ensemble name extraction for prediction runs."""
     runcontext = RunContext()
@@ -245,7 +245,7 @@ def test_runcontext_ensemble_name_prediction(
 
 
 def test_runcontext_ensemble_name_flat_structure(
-    monkeypatch: MonkeyPatch, fmurun_no_iter_folder: Path
+    monkeypatch: MonkeyPatch, runpath_no_iter_dir: Path
 ) -> None:
     """Ensemble name defaults to iter-0 when no ensemble folder exists."""
     runcontext = RunContext()
@@ -271,22 +271,22 @@ def test_extract_ensemble_and_realization_name_no_parts() -> None:
 
 
 def test_runcontext_explicit_ensemble_name(
-    monkeypatch: MonkeyPatch, fmurun_prehook: Path
+    monkeypatch: MonkeyPatch, runpath_prehook: Path
 ) -> None:
     """Explicit ensemble_name sets paths when runpath is unavailable."""
     runcontext = RunContext(
-        casepath_proposed=fmurun_prehook,
+        casepath_proposed=runpath_prehook,
         ensemble_name="pred-dg3",
     )
 
     assert runcontext.paths.ensemble_name == "pred-dg3"
     assert (
-        runcontext.ensemble_path == fmurun_prehook / "share" / "ensemble" / "pred-dg3"
+        runcontext.ensemble_path == runpath_prehook / "share" / "ensemble" / "pred-dg3"
     )
 
 
 def test_runcontext_explicit_ensemble_name_overrides_derived(
-    monkeypatch: MonkeyPatch, fmurun_w_casemetadata: Path
+    monkeypatch: MonkeyPatch, runpath_no_dotfmu: Path
 ) -> None:
     """Explicit ensemble_name overrides the name derived from runpath."""
     runcontext = RunContext(ensemble_name="custom-ensemble")

--- a/tests/test_units/test_workflows/test_case_workflow.py
+++ b/tests/test_units/test_workflows/test_case_workflow.py
@@ -41,12 +41,12 @@ def mock_run_paths() -> Callable[[str], MagicMock]:
 
 @pytest.fixture
 def workflow_config(
-    fmurun_prehook: Path,
+    runpath_prehook: Path,
     mock_global_config_validated: GlobalConfiguration,
 ) -> CaseWorkflowConfig:
     """Create a mock CaseWorkflowConfig."""
     return CaseWorkflowConfig(
-        casepath=fmurun_prehook,
+        casepath=runpath_prehook,
         ert_config_path=Path("../../ert/model/"),
         register_on_sumo=True,
         verbosity="WARNING",

--- a/tests/test_units/test_workflows/test_export_case_metadata.py
+++ b/tests/test_units/test_workflows/test_export_case_metadata.py
@@ -30,11 +30,11 @@ def test_crease_case_metadata_barebone(drogon_global_config: dict[str, Any]) -> 
 
 
 def test_export_case_metadata_post_init(
-    monkeypatch: MonkeyPatch, fmurun: Path, drogon_global_config: dict[str, Any]
+    monkeypatch: MonkeyPatch,
+    runpath_no_case_metadata: Path,
+    drogon_global_config: dict[str, Any],
 ) -> None:
-    monkeypatch.chdir(fmurun)
-    caseroot = fmurun.parent.parent
-    logger.info("Active folder is %s", fmurun)
+    caseroot = runpath_no_case_metadata.parent.parent
 
     icase = ExportCaseMetadata(
         config=drogon_global_config,
@@ -49,12 +49,11 @@ def test_export_case_metadata_post_init(
 
 @pytest.mark.filterwarnings("ignore:The global configuration")
 def test_export_case_metadata_post_init_bad_globalconfig(
-    monkeypatch: MonkeyPatch, fmurun: Path, drogon_global_config: dict[str, Any]
+    monkeypatch: MonkeyPatch,
+    runpath_no_case_metadata: Path,
+    drogon_global_config: dict[str, Any],
 ) -> None:
-    monkeypatch.chdir(fmurun)
-    logger.info("Active folder is %s", fmurun)
-    caseroot = fmurun.parent.parent
-    logger.info("Case folder is now %s", caseroot)
+    caseroot = runpath_no_case_metadata.parent.parent
 
     config = deepcopy(drogon_global_config)
     del config["masterdata"]
@@ -68,13 +67,12 @@ def test_export_case_metadata_post_init_bad_globalconfig(
 
 
 def test_export_case_metadata_establish_metadata_files(
-    monkeypatch: MonkeyPatch, fmurun: Path, drogon_global_config: dict[str, Any]
+    monkeypatch: MonkeyPatch,
+    runpath_no_case_metadata: Path,
+    drogon_global_config: dict[str, Any],
 ) -> None:
     """Tests that the required directories are made when establishing the case"""
-    monkeypatch.chdir(fmurun)
-    logger.info("Active folder is %s", fmurun)
-    caseroot = fmurun.parent.parent
-    logger.info("Case folder is now %s", caseroot)
+    caseroot = runpath_no_case_metadata.parent.parent
 
     icase = ExportCaseMetadata(
         config=drogon_global_config, rootfolder=caseroot, casename="mycase"
@@ -87,14 +85,13 @@ def test_export_case_metadata_establish_metadata_files(
 
 
 def test_export_case_metadata_establish_metadata_files_exists(
-    monkeypatch: MonkeyPatch, fmurun: Path, drogon_global_config: dict[str, Any]
+    monkeypatch: MonkeyPatch,
+    runpath_no_case_metadata: Path,
+    drogon_global_config: dict[str, Any],
 ) -> None:
     """Tests that _establish_metadata_files returns correctly if the share/metadata
     directory already exists."""
-    monkeypatch.chdir(fmurun)
-    logger.info("Active folder is %s", fmurun)
-    caseroot = fmurun.parent.parent
-    logger.info("Case folder is now %s", caseroot)
+    caseroot = runpath_no_case_metadata.parent.parent
 
     icase = ExportCaseMetadata(
         config=drogon_global_config, rootfolder=caseroot, casename="mycase"
@@ -109,15 +106,14 @@ def test_export_case_metadata_establish_metadata_files_exists(
 
 
 def test_export_case_metadata_generate_metadata(
-    monkeypatch: MonkeyPatch, fmurun: Path, drogon_global_config: dict[str, Any]
+    monkeypatch: MonkeyPatch,
+    runpath_no_case_metadata: Path,
+    drogon_global_config: dict[str, Any],
 ) -> None:
-    monkeypatch.chdir(fmurun)
-    logger.info("Active folder is %s", fmurun)
-    myroot = fmurun.parent.parent.parent / "mycase"
-    logger.info("Case folder is now %s", myroot)
+    caseroot = runpath_no_case_metadata.parent.parent
 
     icase = ExportCaseMetadata(
-        config=drogon_global_config, rootfolder=myroot, casename="mycase"
+        config=drogon_global_config, rootfolder=caseroot, casename="mycase"
     )
     metadata = icase.generate_metadata()
     assert metadata
@@ -127,11 +123,11 @@ def test_export_case_metadata_generate_metadata(
 
 def test_export_case_metadata_generate_metadata_warn_if_exists(
     monkeypatch: MonkeyPatch,
-    fmurun_w_casemetadata: Path,
+    runpath_no_dotfmu: Path,
     drogon_global_config: dict[str, Any],
 ) -> None:
-    logger.info("Active folder is %s", fmurun_w_casemetadata)
-    casemetafolder = fmurun_w_casemetadata.parent.parent
+    logger.info("Active folder is %s", runpath_no_dotfmu)
+    casemetafolder = runpath_no_dotfmu.parent.parent
 
     icase = ExportCaseMetadata(
         config=drogon_global_config,
@@ -143,10 +139,11 @@ def test_export_case_metadata_generate_metadata_warn_if_exists(
 
 
 def test_export_case_metadata_with_export(
-    monkeypatch: MonkeyPatch, drogon_global_config: dict[str, Any], fmurun: Path
+    monkeypatch: MonkeyPatch,
+    drogon_global_config: dict[str, Any],
+    runpath_no_case_metadata: Path,
 ) -> None:
-    monkeypatch.chdir(fmurun)
-    caseroot = fmurun.parent.parent
+    caseroot = runpath_no_case_metadata.parent.parent
 
     icase = ExportCaseMetadata(
         config=drogon_global_config,
@@ -165,10 +162,11 @@ def test_export_case_metadata_with_export(
 
 
 def test_export_case_metadata_export_with_norsk_alphabet(
-    monkeypatch: MonkeyPatch, drogon_global_config: dict[str, Any], fmurun: Path
+    monkeypatch: MonkeyPatch,
+    drogon_global_config: dict[str, Any],
+    runpath_no_case_metadata: Path,
 ) -> None:
-    monkeypatch.chdir(fmurun)
-    caseroot = fmurun.parent.parent
+    caseroot = runpath_no_case_metadata.parent.parent
 
     drogon_global_config["masterdata"]["smda"]["field"][0]["identifier"] = "æøå"
     case = ExportCaseMetadata(

--- a/tests/test_units/test_workflows/test_preprocessed.py
+++ b/tests/test_units/test_workflows/test_preprocessed.py
@@ -44,7 +44,7 @@ def export_preprocessed_surface(
 
 
 def test_export_preprocessed_surfacefile(
-    fmurun_prehook: Path,
+    runpath_prehook: Path,
     rmsglobalconfig: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
     remove_ert_env: Callable[[], None],
@@ -66,7 +66,7 @@ def test_export_preprocessed_surfacefile(
 
     # run the re-export of the preprocessed data inside an mocked FMU run
     set_ert_env_prehook()
-    edata = dataio.ExportPreprocessedData(is_observation=True, casepath=fmurun_prehook)
+    edata = dataio.ExportPreprocessedData(is_observation=True, casepath=runpath_prehook)
     # generate the updated metadata
     metadata = edata.generate_metadata(surfacepath)
 
@@ -81,7 +81,7 @@ def test_export_preprocessed_surfacefile(
     # check that the file paths are updated. The relative_path should be
     # equal to the initial export except for the share folder
     relative_path = PREPROCESSED_SURFACEPATH.replace("preprocessed", "observations")
-    absolute_path = fmurun_prehook / relative_path
+    absolute_path = runpath_prehook / relative_path
     assert metadata["file"]["relative_path"] == relative_path
     assert metadata["file"]["absolute_path"] == str(absolute_path)
 
@@ -102,7 +102,7 @@ def test_export_preprocessed_surfacefile(
 
 
 def test_export_to_results_folder(
-    fmurun_prehook: Path,
+    runpath_prehook: Path,
     rmsglobalconfig: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
     remove_ert_env: Callable[[], None],
@@ -118,20 +118,22 @@ def test_export_to_results_folder(
 
     # run the re-export of the preprocessed data inside an mocked FMU run
     set_ert_env_prehook()
-    edata = dataio.ExportPreprocessedData(is_observation=False, casepath=fmurun_prehook)
+    edata = dataio.ExportPreprocessedData(
+        is_observation=False, casepath=runpath_prehook
+    )
 
     # check that the export has been to the case/share/results folder
     relative_path = PREPROCESSED_SURFACEPATH.replace("preprocessed", "results")
 
     filepath = Path(edata.export(surfacepath))
-    assert filepath == fmurun_prehook / relative_path
+    assert filepath == runpath_prehook / relative_path
 
     metafile = filepath.parent / f".{filepath.name}.yml"
     assert metafile.exists()
 
 
 def test_outdated_metadata(
-    fmurun_prehook: Path,
+    runpath_prehook: Path,
     rmsglobalconfig: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
     remove_ert_env: Callable[[], None],
@@ -154,7 +156,7 @@ def test_outdated_metadata(
     # run the re-export of the preprocessed data inside an mocked FMU run
     set_ert_env_prehook()
 
-    edata = dataio.ExportPreprocessedData(is_observation=True, casepath=fmurun_prehook)
+    edata = dataio.ExportPreprocessedData(is_observation=True, casepath=runpath_prehook)
     # error should be raised when trying to use the generate_metadata function
     with pytest.raises(InvalidMetadataError, match="outdated"):
         edata.generate_metadata(surfacepath)
@@ -165,7 +167,7 @@ def test_outdated_metadata(
 
 
 def test_export_without_existing_meta(
-    fmurun_prehook: Path,
+    runpath_prehook: Path,
     rmsglobalconfig: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
     remove_ert_env: Callable[[], None],
@@ -184,7 +186,7 @@ def test_export_without_existing_meta(
 
     # delete the metafile
     metafile.unlink()
-    edata = dataio.ExportPreprocessedData(is_observation=True, casepath=fmurun_prehook)
+    edata = dataio.ExportPreprocessedData(is_observation=True, casepath=runpath_prehook)
     # test that error is raised when creating metadata
     with pytest.raises(RuntimeError, match="Could not detect existing metadata"):
         edata.generate_metadata(surfacepath)
@@ -195,11 +197,11 @@ def test_export_without_existing_meta(
 
     # check that the file have been copied into the fmu case path
     assert Path(filepath).exists()
-    assert filepath.startswith(str(fmurun_prehook))
+    assert filepath.startswith(str(runpath_prehook))
 
 
 def test_preprocessed_surface_modified_post_export(
-    fmurun_prehook: Path,
+    runpath_prehook: Path,
     rmsglobalconfig: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
     remove_ert_env: Callable[[], None],
@@ -224,7 +226,7 @@ def test_preprocessed_surface_modified_post_export(
     # should issue warning
     with pytest.warns(UserWarning, match="seem to have been modified"):
         dataio.ExportPreprocessedData(
-            is_observation=True, casepath=fmurun_prehook
+            is_observation=True, casepath=runpath_prehook
         ).export(surfacepath)
 
 
@@ -249,7 +251,7 @@ def test_preprocessed_surface_fmucontext_not_case(
         dataio.ExportPreprocessedData(casepath="dummy")
 
 
-def test_preprocessed_surface_invalid_casepath(fmurun_prehook: Path) -> None:
+def test_preprocessed_surface_invalid_casepath(runpath_prehook: Path) -> None:
     """Test that an error is raised if casepath is wrong or no case meta exist"""
 
     # error should be raised when running on a casepath without case metadata
@@ -261,20 +263,20 @@ def test_preprocessed_surface_invalid_casepath(fmurun_prehook: Path) -> None:
         dataio.ExportPreprocessedData(casepath="dummy")
 
     # shall work when casepath that contains case matadata is provided
-    dataio.ExportPreprocessedData(casepath=fmurun_prehook)
+    dataio.ExportPreprocessedData(casepath=runpath_prehook)
 
     # delete the case matadata and see that it fails
-    metacase_file = fmurun_prehook / ERT_RELATIVE_CASE_METADATA_FILE
+    metacase_file = runpath_prehook / ERT_RELATIVE_CASE_METADATA_FILE
     metacase_file.unlink()
     with (
         pytest.warns(UserWarning),
         pytest.raises(ValueError, match="Could not detect valid case metadata"),
     ):
-        dataio.ExportPreprocessedData(casepath=fmurun_prehook)
+        dataio.ExportPreprocessedData(casepath=runpath_prehook)
 
 
 def test_export_non_preprocessed_data(
-    fmurun_prehook: Path,
+    runpath_prehook: Path,
     rmsglobalconfig: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
     remove_ert_env: Callable[[], None],
@@ -298,12 +300,12 @@ def test_export_non_preprocessed_data(
     # check that the error is given
     with pytest.raises(RuntimeError, match="is not supported"):
         dataio.ExportPreprocessedData(
-            is_observation=True, casepath=fmurun_prehook
+            is_observation=True, casepath=runpath_prehook
         ).generate_metadata(surfacepath)
 
 
 def test_export_preprocessed_file_exportdata_futurewarning(
-    fmurun_prehook: Path,
+    runpath_prehook: Path,
     rmsglobalconfig: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
     remove_ert_env: Callable[[], None],
@@ -323,7 +325,7 @@ def test_export_preprocessed_file_exportdata_futurewarning(
 
     # Use the ExportData class instead of the ExportPreprocessedData
     edata = dataio.ExportData(
-        config=rmsglobalconfig, is_observation=True, casepath=fmurun_prehook
+        config=rmsglobalconfig, is_observation=True, casepath=runpath_prehook
     )
 
     with pytest.warns(FutureWarning, match="no longer supported"):
@@ -341,7 +343,7 @@ def test_export_preprocessed_file_exportdata_futurewarning(
 
 
 def test_export_preprocessed_file_exportdata_casepath_on_export(
-    fmurun_prehook: Path,
+    runpath_prehook: Path,
     rmsglobalconfig: dict[str, Any],
     regsurf: xtgeo.RegularSurface,
     remove_ert_env: Callable[[], None],
@@ -368,7 +370,7 @@ def test_export_preprocessed_file_exportdata_casepath_on_export(
 
     # test that export() works if casepath is provided
     with pytest.warns(FutureWarning, match="no longer supported"):
-        filepath = Path(edata.export(surfacepath, casepath=fmurun_prehook))
+        filepath = Path(edata.export(surfacepath, casepath=runpath_prehook))
     assert filepath.exists()
     metafile = filepath.parent / f".{filepath.name}.yml"
     assert metafile.exists()
@@ -383,7 +385,7 @@ def test_export_preprocessed_file_exportdata_casepath_on_export(
 
     # test that generate_metadata() works if casepath is provided
     with pytest.warns(FutureWarning):
-        meta = edata.generate_metadata(surfacepath, casepath=fmurun_prehook)
+        meta = edata.generate_metadata(surfacepath, casepath=runpath_prehook)
 
     assert "fmu" in meta
     assert "merged" in meta["tracklog"][-1]["event"]


### PR DESCRIPTION
Toward #1624

Renames "fmurun" fixtures to "runpath", as the fixtures both prepare and return a runpath (though where exactly is not consistent).

More importantly though, it renames `fmurun_w_casemetadata` to `runpath_no_dotfmu`.

We have a challenge in that we need to test two cases: one where we continue to support global variables masterdata/stratigraphy, and another where we find this data from `.fmu/`. We will eventually expect the default case to be:

- Case metadata has been exported
- `.fmu/` exists with the masterdata/mappings

This change allows us to begin writing and naming tests toward the goal of `.fmu/` being default.

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
