### PR TITLE
ENH: Update error message for lacking stratigraphy

### DIFF
--- a/src/fmu/dataio/_global_config.py
+++ b/src/fmu/dataio/_global_config.py
@@ -72,6 +72,15 @@ def warn_using_legacy_global_variables() -> None:
     )
 
 
+def has_fmu_directory() -> bool:
+    """Return True if a .fmu/ directory is found, False otherwise."""
+    try:
+        find_nearest_fmu_directory()
+        return True
+    except FileNotFoundError:
+        return False
+
+
 def build_global_configuration(
     config_dict: dict[str, Any], standard_result: bool = False
 ) -> GlobalConfiguration:

--- a/src/fmu/dataio/export/rms/_utils.py
+++ b/src/fmu/dataio/export/rms/_utils.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, Final
 import xtgeo
 from packaging.version import parse as versionparse
 
+from fmu.dataio._global_config import _FMU_SETTINGS_URL, has_fmu_directory
 from fmu.dataio._logging import null_logger
 from fmu.dataio.exceptions import ValidationError
 from fmu.datamodels.fmu_results.global_configuration import GlobalConfiguration
@@ -282,13 +283,36 @@ def get_faultlines_in_folder(project: Any, horizon_folder: str) -> list[xtgeo.Po
 
 def validate_name_in_stratigraphy(name: str, config: GlobalConfiguration) -> None:
     """Validate that an input name is present in the config.stratigraphy."""
+
     if not config.stratigraphy:
+        if has_fmu_directory():
+            raise ValidationError(
+                "No stratigraphy mappings exist in FMU settings. "
+                "This is required for the export function to work. "
+                "From a terminal, navigate to your project directory "
+                "and run 'fmu settings' to open FMU settings. Then add "
+                "the required stratigraphy mappings and rerun.\n"
+                f"Learn more about FMU Settings: {_FMU_SETTINGS_URL}",
+            )
         raise ValidationError(
             "The 'stratigraphy' block is lacking in the config. "
-            "This is required for the export function to work."
+            "This is required for the export function to work.\n"
+            "Tip: FMU Settings is the recommended way to manage "
+            "stratigraphy mappings."
         )
     if name not in config.stratigraphy:
+        if has_fmu_directory():
+            raise ValidationError(
+                f"The stratigraphic {name=} has not been mapped in FMU settings. "
+                "From a terminal, navigate to your project directory "
+                "and run 'fmu settings' to open FMU settings. Then add the "
+                "required stratigraphy mapping and rerun.\n"
+                f"Learn more about FMU Settings: {_FMU_SETTINGS_URL}",
+            )
+
         raise ValidationError(
             f"The stratigraphic {name=} is not listed in the 'stratigraphy' "
-            "block in the config. This is required, please add it and rerun."
+            "block in the config. This is required, please add it and rerun.\n"
+            "Tip: FMU Settings is the recommended way to manage "
+            "stratigraphy mappings."
         )

--- a/tests/test_export_rms/test_export_fluid_contact_outlines.py
+++ b/tests/test_export_rms/test_export_fluid_contact_outlines.py
@@ -209,6 +209,12 @@ def test_unknown_name_in_stratigraphy_raises(
     with pytest.raises(ValueError, match="not listed"):
         mock_export_class.export()
 
+    with (
+        mock.patch("fmu.dataio.export.rms._utils.has_fmu_directory", return_value=True),
+        pytest.raises(ValueError, match="mapped in FMU settings"),
+    ):
+        mock_export_class.export()
+
 
 @pytest.mark.usefixtures("inside_rms_interactive")
 def test_stratigraphy_missing_raises(
@@ -229,6 +235,16 @@ def test_stratigraphy_missing_raises(
             return_value=mock_global_config_validated,
         ),
         pytest.raises(ValueError, match=r"stratigraphy.*is lacking"),
+    ):
+        export_fluid_contact_outlines(mock_project_variable)
+
+    with (
+        mock.patch("fmu.dataio.export.rms._utils.has_fmu_directory", return_value=True),
+        mock.patch(
+            "fmu.dataio.export._base.load_global_config",
+            return_value=mock_global_config_validated,
+        ),
+        pytest.raises(ValueError, match="No stratigraphy mappings exist"),
     ):
         export_fluid_contact_outlines(mock_project_variable)
 

--- a/tests/test_export_rms/test_export_fluid_contact_surfaces.py
+++ b/tests/test_export_rms/test_export_fluid_contact_surfaces.py
@@ -193,6 +193,12 @@ def test_unknown_name_in_stratigraphy_raises(
     with pytest.raises(ValueError, match="not listed"):
         mock_export_class.export()
 
+    with (
+        mock.patch("fmu.dataio.export.rms._utils.has_fmu_directory", return_value=True),
+        pytest.raises(ValueError, match="mapped in FMU settings"),
+    ):
+        mock_export_class.export()
+
 
 @pytest.mark.usefixtures("inside_rms_interactive")
 def test_stratigraphy_missing_raises(
@@ -213,6 +219,16 @@ def test_stratigraphy_missing_raises(
             return_value=mock_global_config_validated,
         ),
         pytest.raises(ValueError, match=r"stratigraphy.*is lacking"),
+    ):
+        export_fluid_contact_surfaces(mock_project_variable)
+
+    with (
+        mock.patch("fmu.dataio.export.rms._utils.has_fmu_directory", return_value=True),
+        mock.patch(
+            "fmu.dataio.export._base.load_global_config",
+            return_value=mock_global_config_validated,
+        ),
+        pytest.raises(ValueError, match="No stratigraphy mappings exist"),
     ):
         export_fluid_contact_surfaces(mock_project_variable)
 

--- a/tests/test_export_rms/test_export_grid_extracted_depth_surfaces.py
+++ b/tests/test_export_rms/test_export_grid_extracted_depth_surfaces.py
@@ -150,6 +150,12 @@ def test_unknown_name_in_stratigraphy_raises(
     with pytest.raises(ValueError, match="not listed"):
         mock_export_class.export()
 
+    with (
+        mock.patch("fmu.dataio.export.rms._utils.has_fmu_directory", return_value=True),
+        pytest.raises(ValueError, match="mapped in FMU settings"),
+    ):
+        mock_export_class.export()
+
 
 @pytest.mark.usefixtures("inside_rms_interactive")
 def test_stratigraphy_missing_raises(
@@ -170,6 +176,16 @@ def test_stratigraphy_missing_raises(
             return_value=mock_global_config_validated,
         ),
         pytest.raises(ValueError, match=r"stratigraphy.*is lacking"),
+    ):
+        export_grid_extracted_depth_surfaces(mock_project_variable, "DS_extracted")
+
+    with (
+        mock.patch("fmu.dataio.export.rms._utils.has_fmu_directory", return_value=True),
+        mock.patch(
+            "fmu.dataio.export._base.load_global_config",
+            return_value=mock_global_config_validated,
+        ),
+        pytest.raises(ValueError, match="No stratigraphy mappings exist"),
     ):
         export_grid_extracted_depth_surfaces(mock_project_variable, "DS_extracted")
 

--- a/tests/test_export_rms/test_export_structure_depth_fault_lines.py
+++ b/tests/test_export_rms/test_export_structure_depth_fault_lines.py
@@ -182,6 +182,16 @@ def test_stratigraphy_missing_raises(
     ):
         export_structure_depth_fault_lines(mock_project_variable, "DS_extracted")
 
+    with (
+        mock.patch("fmu.dataio.export.rms._utils.has_fmu_directory", return_value=True),
+        mock.patch(
+            "fmu.dataio.export._base.load_global_config",
+            return_value=mock_global_config_validated,
+        ),
+        pytest.raises(ValueError, match="No stratigraphy mappings exist"),
+    ):
+        export_structure_depth_fault_lines(mock_project_variable, "DS_extracted")
+
 
 @pytest.mark.usefixtures("inside_rms_interactive")
 def test_config_missing(

--- a/tests/test_export_rms/test_export_structure_depth_isochores.py
+++ b/tests/test_export_rms/test_export_structure_depth_isochores.py
@@ -120,6 +120,12 @@ def test_unknown_name_in_stratigraphy_raises(
     with pytest.raises(ValueError, match="not listed"):
         mock_export_class.export()
 
+    with (
+        mock.patch("fmu.dataio.export.rms._utils.has_fmu_directory", return_value=True),
+        pytest.raises(ValueError, match="mapped in FMU settings"),
+    ):
+        mock_export_class.export()
+
 
 @pytest.mark.usefixtures("inside_rms_interactive")
 def test_stratigraphy_missing_raises(
@@ -140,6 +146,16 @@ def test_stratigraphy_missing_raises(
             return_value=mock_global_config_validated,
         ),
         pytest.raises(ValueError, match=r"stratigraphy.*is lacking"),
+    ):
+        export_structure_depth_isochores(mock_project_variable, "IS_extracted")
+
+    with (
+        mock.patch("fmu.dataio.export.rms._utils.has_fmu_directory", return_value=True),
+        mock.patch(
+            "fmu.dataio.export._base.load_global_config",
+            return_value=mock_global_config_validated,
+        ),
+        pytest.raises(ValueError, match="No stratigraphy mappings exist"),
     ):
         export_structure_depth_isochores(mock_project_variable, "IS_extracted")
 

--- a/tests/test_export_rms/test_export_structure_depth_surfaces.py
+++ b/tests/test_export_rms/test_export_structure_depth_surfaces.py
@@ -146,6 +146,12 @@ def test_unknown_name_in_stratigraphy_raises(
     with pytest.raises(ValueError, match="not listed"):
         mock_export_class.export()
 
+    with (
+        mock.patch("fmu.dataio.export.rms._utils.has_fmu_directory", return_value=True),
+        pytest.raises(ValueError, match="mapped in FMU settings"),
+    ):
+        mock_export_class.export()
+
 
 @pytest.mark.usefixtures("inside_rms_interactive")
 def test_stratigraphy_missing_raises(
@@ -166,6 +172,16 @@ def test_stratigraphy_missing_raises(
             return_value=mock_global_config_validated,
         ),
         pytest.raises(ValueError, match=r"stratigraphy.*is lacking"),
+    ):
+        export_structure_depth_surfaces(mock_project_variable, "DS_extracted")
+
+    with (
+        mock.patch("fmu.dataio.export.rms._utils.has_fmu_directory", return_value=True),
+        mock.patch(
+            "fmu.dataio.export._base.load_global_config",
+            return_value=mock_global_config_validated,
+        ),
+        pytest.raises(ValueError, match="No stratigraphy mappings exist"),
     ):
         export_structure_depth_surfaces(mock_project_variable, "DS_extracted")
 

--- a/tests/test_export_rms/test_export_structure_time_surfaces.py
+++ b/tests/test_export_rms/test_export_structure_time_surfaces.py
@@ -119,6 +119,12 @@ def test_unknown_name_in_stratigraphy_raises(
     with pytest.raises(ValueError, match="not listed"):
         mock_export_class.export()
 
+    with (
+        mock.patch("fmu.dataio.export.rms._utils.has_fmu_directory", return_value=True),
+        pytest.raises(ValueError, match="mapped in FMU settings"),
+    ):
+        mock_export_class.export()
+
 
 @pytest.mark.usefixtures("inside_rms_interactive")
 def test_stratigraphy_missing_raises(
@@ -139,6 +145,16 @@ def test_stratigraphy_missing_raises(
             return_value=mock_global_config_validated,
         ),
         pytest.raises(ValueError, match=r"stratigraphy.*is lacking"),
+    ):
+        export_structure_time_surfaces(mock_project_variable, "TS_extracted")
+
+    with (
+        mock.patch("fmu.dataio.export.rms._utils.has_fmu_directory", return_value=True),
+        mock.patch(
+            "fmu.dataio.export._base.load_global_config",
+            return_value=mock_global_config_validated,
+        ),
+        pytest.raises(ValueError, match="No stratigraphy mappings exist"),
     ):
         export_structure_time_surfaces(mock_project_variable, "TS_extracted")
 

--- a/tests/test_units/test_global_config.py
+++ b/tests/test_units/test_global_config.py
@@ -13,6 +13,7 @@ from pytest import MonkeyPatch
 from fmu.dataio._global_config import (
     _resolve_global_config_path,
     build_global_configuration,
+    has_fmu_directory,
     load_global_config,
     load_global_config_from_fmu_settings,
     load_global_config_from_global_variables,
@@ -209,6 +210,23 @@ def test_load_from_fmu_settings_returns_none_when_no_dotfmu(
 
     result = load_global_config_from_fmu_settings()
     assert result is None
+
+
+def test_has_fmu_directory_returns_true_when_found(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """Returns True when find_nearest_fmu_directory succeeds."""
+    create_drogon_fmu_dir(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    assert has_fmu_directory() is True
+
+
+def test_has_fmu_directory_returns_false_when_not_found(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """Returns False when no .fmu/ directory exists."""
+    monkeypatch.chdir(tmp_path)
+    assert has_fmu_directory() is False
 
 
 def test_load_from_fmu_settings_raises_when_config_incomplete(


### PR DESCRIPTION
Adresses #1762

Split error warning given for missing stratigraphy mappings in simple exports to one specific for .fmu and one for global variables.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
