### PR TITLE
BUG:Fix fail on symbolic links

### DIFF
--- a/src/fmu/dataio/_workflows/copy_preprocessed.py
+++ b/src/fmu/dataio/_workflows/copy_preprocessed.py
@@ -78,7 +78,11 @@ def copy_preprocessed_data_main(args: argparse.Namespace) -> None:
 
     searchpath = Path(args.ert_config_path) / args.inpath
     match_pattern = "[!.]*"  # ignore metafiles (starts with '.')
-    files = [f for f in searchpath.rglob(match_pattern) if f.is_file()]
+    files = [
+        filepath
+        for filepath in searchpath.rglob(match_pattern)
+        if filepath.is_file() and not filepath.is_symlink()
+    ]
     logger.debug("files found %s", files)
 
     if not files:

--- a/tests/test_ert_integration/test_wf_copy_preprocessed_data.py
+++ b/tests/test_ert_integration/test_wf_copy_preprocessed_data.py
@@ -53,6 +53,8 @@ def test_copy_preprocessed_runs_successfully(
     """Test that exporting preprocessed data works and that the metadata is updated"""
     monkeypatch.chdir(fmu_snakeoil_project)
     _export_preprocessed_data(drogon_global_config, regsurf)
+    preprocessed_maps = fmu_snakeoil_project / "share/preprocessed/maps"
+    (preprocessed_maps / "linked.gri").symlink_to(preprocessed_maps / "topvolon.gri")
 
     ert_model_path = fmu_snakeoil_project / "ert/model"
     monkeypatch.chdir(ert_model_path)
@@ -78,6 +80,7 @@ def test_copy_preprocessed_runs_successfully(
     assert (observations_folder / "maps/.topvolon.gri.yml").exists()
     assert (observations_folder / "maps/mysubfolder/topvolantis.gri").exists()
     assert (observations_folder / "maps/mysubfolder/.topvolantis.gri.yml").exists()
+    assert not (observations_folder / "maps/linked.gri").exists()
 
     # check one of the metafiles to see that the fmu block has been added
     metafile = observations_folder / "maps/.topvolon.gri.yml"


### PR DESCRIPTION
Resolves #1719 

- Updated the `WF_COPY_PREPROCESSED_DATAIO` workflow to exclude symbolic links from discovered files.
- Added not `filepath.is_symlink()` to the file filter in `copy_preprocessed.py.`
- Added an integration regression case ensuring a symlink is not copied in` test_wf_copy_preprocessed_data.py.`


## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
