### PR TITLE
TST: Change import path of create_observation_dataframes

### DIFF
--- a/tests/test_ert_integration/test_wf_create_case_metadata.py
+++ b/tests/test_ert_integration/test_wf_create_case_metadata.py
@@ -17,8 +17,10 @@ import pyarrow as pa
 import pytest
 import yaml
 from ert.config import GenKwConfig, ShapeRegistry
+from ert.config._create_observation_dataframes import (
+    create_observation_dataframes,  # TODO: consider removing this private import
+)
 from ert.config.distribution import DistributionSettings
-from ert.config.ert_config import create_observation_dataframes
 from fmu.datamodels import (
     ErtObservationsRftSchema,
 )

--- a/tests/test_units/test_workflows/test_case_observations.py
+++ b/tests/test_units/test_workflows/test_case_observations.py
@@ -19,7 +19,9 @@ import polars as pl
 import pyarrow as pa
 import pytest
 from ert.config import ErtConfig
-from ert.config.ert_config import create_observation_dataframes
+from ert.config._create_observation_dataframes import (
+    create_observation_dataframes,  # TODO: consider removing this private import
+)
 from fmu.datamodels import (
     ErtObservationsBreakthroughResult,
     ErtObservationsBreakthroughSchema,


### PR DESCRIPTION
Part of #1786 

Import `create_observation_dataframes` directly from private module to avoid `ImportError` in bleeding test because `ert` doesn't expose `create_observation_dataframes` in public API anymore.

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
