### PR TITLE
ENH: support FaultRoom object creation from grouped faults (#1588)

### DIFF
--- a/src/fmu/dataio/_readers/faultroom.py
+++ b/src/fmu/dataio/_readers/faultroom.py
@@ -61,7 +61,13 @@ class FaultRoomSurface:
         self.horizons = self.storage["metadata"].get("horizons")
 
     def _set_faults(self) -> None:
-        self.faults = self.storage["metadata"]["faults"].get("default")
+        """
+        Set faults from groups of faults.
+        """
+        faults = self.storage["metadata"].get("faults", {})
+        self.faults = []
+        for faults_in_group in faults.values():
+            self.faults.extend(faults_in_group)
 
     def _set_juxtaposition(self) -> None:
         self.juxtaposition_fw = self.storage["metadata"]["juxtaposition"].get("fw")

--- a/tests/test_units/test_objectdataprovider_class.py
+++ b/tests/test_units/test_objectdataprovider_class.py
@@ -405,6 +405,27 @@ def test_faultroom_bbox(
     assert bbox.zmax == 2.3
 
 
+def test_faultroom_fault_groups(
+    faultroom_object: FaultRoomSurface, drogon_exportdata: ExportData
+) -> None:
+    """FaultRoomSurface fault groups are derived correctly."""
+
+    # Modify the faultroom object to have faults in group format
+    faultroom_object.storage["metadata"]["faults"] = {
+        "best_faults": ["F1", "F2", "F3"],
+        "even_better_faults": ["F4", "F5"],
+        "absolutely_best_faults": ["F6"],
+    }
+    faultroom_object._set_faults()
+
+    objdata = objectdata_provider_factory(
+        faultroom_object, drogon_exportdata._export_config
+    )
+    spec = objdata.get_spec()
+
+    assert spec.faults == ["F1", "F2", "F3", "F4", "F5", "F6"]
+
+
 def test_faultroom_spec_juxtaposition(
     faultroom_object: FaultRoomSurface, drogon_exportdata: ExportData
 ) -> None:


### PR DESCRIPTION
Resolves #1588 

Allow creation of FaultRoom object from either a plain list of faults or a grouped list of faults

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
