### PR TITLE
FIX: add file.size_bytes field to file metadata for preprocessed exports

### DIFF
--- a/src/fmu/dataio/preprocessed.py
+++ b/src/fmu/dataio/preprocessed.py
@@ -154,13 +154,14 @@ class ExportPreprocessedData:
                 "Please re-export your objects to disk."
             )
 
-    def _build_file_metadata(self, objfile: Path, checksum_md5: str) -> File:
-        """Return a File model with updated paths and checksum_md5"""
+    def _build_file_metadata(self, objfile: Path, checksum_md5: str, size: int) -> File:
+        """Return a File model with updated paths, checksum_md5, and size."""
         relative_path = self._get_relative_export_path(existing_path=objfile)
         return File(
             absolute_path=self.casepath / relative_path,
             relative_path=relative_path,
             checksum_md5=checksum_md5,
+            size_bytes=size,
         )
 
     def _get_updated_metadata(
@@ -180,6 +181,7 @@ class ExportPreprocessedData:
         """
 
         checksum_md5_file = md5sum(objfile)
+        size_file = objfile.stat().st_size
         if checksum_md5_meta := existing_metadata["file"].get("checksum_md5"):
             self._check_md5sum_consistency(checksum_md5_file, checksum_md5_meta)
 
@@ -189,7 +191,7 @@ class ExportPreprocessedData:
             runcontext=self._runcontext
         ).get_metadata()
         existing_metadata["file"] = self._build_file_metadata(
-            objfile, checksum_md5_file
+            objfile, checksum_md5_file, size_file
         )
 
         try:

--- a/tests/test_units/test_workflows/test_preprocessed.py
+++ b/tests/test_units/test_workflows/test_preprocessed.py
@@ -181,7 +181,7 @@ def test_export_without_existing_meta(
     remove_ert_env()
     surfacepath, metafile = export_preprocessed_surface(rmsglobalconfig, regsurf)
 
-    # run the re-export of the preprocessed data inside an mocked FMU run
+    # mock being inside of FMU
     set_ert_env_prehook()
 
     # delete the metafile
@@ -228,6 +228,36 @@ def test_preprocessed_surface_modified_post_export(
         dataio.ExportPreprocessedData(
             is_observation=True, casepath=runpath_prehook
         ).export(surfacepath)
+
+
+def test_preprocessed_surface_size_bytes_matches_file_post_export(
+    runpath_prehook: Path,
+    rmsglobalconfig: dict[str, Any],
+    regsurf: xtgeo.RegularSurface,
+    remove_ert_env: Callable[[], None],
+    set_ert_env_prehook: Callable[[], None],
+) -> None:
+    """
+    Test that the size_bytes in the exported metadata matches the actual
+    file size of the exported object file.
+    """
+    # mock being outside of FMU and export preprocessed surface
+    remove_ert_env()
+    surfacepath, _ = export_preprocessed_surface(rmsglobalconfig, regsurf)
+
+    # run the re-export of the preprocessed data inside a mocked FMU run
+    set_ert_env_prehook()
+    edata = dataio.ExportPreprocessedData(is_observation=True, casepath=runpath_prehook)
+
+    # generate the updated metadata and check size_bytes matches source file
+    metadata = edata.generate_metadata(surfacepath)
+    assert metadata["file"]["size_bytes"] == surfacepath.stat().st_size
+
+    # do the actual export and verify size_bytes matches the copied file
+    filepath = Path(edata.export(surfacepath))
+    metafile = filepath.parent / f".{filepath.name}.yml"
+    exported_meta = read_metadata(metafile)
+    assert exported_meta["file"]["size_bytes"] == filepath.stat().st_size
 
 
 def test_preprocessed_surface_fmucontext_not_case(


### PR DESCRIPTION
Resolves #1741 

Add `file.size_bytes` field to file metadata for preprocessed exports.

The _build_file_metadata method now accepts a size parameter and includes size_bytes in the File model. Previously, the file size was not being propagated into the metadata, meaning the size_bytes field would be missing from the file block in exported preprocessed metadata.

## Checklist

- [x] Tests added (if not, comment why)
      - Tested with uploading a case to sumo, and it worked as expected.
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
