### PR TITLE
BUG: Fix RMS unit system normalization

### DIFF
--- a/src/fmu/dataio/export/rms/_utils.py
+++ b/src/fmu/dataio/export/rms/_utils.py
@@ -87,7 +87,7 @@ def get_rms_project_units(project: Any) -> str | None:
 
     warnings.warn(
         f"RMS project unit system {units!r} is not a known RMS unit system. "
-        "Exported metadata unit will be set to unknown.",
+        "Exported metadata unit will be set to an empty string.",
         UserWarning,
         stacklevel=2,
     )

--- a/src/fmu/dataio/export/rms/_utils.py
+++ b/src/fmu/dataio/export/rms/_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING, Any, Final
 
 import xtgeo
@@ -72,16 +73,11 @@ def check_rmsapi_version(minimum_version: str) -> None:
     logger.debug("Check API version... DONE")
 
 
-def _get_rms_project_unit_name(project_units: Any) -> str:
-    unit_name = getattr(project_units, "name", None) or str(project_units)
-    return unit_name.rsplit(".", maxsplit=1)[-1].lower()
-
-
 def get_rms_project_units(project: Any) -> str | None:
     """Return whether the RMS project uses metric or field-family units."""
 
     units = project.project_units
-    unit_name = _get_rms_project_unit_name(units)
+    unit_name = str(units)
     logger.debug("Units are %s", units)
 
     if unit_name in _RMS_METRIC_UNIT_SYSTEMS:
@@ -89,10 +85,11 @@ def get_rms_project_units(project: Any) -> str | None:
     if unit_name in _RMS_FIELD_UNIT_SYSTEMS:
         return "field"
 
