### PR TITLE
DOC: remove outdated claim

### DIFF
--- a/docs/src/simple_exports/structure_depth_fault_surfaces.md
+++ b/docs/src/simple_exports/structure_depth_fault_surfaces.md
@@ -39,9 +39,6 @@ will be `share/results/maps/structure_depth_fault_surface/f1.ts`.
 The `.ts` file extension indicates that the file represents the fault surface
 in the TSurf file format.
 
-The file content has been validated using a Pydantic model representing
-TSurf data.
-
 ## Standard result schema
 
 This standard result is not presented in a tabular format; therefore, no


### PR DESCRIPTION
Resolves #1832 

Removes outdated claim in documentation for `structure_depth_fault_surfaces`

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
