### PR TITLE
ENH: Inform about fmu settings on global config load

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,7 +138,9 @@ filterwarnings = [
     # https://github.com/scikit-learn-contrib/hdbscan/issues/457#issuecomment-773671043
     # https://numpy.org/doc/stable/release/1.20.0-notes.html#size-of-np-ndarray-and-np-void-changed
     "ignore:numpy.ndarray size changed:RuntimeWarning",
-    "ignore:Config contains a SUMMARY key but no forward model steps known to generate summary files:UserWarning",
+    "ignore:Config contains a SUMMARY key but no forward model steps known to generate summary files:UserWarning",    
+    "ignore:This project is configured to use FMU Settings.:UserWarning",
+    "ignore:This project is not yet configured to use FMU Settings.:FutureWarning",
 ]
 
 [tool.coverage.run]

--- a/src/fmu/dataio/_global_config.py
+++ b/src/fmu/dataio/_global_config.py
@@ -1,5 +1,6 @@
 """Module to produce a GlobalConfiguration object or dictionary."""
 
+import contextlib
 import warnings
 from pathlib import Path
 from typing import Any, Final
@@ -13,7 +14,7 @@ from fmu.datamodels.fmu_results.global_configuration import (
     Access,
     GlobalConfiguration,
 )
-from fmu.settings import find_nearest_fmu_directory
+from fmu.settings import find_global_config, find_nearest_fmu_directory
 
 RUNPATH_GLOBAL_VARIABLES_PATH: Final[Path] = Path(
     "fmuconfig/output/global_variables.yml"
@@ -24,7 +25,7 @@ RELATIVE_GLOBAL_VARIABLES_PATH: Final[Path] = (
 
 logger: Final = null_logger(__name__)
 
-
+_FMU_SETTINGS_URL = "https://equinor.github.io/fmu-settings"
 _GETTING_STARTED_URL = (
     "https://fmu-dataio.readthedocs.io/en/latest/getting_started.html"
 )
@@ -43,6 +44,30 @@ def warn_invalid_global_configuration(err: ValidationError) -> None:
         f"configuration. Invalid configuration may be disallowed in future "
         f"versions.\n\n{err}",
         UserWarning,
+        stacklevel=2,
+    )
+
+
+def warn_global_variables_unused() -> None:
+    """Warn when legacy global_variables.yml exists but .fmu/ is used."""
+    warnings.warn(
+        "This project is configured to use FMU Settings. "
+        "Please remove the masterdata, access, model, and stratigraphy "
+        "blocks from global_variables.yml as they are no longer used.\n"
+        f"Learn more about FMU Settings: {_FMU_SETTINGS_URL}",
+        UserWarning,
+        stacklevel=2,
+    )
+
+
+def warn_using_legacy_global_variables() -> None:
+    """Warn when loading global configuration from global_variables.yml."""
+    warnings.warn(
+        "This project is not yet configured to use FMU Settings.\n"
+        "Follow the 'Getting started' steps to do the necessary setup: "
+        f"{_FMU_SETTINGS_URL}/getting_started.html\n"
+        "Reading data from global_variables.yml will be deprecated in the future.",
+        FutureWarning,
         stacklevel=2,
     )
 
@@ -139,8 +164,12 @@ def load_global_config_from_fmu_settings() -> GlobalConfiguration | None:
     Returns:
         Valid GlobalConfiguration object, or None if:
             - .fmu/ cannot be found
-            - data in .fmu/ is invalid or cannot be loaded
             - data in .fmu/ does not validate against current GlobalConfiguration model
+
+    Raises:
+        ValueError: If data in .fmu/ is invalid or cannot be loaded
+        ValidationError: If the required fields masterdata, access, or model are
+            missing in .fmu/.
     """
     try:
         fmu_dir = find_nearest_fmu_directory()
@@ -150,7 +179,12 @@ def load_global_config_from_fmu_settings() -> GlobalConfiguration | None:
 
     config = fmu_dir.config.load()
     if config.masterdata is None or config.access is None or config.model is None:
-        return None
+        raise ValidationError(
+            "The configuration in FMU Settings is incomplete. From a terminal, "
+            "navigate to your project directory, type `fmu settings` to open "
+            "FMU Settings and complete the setup checklist. "
+            f"Learn more about FMU Settings: {_FMU_SETTINGS_URL}",
+        )
 
     try:
         cfg_access = Access.model_validate(config.access.model_dump(mode="json"))
@@ -204,9 +238,18 @@ def load_global_config(
         Validated GlobalConfiguration object
     """
     if fmu_settings_global_config := load_global_config_from_fmu_settings():
+        fmu_dir = find_nearest_fmu_directory()
+
+        with contextlib.suppress(pydantic.ValidationError):
+            if find_global_config(fmu_dir.base_path, strict=False):
+                warn_global_variables_unused()
+
         return fmu_settings_global_config
 
     resolved_config_path = _resolve_global_config_path(config_path)
-    return load_global_config_from_global_variables(
+    if global_config := load_global_config_from_global_variables(
         resolved_config_path, standard_result
-    )
+    ):
+        warn_using_legacy_global_variables()
+
+    return global_config

--- a/tests/test_units/test_global_config.py
+++ b/tests/test_units/test_global_config.py
@@ -1,4 +1,5 @@
 import shutil
+import warnings
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
@@ -210,17 +211,17 @@ def test_load_from_fmu_settings_returns_none_when_no_dotfmu(
     assert result is None
 
 
-def test_load_from_fmu_settings_returns_none_when_config_incomplete(
+def test_load_from_fmu_settings_raises_when_config_incomplete(
     tmp_path: Path, monkeypatch: MonkeyPatch
 ) -> None:
-    """If the .fmu config is missing required fields, returns None."""
+    """If the .fmu config is missing required fields, raises ValidationError."""
     fmu_dir = create_drogon_fmu_dir(tmp_path)
     monkeypatch.chdir(tmp_path)
 
     fmu_dir.config.set("masterdata", None)
 
-    result = load_global_config_from_fmu_settings()
-    assert result is None
+    with pytest.raises(ValidationError, match="FMU Settings is incomplete"):
+        load_global_config_from_fmu_settings()
 
 
 def test_load_from_fmu_settings_returns_none_on_invalid_access(
@@ -325,12 +326,12 @@ def test_load_global_config_raises_when_neither_source_exists(
         load_global_config()
 
 
-def test_load_global_config_falls_back_when_fmu_settings_incomplete(
+def test_load_global_config_raises_when_fmu_settings_incomplete(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
     drogon_global_config_path: Path,
 ) -> None:
-    """When .fmu/ config is incomplete, falls back to global_variables.yml."""
+    """When .fmu/ config is incomplete, raises ValidationError."""
     fmu_dir = create_drogon_fmu_dir(tmp_path)
 
     fmu_dir.config.set("masterdata", None)
@@ -341,9 +342,8 @@ def test_load_global_config_falls_back_when_fmu_settings_incomplete(
 
     monkeypatch.chdir(tmp_path)
 
-    result = load_global_config()
-    assert isinstance(result, GlobalConfiguration)
-    assert result.model.name == "global_variables"
+    with pytest.raises(ValidationError, match="FMU Settings is incomplete"):
+        load_global_config()
 
 
 def test_load_global_config_with_explicit_path_still_prefers_fmu_settings(
@@ -384,3 +384,67 @@ def test_load_global_config_from_runpath_without_dotfmu(
     result = load_global_config()
     assert isinstance(result, GlobalConfiguration)
     assert result.model.name == "global_variables"
+
+
+def test_load_global_config_warns_when_both_sources_exist(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    drogon_global_config_path: Path,
+) -> None:
+    """Warns users to remove unused global_variables fields when .fmu/ is used."""
+    create_drogon_fmu_dir(tmp_path)
+
+    fmuconfig_output = tmp_path / "fmuconfig" / "output"
+    fmuconfig_output.mkdir(parents=True)
+    shutil.copy(drogon_global_config_path, fmuconfig_output / "global_variables.yml")
+
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.warns(UserWarning, match=r"Please remove.*no longer used"):
+        result = load_global_config()
+
+    assert isinstance(result, GlobalConfiguration)
+    assert result.model.name == "Drogon"
+
+
+def test_load_global_config_does_not_warn_on_invalid_global_variables(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """Does not warn users when global_variables.yml is invalid."""
+    create_drogon_fmu_dir(tmp_path)
+
+    fmuconfig_output = tmp_path / "fmuconfig" / "output"
+    fmuconfig_output.mkdir(parents=True)
+    fmuconfig = fmuconfig_output / "global_variables.yml"
+
+    fmuconfig.write_text("invalid: data")
+
+    monkeypatch.chdir(tmp_path)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        result = load_global_config()
+
+    assert isinstance(result, GlobalConfiguration)
+    assert result.model.name == "Drogon"
+
+
+def test_load_global_config_warns_when_using_global_variables(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    drogon_global_config_path: Path,
+) -> None:
+    """Warns users to initialize FMU settings when loading global_variables.yml."""
+    fmuconfig_output = tmp_path / "fmuconfig" / "output"
+    fmuconfig_output.mkdir(parents=True)
+    shutil.copy(drogon_global_config_path, fmuconfig_output / "global_variables.yml")
+
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.warns(FutureWarning, match="not yet configured to use FMU Settings"):
+        result = load_global_config()
+
+    assert isinstance(result, GlobalConfiguration)
+    assert result.model.name == "global_variables"
+
+    monkeypatch.chdir(tmp_path)

--- a/uv.lock
+++ b/uv.lock
@@ -12,11 +12,11 @@ resolution-markers = [
     "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version >= '3.12' and python_full_version < '3.14' and platform_machine == 'ARM64' and sys_platform == 'win32'",
     "python_full_version >= '3.12' and python_full_version < '3.14' and platform_machine != 'ARM64' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version < '3.12' and platform_machine == 'ARM64' and sys_platform == 'win32'",
     "python_full_version < '3.12' and platform_machine != 'ARM64' and sys_platform == 'win32'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
     "python_full_version < '3.12' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
@@ -1203,7 +1203,7 @@ wheels = [
 
 [[package]]
 name = "fmu-settings"
-version = "0.34.0"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
@@ -1213,9 +1213,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/39/ec/4af9a865f30a608e79c99e80dfd729296f055a7981cfa9c3e63978aca8b3/fmu_settings-0.34.0.tar.gz", hash = "sha256:b732c1c81fb3bf6850eda3dad71ec310ef267a23d89a6b986a82de68b63ddbd4", size = 782609, upload-time = "2026-06-25T12:07:58.439Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/48/467e87b3d43ed01ed2171986bed0447aad615e4ffc3ab23e9002a14d7d76/fmu_settings-1.0.0.tar.gz", hash = "sha256:36c28b799dae639cc64ce2b896168ca7cb870384d32865a44c2248ae25dfb723", size = 783965, upload-time = "2026-06-29T09:59:40.064Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/be/5d1280d17e44e9ebb05f898c18892101d9b1bbdc40048455418569a02104/fmu_settings-0.34.0-py3-none-any.whl", hash = "sha256:0440012d7a65fa3c33d2d92eeacd920ddbc5db6ed91149e94e93868986924ba4", size = 63299, upload-time = "2026-06-25T12:07:56.824Z" },
+    { url = "https://files.pythonhosted.org/packages/96/00/80c5bbb439b258295914b36c58385c62c9acda9ca97e057c343be5af387e/fmu_settings-1.0.0-py3-none-any.whl", hash = "sha256:829657aeb63bbfd10a45227b827233096f8eeb89cfdede3cf982eb9b42717a31", size = 64017, upload-time = "2026-06-29T09:59:38.326Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Resolves #1764 
Resolves #1704 

PR to start giving users notification of FMU settings. 

- inform to start using FMU settings if they have global variables
- inform to remove data in global  variables if FMU settings is set up
- inform to complete setup checklist if `.fmu` exists and `masterdata,` `access` or `model` is lacking

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
