### PR TITLE
MAINT: Lower case enums

### DIFF
--- a/src/fmu/dataio/_definitions.py
+++ b/src/fmu/dataio/_definitions.py
@@ -14,9 +14,9 @@ ERT_RELATIVE_CASE_METADATA_FILE: Final = "share/metadata/fmu_case.yml"
 
 
 class ShareFolder(StrEnum):
-    PREPROCESSED = "share/preprocessed/"
-    OBSERVATIONS = "share/observations/"
-    RESULTS = "share/results/"
+    preprocessed = "share/preprocessed/"
+    observations = "share/observations/"
+    results = "share/results/"
 
 
 class FileExtension(StrEnum):

--- a/src/fmu/dataio/_metadata/_file.py
+++ b/src/fmu/dataio/_metadata/_file.py
@@ -43,10 +43,10 @@ class SharePathConstructor:
     def _get_share_root(self) -> Path:
         """Get the main share root location as a path e.g. share/results."""
         if self.export_config.preprocessed:
-            return Path(ShareFolder.PREPROCESSED.value)
+            return Path(ShareFolder.preprocessed.value)
         if self.export_config.is_observation:
-            return Path(ShareFolder.OBSERVATIONS.value)
-        return Path(ShareFolder.RESULTS.value)
+            return Path(ShareFolder.observations.value)
+        return Path(ShareFolder.results.value)
 
     def _get_share_folders(self) -> Path:
         """Get the full share folders as a path."""

--- a/src/fmu/dataio/preprocessed.py
+++ b/src/fmu/dataio/preprocessed.py
@@ -92,9 +92,9 @@ class ExportPreprocessedData:
         if not objfile.exists():
             raise FileNotFoundError(f"The file {obj} does not exist.")
 
-        if ShareFolder.PREPROCESSED not in str(objfile):
+        if ShareFolder.preprocessed not in str(objfile):
             raise RuntimeError(
-                f"Exporting files located outside the '{ShareFolder.PREPROCESSED}' "
+                f"Exporting files located outside the '{ShareFolder.preprocessed}' "
                 "folder is not supported. Please re-export your objects to disk "
                 "using ExportData(preprocessed=True)"
             )
@@ -122,16 +122,16 @@ class ExportPreprocessedData:
         The existing subfolders and filename will be kept.
         """
         share_folder = (
-            Path(ShareFolder.OBSERVATIONS.value)
+            Path(ShareFolder.observations.value)
             if self._is_observation
-            else Path(ShareFolder.RESULTS.value)
+            else Path(ShareFolder.results.value)
         )
         for parent in existing_path.parents:
             if parent.name == "preprocessed" and parent.parent.name == "share":
                 return share_folder / existing_path.relative_to(parent)
 
         raise RuntimeError(
-            f"Path {existing_path} is not inside a '{ShareFolder.PREPROCESSED}' folder."
+            f"Path {existing_path} is not inside a '{ShareFolder.preprocessed}' folder."
         )
 
     def _check_md5sum_consistency(

--- a/tests/test_units/test_filemetadata.py
+++ b/tests/test_units/test_filemetadata.py
@@ -305,7 +305,7 @@ def test_sharepath_get_share_root(
     objdata = create_object_data(regsurf, exportdata._export_config)
     assert SharePathConstructor(
         exportdata._export_config, objdata
-    )._get_share_root() == Path(ShareFolder.RESULTS.value)
+    )._get_share_root() == Path(ShareFolder.results.value)
 
     # share/preprosessed
     preprocessed_exportdata = ExportData(
@@ -317,7 +317,7 @@ def test_sharepath_get_share_root(
     objdata = create_object_data(regsurf, preprocessed_exportdata._export_config)
     assert SharePathConstructor(
         preprocessed_exportdata._export_config, objdata
-    )._get_share_root() == Path(ShareFolder.PREPROCESSED.value)
+    )._get_share_root() == Path(ShareFolder.preprocessed.value)
 
     # share/observations
     obs_exportdata = ExportData(
@@ -329,7 +329,7 @@ def test_sharepath_get_share_root(
     objdata = create_object_data(regsurf, obs_exportdata._export_config)
     assert SharePathConstructor(
         obs_exportdata._export_config, objdata
-    )._get_share_root() == Path(ShareFolder.OBSERVATIONS.value)
+    )._get_share_root() == Path(ShareFolder.observations.value)
 
     # preprosessed should win over is_observation
     preprocessed_obs_exportdata = ExportData(
@@ -341,7 +341,7 @@ def test_sharepath_get_share_root(
     objdata = create_object_data(regsurf, preprocessed_obs_exportdata._export_config)
     assert SharePathConstructor(
         preprocessed_obs_exportdata._export_config, objdata
-    )._get_share_root() == Path(ShareFolder.PREPROCESSED.value)
+    )._get_share_root() == Path(ShareFolder.preprocessed.value)
 
 
 def test_sharepath_with_date(
@@ -361,7 +361,7 @@ def test_sharepath_with_date(
     share_path = SharePathConstructor(exportdata._export_config, objdata)
 
     expected_filename = Path("test--mytag--20250512.gri")
-    expected_path = Path(ShareFolder.RESULTS.value) / "maps" / expected_filename
+    expected_path = Path(ShareFolder.results.value) / "maps" / expected_filename
 
     assert share_path.get_share_path() == expected_path
 
@@ -383,7 +383,7 @@ def test_sharepath_with_two_dates(
     share_path = SharePathConstructor(exportdata._export_config, objdata)
 
     expected_filename = Path("test--mytag--20250512_20250511.gri")
-    expected_path = Path(ShareFolder.RESULTS.value) / "maps" / expected_filename
+    expected_path = Path(ShareFolder.results.value) / "maps" / expected_filename
 
     assert share_path.get_share_path() == expected_path
     share_path = SharePathConstructor(
@@ -410,7 +410,7 @@ def test_sharepath_with_parent(
     share_path = SharePathConstructor(exportdata._export_config, objdata)
 
     expected_filename = Path("myparent--test--mytag.gri")
-    expected_path = Path(ShareFolder.RESULTS.value) / "maps" / expected_filename
+    expected_path = Path(ShareFolder.results.value) / "maps" / expected_filename
 
     assert share_path.get_share_path() == expected_path
     share_path = SharePathConstructor(
@@ -431,7 +431,7 @@ def test_sharepath_name_from_objprovider(
     share_path = SharePathConstructor(exportdata._export_config, objdata)
 
     expected_filename = Path(f"{objdata.name}.gri")
-    expected_path = Path(ShareFolder.RESULTS.value) / "maps" / expected_filename
+    expected_path = Path(ShareFolder.results.value) / "maps" / expected_filename
 
     assert share_path.get_share_path() == expected_path
     share_path = SharePathConstructor(


### PR DESCRIPTION
Resolves #732 

Standardized enum member capitalization by renaming ShareFolder members from all caps to lowercase while keeping their serialized path values unchanged. Updated internal usages and focused tests accordingly.



## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
