### PR TITLE
DOC: Update WF_CREATE_CASE_METADATA example in docs

### DIFF
--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -266,21 +266,18 @@ Example script from the Drogon workflow:
 
 ```sql
 -- Create case metadata
---                       ert_caseroot                 ert_configpath    ert_casename   ert_username   sumo-flag
-WF_CREATE_CASE_METADATA  <SCRATCH>/<USER>/<CASE_DIR>  <CONFIG_PATH>     <CASE_DIR>     <USER>.        "--sumo"
+--                       ert-casepath    sumo-flag
+WF_CREATE_CASE_METADATA   casepath        "--sumo"
 
 -- This workflow is intended to be ran as a HOOK workflow.
 
 -- Arguments:
--- ert_caseroot (Path): The absolute path to the root of the case on /scratch
--- ert_configpath (Path): The absolute path to the ERT config
--- ert_casename (str): The name of the case
--- ert_user (str): The username used in ERT
+-- casepath (Path): Absolute path to root of the case, typically <SCRATCH>/<USER>/<CASE_DIR>
 
 -- Optional arguments:
---  --sumo: If passed, case will be registered on Sumo. Remove this flag if you do not intend to upload data to Sumo.
---  --global_variables_path (str): Path to global variables relative to CONFIG path
---
+-- --sumo (str):      If passed, case will be registered on Sumo.
+-- --verbosity (str): Set log level
+
 -- NOTE! If using optional arguments, note that the "--" annotation will be interpreted
 --       as comments by ERT if not wrapped in quotes. This is the syntax to use:
 --       (existing arguments) "--sumo"


### PR DESCRIPTION
Updated WF_CREATE_CASE_METADATA usage example in getting_started.md and aligned it with the ERT 22.0 documentation example.

Resolves #1748 

ref: [ERT 22.0 Documentation ](https://fmu-docs.equinor.com/docs/ert/reference/workflows/added_workflow_jobs.html#WF_CREATE_CASE_METADATA-job-config)

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
