### PR TITLE
ENH: Make ValidationError messages preserve line breaks

### DIFF
--- a/src/fmu/dataio/exceptions.py
+++ b/src/fmu/dataio/exceptions.py
@@ -9,6 +9,10 @@ class InvalidMetadataError(Exception):
 class ValidationError(ValueError, KeyError):
     """Raise error while validating."""
 
+    def __str__(self) -> str:
+        """Avoid KeyError repr formatting and preserve readable multiline messages."""
+        return Exception.__str__(self)
+
 
 class ConfigurationError(ValueError):
     pass

--- a/tests/test_units/test_exceptions.py
+++ b/tests/test_units/test_exceptions.py
@@ -1,0 +1,14 @@
+from fmu.dataio.exceptions import ValidationError
+
+
+def test_validation_error_str_preserves_line_breaks() -> None:
+    err = ValidationError("line one\nline two")
+
+    assert str(err) == "line one\nline two"
+
+
+def test_validation_error_str_is_not_keyerror_repr() -> None:
+    err = ValidationError("hello")
+
+    assert str(err) == "hello"
+    assert str(err) != "'hello'"


### PR DESCRIPTION
Resolves #1777
Adresses #1751 


## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