-    logger.warning(
-        "RMS project unit system %r is not a known RMS unit system. "
+    warnings.warn(
+        f"RMS project unit system {units!r} is not a known RMS unit system. "
         "Exported metadata unit will be set to unknown.",
-        units,
+        UserWarning,
+        stacklevel=2,
     )
     return None
 
@@ -116,6 +113,16 @@ def get_rms_project_volume_unit(project: Any) -> str:
         return "m3"
     if units == "field":
         return "ft3"
+    return ""
+
+
+def get_rms_project_time_unit(project: Any) -> str:
+    """Return the metadata time unit for the RMS project."""
+
+    if str(project.project_units) == "si":
+        return "s"
+    if get_rms_project_units(project) in {"metric", "field"}:
+        return "ms"
     return ""
 
 

--- a/src/fmu/dataio/export/rms/_utils.py
+++ b/src/fmu/dataio/export/rms/_utils.py
@@ -25,6 +25,24 @@ if TYPE_CHECKING:
 
 logger: Final = null_logger(__name__)
 
+_RMS_METRIC_UNIT_SYSTEMS: Final = frozenset(
+    {
+        "metric",
+        "metric_cmg",
+        "metric_tempest",
+        "si",
+    }
+)
+_RMS_FIELD_UNIT_SYSTEMS: Final = frozenset(
+    {
+        "field",
+        "field_cmg",
+        "field_nexus",
+        "field_us",
+        "mmft",
+    }
+)
+
 
 RMS_API_PROJECT_MAPPING = {
     "1.10": "14.2",
@@ -54,12 +72,51 @@ def check_rmsapi_version(minimum_version: str) -> None:
     logger.debug("Check API version... DONE")
 
 
-def get_rms_project_units(project: Any) -> str:
-    """See if the RMS project is defined in metric or feet."""
+def _get_rms_project_unit_name(project_units: Any) -> str:
+    unit_name = getattr(project_units, "name", None) or str(project_units)
+    return unit_name.rsplit(".", maxsplit=1)[-1].lower()
+
+
+def get_rms_project_units(project: Any) -> str | None:
+    """Return whether the RMS project uses metric or field-family units."""
 
     units = project.project_units
+    unit_name = _get_rms_project_unit_name(units)
     logger.debug("Units are %s", units)
-    return str(units)
+
+    if unit_name in _RMS_METRIC_UNIT_SYSTEMS:
+        return "metric"
+    if unit_name in _RMS_FIELD_UNIT_SYSTEMS:
+        return "field"
+
+    logger.warning(
+        "RMS project unit system %r is not a known RMS unit system. "
+        "Exported metadata unit will be set to unknown.",
+        units,
+    )
+    return None
+
+
+def get_rms_project_length_unit(project: Any) -> str:
+    """Return the metadata length unit for the RMS project."""
+
+    units = get_rms_project_units(project)
+    if units == "metric":
+        return "m"
+    if units == "field":
+        return "ft"
+    return ""
+
+
+def get_rms_project_volume_unit(project: Any) -> str:
+    """Return the metadata volume unit for the RMS project."""
+
+    units = get_rms_project_units(project)
+    if units == "metric":
+        return "m3"
+    if units == "field":
+        return "ft3"
+    return ""
 
 
 def get_open_polygons_id(pol: xtgeo.Polygons) -> list[int]:

--- a/src/fmu/dataio/export/rms/fluid_contact_outlines.py
+++ b/src/fmu/dataio/export/rms/fluid_contact_outlines.py
@@ -10,7 +10,7 @@ from fmu.dataio.export._base import SimpleExportBase
 from fmu.dataio.export._export_result import ExportResult, ExportResultItem
 from fmu.dataio.export.rms._utils import (
     get_polygons_in_general2d_folder,
-    get_rms_project_units,
+    get_rms_project_length_unit,
     list_folder_names_in_general2d_folder,
     validate_name_in_stratigraphy,
 )
@@ -39,7 +39,7 @@ class _ExportFluidContactOutlines(SimpleExportBase):
         _logger.debug("Process data, establish state prior to export.")
         self.project = project
         self._contact_outlines = self._get_contact_outlines()
-        self._unit = "m" if get_rms_project_units(project) == "metric" else "ft"
+        self._unit = get_rms_project_length_unit(project)
         _logger.debug("Process data... DONE")
 
     def _get_contacts(self) -> list[FluidContactType]:

--- a/src/fmu/dataio/export/rms/fluid_contact_surfaces.py
+++ b/src/fmu/dataio/export/rms/fluid_contact_surfaces.py
@@ -9,7 +9,7 @@ from fmu.dataio.exceptions import ValidationError
 from fmu.dataio.export._base import SimpleExportBase
 from fmu.dataio.export._export_result import ExportResult, ExportResultItem
 from fmu.dataio.export.rms._utils import (
-    get_rms_project_units,
+    get_rms_project_length_unit,
     get_surfaces_in_general2d_folder,
     list_folder_names_in_general2d_folder,
     validate_name_in_stratigraphy,
@@ -39,7 +39,7 @@ class _ExportFluidContactSurfaces(SimpleExportBase):
         _logger.debug("Process data, establish state prior to export.")
         self.project = project
         self._contact_surfaces = self._get_contact_surfaces()
-        self._unit = "m" if get_rms_project_units(project) == "metric" else "ft"
+        self._unit = get_rms_project_length_unit(project)
         _logger.debug("Process data... DONE")
 
     def _get_contacts(self) -> list[FluidContactType]:

--- a/src/fmu/dataio/export/rms/grid_extracted_depth_surfaces.py
+++ b/src/fmu/dataio/export/rms/grid_extracted_depth_surfaces.py
@@ -9,7 +9,7 @@ from fmu.dataio.export._base import SimpleExportBase
 from fmu.dataio.export._export_result import ExportResult, ExportResultItem
 from fmu.dataio.export.rms._utils import (
     get_horizons_in_folder,
-    get_rms_project_units,
+    get_rms_project_length_unit,
     validate_name_in_stratigraphy,
 )
 from fmu.datamodels.common.enums import Classification
@@ -32,7 +32,7 @@ class _ExportGridExtractedDepthSurfaces(SimpleExportBase):
 
         _logger.debug("Process data, establish state prior to export.")
         self._surfaces = get_horizons_in_folder(project, horizon_folder)
-        self._unit = "m" if get_rms_project_units(project) == "metric" else "ft"
+        self._unit = get_rms_project_length_unit(project)
         _logger.debug("Process data... DONE")
 
     def _get_export_config(self, name: str) -> ExportConfig:

--- a/src/fmu/dataio/export/rms/inplace_volumes.py
+++ b/src/fmu/dataio/export/rms/inplace_volumes.py
@@ -15,7 +15,7 @@ from fmu.dataio.export._export_result import ExportResult, ExportResultItem
 from fmu.dataio.export.rms._conditional_rms_imports import import_rms_package
 from fmu.dataio.export.rms._utils import (
     check_rmsapi_version,
-    get_rms_project_units,
+    get_rms_project_volume_unit,
 )
 from fmu.datamodels import InplaceVolumesResult
 from fmu.datamodels.common.enums import Classification
@@ -338,7 +338,7 @@ class _ExportVolumetricsRMS(SimpleExportBase):
             ExportConfig.builder()
             .content(Content.volumes)
             .domain(VerticalDomain.depth, DomainReference.msl)
-            .unit("m3" if get_rms_project_units(self.project) == "metric" else "ft3")
+            .unit(get_rms_project_volume_unit(self.project))
             .file_config(
                 name=self.grid_name,
                 subfolder=enums.StandardResultName.inplace_volumes.value,

--- a/src/fmu/dataio/export/rms/structure_depth_fault_lines.py
+++ b/src/fmu/dataio/export/rms/structure_depth_fault_lines.py
@@ -11,7 +11,7 @@ from fmu.dataio.export._export_result import ExportResult, ExportResultItem
 from fmu.dataio.export.rms._utils import (
     get_faultlines_in_folder,
     get_open_polygons_id,
-    get_rms_project_units,
+    get_rms_project_length_unit,
     validate_name_in_stratigraphy,
 )
 from fmu.datamodels.common.enums import Classification
@@ -36,7 +36,7 @@ class _ExportStructureDepthFaultLines(SimpleExportBase):
         _logger.debug("Process data, establish state prior to export.")
         self._horizon_folder = horizon_folder
         self._fault_lines = get_faultlines_in_folder(project, horizon_folder)
-        self._unit = "m" if get_rms_project_units(project) == "metric" else "ft"
+        self._unit = get_rms_project_length_unit(project)
         _logger.debug("Process data... DONE")
 
     def _get_export_config(self, name: str) -> ExportConfig:

--- a/src/fmu/dataio/export/rms/structure_depth_fault_surfaces.py
+++ b/src/fmu/dataio/export/rms/structure_depth_fault_surfaces.py
@@ -9,7 +9,7 @@ from fmu.dataio._export import ExportConfig, export_with_metadata
 from fmu.dataio._logging import null_logger
 from fmu.dataio.export._base import SimpleExportBase
 from fmu.dataio.export._export_result import ExportResult, ExportResultItem
-from fmu.dataio.export.rms._utils import get_rms_project_units
+from fmu.dataio.export.rms._utils import get_rms_project_length_unit
 from fmu.datamodels.common.enums import Classification
 from fmu.datamodels.fmu_results.enums import (
     Content,
@@ -31,7 +31,7 @@ class _ExportStructureDepthFaultSurfaces(SimpleExportBase):
 
         _logger.debug("Process data, establish state prior to export.")
 
-        self._unit = "m" if get_rms_project_units(project) == "metric" else "ft"
+        self._unit = get_rms_project_length_unit(project)
 
         self._surfaces = _get_fault_surfaces_from_rms(project, structural_model_name)
 
@@ -111,7 +111,7 @@ def _get_fault_surfaces_from_rms(
 
         # To get coordinate system info in the GOCAD TSurf file
         # it must be set using metadata in the xtgeo object
-        unit = "m" if get_rms_project_units(project) == "metric" else "ft"
+        unit = get_rms_project_length_unit(project)
 
         tsurf.metadata.freeform = {
             "tsurf_coord_sys": {

--- a/src/fmu/dataio/export/rms/structure_depth_isochores.py
+++ b/src/fmu/dataio/export/rms/structure_depth_isochores.py
@@ -9,7 +9,7 @@ from fmu.dataio.exceptions import ValidationError
 from fmu.dataio.export._base import SimpleExportBase
 from fmu.dataio.export._export_result import ExportResult, ExportResultItem
 from fmu.dataio.export.rms._utils import (
-    get_rms_project_units,
+    get_rms_project_length_unit,
     get_zones_in_folder,
     validate_name_in_stratigraphy,
 )
@@ -33,7 +33,7 @@ class _ExportStructureDepthIsochores(SimpleExportBase):
 
         _logger.debug("Process data, establish state prior to export.")
         self._surfaces = get_zones_in_folder(project, zone_folder)
-        self._unit = "m" if get_rms_project_units(project) == "metric" else "ft"
+        self._unit = get_rms_project_length_unit(project)
         _logger.debug("Process data... DONE")
 
     def _get_export_config(self, name: str) -> ExportConfig:

--- a/src/fmu/dataio/export/rms/structure_depth_surfaces.py
+++ b/src/fmu/dataio/export/rms/structure_depth_surfaces.py
@@ -9,7 +9,7 @@ from fmu.dataio.export._base import SimpleExportBase
 from fmu.dataio.export._export_result import ExportResult, ExportResultItem
 from fmu.dataio.export.rms._utils import (
     get_horizons_in_folder,
-    get_rms_project_units,
+    get_rms_project_length_unit,
     validate_name_in_stratigraphy,
 )
 from fmu.datamodels.common.enums import Classification
@@ -33,7 +33,7 @@ class _ExportStructureDepthSurfaces(SimpleExportBase):
 
         _logger.debug("Process data, establish state prior to export.")
         self._surfaces = get_horizons_in_folder(project, horizon_folder)
-        self._unit = "m" if get_rms_project_units(project) == "metric" else "ft"
+        self._unit = get_rms_project_length_unit(project)
         _logger.debug("Process data... DONE")
 
     @property

--- a/src/fmu/dataio/export/rms/structure_time_surfaces.py
+++ b/src/fmu/dataio/export/rms/structure_time_surfaces.py
@@ -9,7 +9,7 @@ from fmu.dataio.export._base import SimpleExportBase
 from fmu.dataio.export._export_result import ExportResult, ExportResultItem
 from fmu.dataio.export.rms._utils import (
     get_horizons_in_folder,
-    get_rms_project_units,
+    get_rms_project_length_unit,
     validate_name_in_stratigraphy,
 )
 from fmu.datamodels.common.enums import Classification
@@ -32,7 +32,7 @@ class _ExportStructureTimeSurfaces(SimpleExportBase):
 
         _logger.debug("Process data, establish state prior to export.")
         self._surfaces = get_horizons_in_folder(project, horizon_folder)
-        self._unit = "m" if get_rms_project_units(project) == "metric" else "ft"
+        self._unit = get_rms_project_length_unit(project)
         _logger.debug("Process data... DONE")
 
     def _get_export_config(self, name: str) -> ExportConfig:

--- a/src/fmu/dataio/export/rms/structure_time_surfaces.py
+++ b/src/fmu/dataio/export/rms/structure_time_surfaces.py
@@ -9,7 +9,7 @@ from fmu.dataio.export._base import SimpleExportBase
 from fmu.dataio.export._export_result import ExportResult, ExportResultItem
 from fmu.dataio.export.rms._utils import (
     get_horizons_in_folder,
-    get_rms_project_length_unit,
+    get_rms_project_time_unit,
     validate_name_in_stratigraphy,
 )
 from fmu.datamodels.common.enums import Classification
@@ -32,7 +32,7 @@ class _ExportStructureTimeSurfaces(SimpleExportBase):
 
         _logger.debug("Process data, establish state prior to export.")
         self._surfaces = get_horizons_in_folder(project, horizon_folder)
-        self._unit = get_rms_project_length_unit(project)
+        self._unit = get_rms_project_time_unit(project)
         _logger.debug("Process data... DONE")
 
     def _get_export_config(self, name: str) -> ExportConfig:

--- a/tests/test_export_rms/test_export_structure_time_surfaces.py
+++ b/tests/test_export_rms/test_export_structure_time_surfaces.py
@@ -100,6 +100,7 @@ def test_public_export_function(
     metadata = dataio.read_metadata(out.items[0].absolute_path)
 
     assert "time" in metadata["data"]["content"]
+    assert metadata["data"]["unit"] == "ms"
     assert metadata["access"]["classification"] == "internal"
     assert metadata["data"]["is_prediction"]
     assert (

--- a/tests/test_export_rms/test_utils.py
+++ b/tests/test_export_rms/test_utils.py
@@ -11,6 +11,67 @@ if TYPE_CHECKING:
     import xtgeo
 
 
+class MockRmsUnitSystem:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def __str__(self) -> str:
+        return f"UnitSystem.{self.name}"
+
+
+@pytest.mark.parametrize(
+    ("project_units", "expected_units", "expected_length_unit", "expected_volume_unit"),
+    [
+        (MockRmsUnitSystem("metric"), "metric", "m", "m3"),
+        (MockRmsUnitSystem("metric_cmg"), "metric", "m", "m3"),
+        ("UnitSystem.metric_tempest", "metric", "m", "m3"),
+        ("si", "metric", "m", "m3"),
+        (MockRmsUnitSystem("field"), "field", "ft", "ft3"),
+        ("field_cmg", "field", "ft", "ft3"),
+        ("UnitSystem.field_us", "field", "ft", "ft3"),
+        ("field_nexus", "field", "ft", "ft3"),
+        (MockRmsUnitSystem("mmft"), "field", "ft", "ft3"),
+    ],
+)
+def test_get_rms_project_units_known_unit_systems(
+    mock_project_variable: MagicMock,
+    project_units: object,
+    expected_units: str,
+    expected_length_unit: str,
+    expected_volume_unit: str,
+) -> None:
+    from fmu.dataio.export.rms._utils import (
+        get_rms_project_length_unit,
+        get_rms_project_units,
+        get_rms_project_volume_unit,
+    )
+
+    mock_project_variable.project_units = project_units
+
+    assert get_rms_project_units(mock_project_variable) == expected_units
+    assert get_rms_project_length_unit(mock_project_variable) == expected_length_unit
+    assert get_rms_project_volume_unit(mock_project_variable) == expected_volume_unit
+
+
+def test_get_rms_project_units_unknown_unit_system(
+    mock_project_variable: MagicMock, caplog: pytest.LogCaptureFixture
+) -> None:
+    from fmu.dataio.export.rms._utils import (
+        get_rms_project_length_unit,
+        get_rms_project_units,
+        get_rms_project_volume_unit,
+    )
+
+    mock_project_variable.project_units = "custom_units"
+
+    with caplog.at_level("WARNING", logger="fmu.dataio.export.rms._utils"):
+        assert get_rms_project_units(mock_project_variable) is None
+        assert get_rms_project_length_unit(mock_project_variable) == ""
+        assert get_rms_project_volume_unit(mock_project_variable) == ""
+
+    assert "not a known RMS unit system" in caplog.text
+
+
 def test_get_horizons_in_folder(mock_project_variable: MagicMock) -> None:
     from fmu.dataio.export.rms._utils import get_horizons_in_folder
 

--- a/tests/test_export_rms/test_utils.py
+++ b/tests/test_export_rms/test_utils.py
@@ -16,21 +16,27 @@ class MockRmsUnitSystem:
         self.name = name
 
     def __str__(self) -> str:
-        return f"UnitSystem.{self.name}"
+        return self.name
 
 
 @pytest.mark.parametrize(
-    ("project_units", "expected_units", "expected_length_unit", "expected_volume_unit"),
+    (
+        "project_units",
+        "expected_units",
+        "expected_length_unit",
+        "expected_volume_unit",
+        "expected_time_unit",
+    ),
     [
-        (MockRmsUnitSystem("metric"), "metric", "m", "m3"),
-        (MockRmsUnitSystem("metric_cmg"), "metric", "m", "m3"),
-        ("UnitSystem.metric_tempest", "metric", "m", "m3"),
-        ("si", "metric", "m", "m3"),
-        (MockRmsUnitSystem("field"), "field", "ft", "ft3"),
-        ("field_cmg", "field", "ft", "ft3"),
-        ("UnitSystem.field_us", "field", "ft", "ft3"),
-        ("field_nexus", "field", "ft", "ft3"),
-        (MockRmsUnitSystem("mmft"), "field", "ft", "ft3"),
+        (MockRmsUnitSystem("metric"), "metric", "m", "m3", "ms"),
+        (MockRmsUnitSystem("metric_cmg"), "metric", "m", "m3", "ms"),
+        ("metric_tempest", "metric", "m", "m3", "ms"),
+        ("si", "metric", "m", "m3", "s"),
+        (MockRmsUnitSystem("field"), "field", "ft", "ft3", "ms"),
+        ("field_cmg", "field", "ft", "ft3", "ms"),
+        ("field_us", "field", "ft", "ft3", "ms"),
+        ("field_nexus", "field", "ft", "ft3", "ms"),
+        (MockRmsUnitSystem("mmft"), "field", "ft", "ft3", "ms"),
     ],
 )
 def test_get_rms_project_units_known_unit_systems(
@@ -39,9 +45,11 @@ def test_get_rms_project_units_known_unit_systems(
     expected_units: str,
     expected_length_unit: str,
     expected_volume_unit: str,
+    expected_time_unit: str,
 ) -> None:
     from fmu.dataio.export.rms._utils import (
         get_rms_project_length_unit,
+        get_rms_project_time_unit,
         get_rms_project_units,
         get_rms_project_volume_unit,
     )
@@ -51,25 +59,32 @@ def test_get_rms_project_units_known_unit_systems(
     assert get_rms_project_units(mock_project_variable) == expected_units
     assert get_rms_project_length_unit(mock_project_variable) == expected_length_unit
     assert get_rms_project_volume_unit(mock_project_variable) == expected_volume_unit
+    assert get_rms_project_time_unit(mock_project_variable) == expected_time_unit
 
 
 def test_get_rms_project_units_unknown_unit_system(
-    mock_project_variable: MagicMock, caplog: pytest.LogCaptureFixture
+    mock_project_variable: MagicMock,
 ) -> None:
     from fmu.dataio.export.rms._utils import (
         get_rms_project_length_unit,
+        get_rms_project_time_unit,
         get_rms_project_units,
         get_rms_project_volume_unit,
     )
 
     mock_project_variable.project_units = "custom_units"
 
-    with caplog.at_level("WARNING", logger="fmu.dataio.export.rms._utils"):
+    with pytest.warns(UserWarning, match="not a known RMS unit system"):
         assert get_rms_project_units(mock_project_variable) is None
+
+    with pytest.warns(UserWarning, match="not a known RMS unit system"):
         assert get_rms_project_length_unit(mock_project_variable) == ""
+
+    with pytest.warns(UserWarning, match="not a known RMS unit system"):
         assert get_rms_project_volume_unit(mock_project_variable) == ""
 
-    assert "not a known RMS unit system" in caplog.text
+    with pytest.warns(UserWarning, match="not a known RMS unit system"):
+        assert get_rms_project_time_unit(mock_project_variable) == ""
 
 
 def test_get_horizons_in_folder(mock_project_variable: MagicMock) -> None:


### PR DESCRIPTION
Resolves #1755

This PR fixes RMS project unit detection by normalizing RMS unit-system values before deciding export metadata units. It now handles the known RMS unit systems explicitly, mapping metric-family units to `m/m3` and field-family units to `ft/ft3`.

Custom or unknown RMS unit systems no longer silently default to imperial units; they produce a warning and export an unknown/empty metadata unit instead. Regression tests were added for the supported RMS unit systems and custom unit handling.

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [ ] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [ ] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [ ] Checked the boxes in this checklist ✅
