### PR TITLE
TST: Change RFT obs radius assertion to 3000

### DIFF
--- a/tests/test_units/test_workflows/test_case_observations.py
+++ b/tests/test_units/test_workflows/test_case_observations.py
@@ -221,7 +221,7 @@ def test_ert_observations_rft_dataframe_as_expected(ert_config_path: Path) -> No
     assert df["std"].to_list() == pytest.approx([30.5])
     assert df["east"].to_list() == pytest.approx([9500])
     assert df["north"].to_list() == pytest.approx([10500.5])
-    assert df["radius"].to_list() == pytest.approx([2000])
+    assert df["radius"].to_list() == pytest.approx([3000])
 
 
 def test_ert_observations_rft_dataframe_validates_against_schema(


### PR DESCRIPTION
Resolves #1725 

This commit in ert https://github.com/equinor/ert/commit/1769dfef28735500d83b4840015f67235324ee72 change the default radius from 2 km to 3 km, we should reflect that in our test.

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
