### PR TITLE
MAINT: Handle empty manifest files

### DIFF
--- a/src/fmu/dataio/manifest/_models.py
+++ b/src/fmu/dataio/manifest/_models.py
@@ -37,7 +37,12 @@ class ExportManifest(RootModel):
     def from_file(cls, manifest_path: Path) -> Self:
         """Load the export manifest from the JSON file."""
         with manifest_path.open("r", encoding="utf-8") as file:
-            return cls.model_validate(json.load(file))
+            content = file.read()
+
+        if not content.strip():
+            return cls()
+
+        return cls.model_validate(json.loads(content))
 
     def add_entry(self, absolute_path: Path) -> None:
         """Append a new file to the manifest."""

--- a/src/fmu/dataio/manifest/_models.py
+++ b/src/fmu/dataio/manifest/_models.py
@@ -36,13 +36,11 @@ class ExportManifest(RootModel):
     @classmethod
     def from_file(cls, manifest_path: Path) -> Self:
         """Load the export manifest from the JSON file."""
-        with manifest_path.open("r", encoding="utf-8") as file:
-            content = file.read()
-
-        if not content.strip():
+        if manifest_path.stat().st_size == 0:
             return cls()
 
-        return cls.model_validate(json.loads(content))
+        with manifest_path.open("r", encoding="utf-8") as file:
+            return cls.model_validate(json.load(file))
 
     def add_entry(self, absolute_path: Path) -> None:
         """Append a new file to the manifest."""

--- a/tests/test_units/test_manifest.py
+++ b/tests/test_units/test_manifest.py
@@ -49,6 +49,16 @@ def test_export_manifest_from_file_not_exist(tmp_path: Path) -> None:
         ExportManifest.from_file(tmp_path / MANIFEST_FILENAME)
 
 
+def test_export_manifest_from_empty_file(tmp_path: Path) -> None:
+    """Test that an empty manifest file is loaded as a new manifest."""
+    manifest_path = tmp_path / MANIFEST_FILENAME
+    manifest_path.touch()
+
+    manifest = ExportManifest.from_file(manifest_path)
+
+    assert len(manifest) == 0
+
+
 def test_get_manifest_path_realization_context(runpath_no_dotfmu: Path) -> None:
     """Test that the manifest path is correctly derived in a realization context."""
     # check test assumption that the fixture points to the runpath


### PR DESCRIPTION
Resolves #1807

- Updated `_models.py` so `ExportManifest.from_file()` returns a fresh empty manifest when the file is empty or whitespace-only. 
- Nonexistent files and malformed non-empty JSON retain their existing error behavior.
- Added the regression test in `test_manifest.py`.

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
