### PR TITLE
TST: Adjust create_observation_dataframes() args

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,18 @@ jobs:
         run: uv pip install \ "fmu-sumo-uploader @
           git+https://github.com/equinor/fmu-sumo-uploader.git"
 
+      - name: Install ert
+        if: matrix.python-version != '3.11'
+        run: |
+          uv pip install "ert @ git+https://github.com/equinor/ert.git"
+
       - name: Full test
         run: |
-          uv run pytest -n auto -v --cov --cov-report term-missing
+          pytest_args="-n auto -v --cov --cov-report term-missing"
+
+          if [ "${{ matrix.python-version }}" = "3.11" ]; then
+            pytest_args="$pytest_args --ignore=tests/test_units/test_workflows/test_case_observations.py"
+            pytest_args="$pytest_args --deselect=tests/test_ert_integration/test_wf_create_case_metadata.py::test_create_case_metadata_collects_rft_observations_as_expected"
+          fi
+
+          uv run pytest $pytest_args

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,3 +215,5 @@ exclude-newer = "1 week"
 "sumo-wrapper-python" = false
 "xtgeo" = false
 "ert" = false
+"ropt" = false # Developed in cooperation with Equinor
+"ropt-dakota" = false # Developed in cooperation with Equinor

--- a/tests/test_ert_integration/test_wf_create_case_metadata.py
+++ b/tests/test_ert_integration/test_wf_create_case_metadata.py
@@ -815,19 +815,14 @@ def test_create_case_metadata_collects_rft_observations_as_expected(
 
     def mock_create_observation_dataframes(
         observations: ert.Ensemble,
-        rft_config: None,
         shape_registry: ShapeRegistry,
-    ) -> None:
+    ) -> dict[str, pl.DataFrame]:
         """mock"""
-        return create_observation_dataframes(observations, MagicMock(), shape_registry)
+        return create_observation_dataframes(observations, shape_registry)
 
     with (
         patch(
             "ert.storage.local_experiment.create_observation_dataframes",
-            side_effect=mock_create_observation_dataframes,
-        ),
-        patch(
-            "ert.config.ert_config.create_observation_dataframes",
             side_effect=mock_create_observation_dataframes,
         ),
         patch(

--- a/tests/test_units/test_workflows/test_case_observations.py
+++ b/tests/test_units/test_workflows/test_case_observations.py
@@ -71,7 +71,7 @@ def test_ert_observations_as_expected(ert_config_path: Path) -> None:
 
     ert_config = ErtConfig.from_file(ert_config_path)
     observations = create_observation_dataframes(
-        ert_config.observation_declarations, MagicMock(), ert_config.shape_registry
+        ert_config.observation_declarations, ert_config.shape_registry
     )
 
     assert len(observations) == 3
@@ -86,9 +86,7 @@ def test_ert_observations_breakthrough_dataframe_as_expected(
     add_breakthrough_observations(ert_config_path)
 
     ert_config = ErtConfig.from_file(ert_config_path)
-    observations = create_observation_dataframes(
-        ert_config.observation_declarations, MagicMock()
-    )
+    observations = create_observation_dataframes(ert_config.observation_declarations)
 
     assert len(observations) == 1
     assert "breakthrough" in observations
@@ -143,9 +141,7 @@ def test_ert_observations_breakthrough_dataframe_validates_against_schema(
     add_breakthrough_observations(ert_config_path)
 
     ert_config = ErtConfig.from_file(ert_config_path)
-    observations = create_observation_dataframes(
-        ert_config.observation_declarations, MagicMock()
-    )
+    observations = create_observation_dataframes(ert_config.observation_declarations)
 
     obs_df = observations["breakthrough"]
 
@@ -177,9 +173,7 @@ def test_ert_observations_summary_dataframe_as_expected(ert_config_path: Path) -
     add_summary_observations(ert_config_path)
 
     ert_config = ErtConfig.from_file(ert_config_path)
-    observations = create_observation_dataframes(
-        ert_config.observation_declarations, MagicMock()
-    )
+    observations = create_observation_dataframes(ert_config.observation_declarations)
 
     assert len(observations) == 1
     assert "summary" in observations
@@ -231,9 +225,7 @@ def test_ert_observations_summary_dataframe_validates_against_schema(
     add_summary_observations(ert_config_path)
 
     ert_config = ErtConfig.from_file(ert_config_path)
-    observations = create_observation_dataframes(
-        ert_config.observation_declarations, MagicMock()
-    )
+    observations = create_observation_dataframes(ert_config.observation_declarations)
 
     obs_df = observations["summary"]
 
@@ -266,7 +258,7 @@ def test_ert_observations_rft_dataframe_as_expected(ert_config_path: Path) -> No
 
     ert_config = ErtConfig.from_file(ert_config_path)
     observations = create_observation_dataframes(
-        ert_config.observation_declarations, MagicMock(), ert_config.shape_registry
+        ert_config.observation_declarations, ert_config.shape_registry
     )
 
     assert len(observations) == 1
@@ -332,7 +324,7 @@ def test_ert_observations_rft_dataframe_validates_against_schema(
 
     ert_config = ErtConfig.from_file(ert_config_path)
     observations = create_observation_dataframes(
-        ert_config.observation_declarations, MagicMock(), ert_config.shape_registry
+        ert_config.observation_declarations, ert_config.shape_registry
     )
 
     obs_df = observations["rft"]


### PR DESCRIPTION
Part of #1786 

Second arg in `create_observation_dataframes()` is removed, so we need to adjust for that. We also need the latest `ert` in CI to test it.

Some notes:

- ert now drops support for py311, because newest numpy also drops support of py311. We should look into dropping support of py3.11 as well (?) For now we just skip the test that require `create_observation_dataframes()` in py311
- added some exclude-newer-package for dependencies of ert (https://github.com/equinor/ert/blob/eea2fa30fcadf0dc515f6f2f70eb54a299f6820c/pyproject.toml#L349-L350)

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [ ] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [ ] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [ ] Checked the boxes in this checklist ✅
