### PR TITLE
DOC: Document ert observations

### DIFF
--- a/src/fmu/dataio/_workflows/case/main.py
+++ b/src/fmu/dataio/_workflows/case/main.py
@@ -40,7 +40,10 @@ logger.setLevel(logging.CRITICAL)
 # This documentation is compiled into ert's internal docs
 DESCRIPTION = """
 WF_CREATE_CASE_METADATA will create case metadata with fmu-dataio for storing on disk
-and on Sumo.
+and on Sumo. When Sumo upload is enabled, the workflow also uploads Ert parameters
+and observations, including summary, RFT, and breakthrough observations. The workflow
+uses Ert storage directly, so the relevant case metadata, parameters, and observations
+are collected automatically from the active Ert run.
 """
 
 EXAMPLES = """


### PR DESCRIPTION
Resolves #1709 

Updates the `WF_CREATE_CASE_METADATA` Ert workflow documentation to clarify that, when Sumo upload is enabled, it also uploads Ert parameters and observations, including summary, RFT, and breakthrough observations. The description now also explains that the workflow integrates directly with Ert storage and automatically collects relevant data from the active Ert run.

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
