### PR TITLE
DOC: Remove deprecated argument in create_case_metadata

### DIFF
--- a/src/fmu/dataio/_workflows/case/main.py
+++ b/src/fmu/dataio/_workflows/case/main.py
@@ -34,7 +34,7 @@ and on Sumo.
 EXAMPLES = """
 Create an Ert workflow e.g. called ``ert/bin/workflows/create_case_metadata`` with::
 
-  WF_CREATE_CASE_METADATA <casepath> <ert_config_path> "--sumo"
+  WF_CREATE_CASE_METADATA <casepath> "--sumo"
 
 Arguments:
     <casepath>: Absolute path to root of the case, typically <SCRATCH>/<USER>/<CASE_DIR>
@@ -141,7 +141,7 @@ def get_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "ert_config_path",
         type=Path,
-        help="Ert config path (<CONFIG_PATH>)",
+        help="Deprecated and can safely be removed",
         nargs="?",  # Optional
         default=None,
     )


### PR DESCRIPTION
PR to drop newly deprecated `ert_config_path` argument from the `create_case_metadata` documentation

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
