### PR TITLE
ENH: Improve error message when missing config data

### DIFF
--- a/src/fmu/dataio/_global_config.py
+++ b/src/fmu/dataio/_global_config.py
@@ -9,6 +9,7 @@ import pydantic
 import yaml
 
 from fmu.dataio._logging import null_logger
+from fmu.dataio._runcontext import FMUEnvironment
 from fmu.dataio.exceptions import ValidationError
 from fmu.datamodels.fmu_results.global_configuration import (
     Access,
@@ -30,6 +31,7 @@ _FMU_SETTINGS_URL = "https://equinor.github.io/fmu-settings"
 _GETTING_STARTED_URL = (
     "https://fmu-dataio.readthedocs.io/en/latest/getting_started.html"
 )
+_REQUIRED_GLOBAL_CONFIG_FIELDS: Final = ("masterdata", "access", "model")
 
 
 def warn_invalid_global_configuration(err: ValidationError) -> None:
@@ -99,6 +101,13 @@ def get_stratigraphy_element_from_config(
     return None
 
 
+def _missing_required_fields_in_config(config_dict: dict[str, Any]) -> list[str]:
+    """Return missing top-level required fields for GlobalConfiguration."""
+    return [
+        field for field in _REQUIRED_GLOBAL_CONFIG_FIELDS if field not in config_dict
+    ]
+
+
 def build_global_configuration(
     config_dict: dict[str, Any], standard_result: bool = False
 ) -> GlobalConfiguration:
@@ -106,31 +115,54 @@ def build_global_configuration(
 
     Raises:
         ValidationError: If `config_dict` does not validate. The message summarizes
-            the problem in a user-facing way and includes the underlying pydantic
-            errors.
+            the problem in a user-facing way.
     """
+    config_dict = config_dict or {}
+
     try:
         return GlobalConfiguration.model_validate(config_dict)
     except pydantic.ValidationError as err:
-        summary = (
-            "The global configuration was not provided."
-            if not config_dict
-            else "The global configuration is invalid."
-        )
+        logger.debug("Global configuration validation failed.", exc_info=True)
 
-        parts = [summary]
+        message = ["The global configuration is invalid."]
+
         if standard_result:
-            parts.append(
+            message.append(
                 "Exporting standard results requires a valid global configuration."
             )
-        if "masterdata" not in (config_dict or {}):
-            parts.append(
-                "Follow the 'Getting started' steps to do the necessary setup:\n"
-                f"{_GETTING_STARTED_URL}"
-            )
-        parts.append(f"Detailed information:\n{err}")
 
-        raise ValidationError("\n\n".join(parts)) from err
+        missing_fields = _missing_required_fields_in_config(config_dict)
+
+        if not missing_fields:
+            # if error is not due to missing fields include the error
+            message.append(f"Detailed information:\n{err}")
+            raise ValidationError("\n\n".join(message)) from None
+
+        message.append(
+            "The following required entries are missing:\n"
+            + "\n".join(f"  - {field}" for field in missing_fields)
+        )
+
+        message.append(
+            "Follow the 'Getting started' steps to complete the setup. "
+            "We recommend using FMU Settings for the configuration.\n"
+            f"{_GETTING_STARTED_URL}"
+        )
+
+        # If all fields are missing when running inside ERT
+        # it may be due to .fmu not being copied to scratch.
+        running_inside_ert = FMUEnvironment.from_env().fmu_context is not None
+        if (
+            set(missing_fields) == set(_REQUIRED_GLOBAL_CONFIG_FIELDS)
+            and running_inside_ert
+        ):
+            message.append(
+                "Note: If you are already onboarded to FMU Settings, make sure "
+                "the 'WF_CREATE_CASE_METADATA' workflow is included in your "
+                "ERT config so `.fmu/` is copied to scratch.\n"
+            )
+
+        raise ValidationError("\n\n".join(message)) from None
 
 
 def load_global_config_from_global_variables(

--- a/tests/test_units/test_global_config.py
+++ b/tests/test_units/test_global_config.py
@@ -11,6 +11,7 @@ from fmu.settings._drogon import create_drogon_fmu_dir
 from pytest import MonkeyPatch
 
 from fmu.dataio._global_config import (
+    _missing_required_fields_in_config,
     _resolve_global_config_path,
     build_global_configuration,
     get_stratigraphy_element_from_config,
@@ -19,6 +20,7 @@ from fmu.dataio._global_config import (
     load_global_config_from_fmu_settings,
     load_global_config_from_global_variables,
 )
+from fmu.dataio._runcontext import FMUEnvironment
 from fmu.dataio.exceptions import ValidationError
 
 
@@ -44,6 +46,98 @@ def test_build_global_configuration_missing_masterdata(
 
     with pytest.raises(ValidationError, match="https://fmu-dataio.readthedocs.io"):
         build_global_configuration(mock_global_config)
+
+
+def test_build_global_configuration_shows_details_for_invalid_fields(
+    mock_global_config: dict[str, Any],
+) -> None:
+    """Pydantic error is shown for invalid fields."""
+    invalid_type_config = dict(mock_global_config)
+    invalid_type_config["model"] = "not-a-model"  # should be a dict
+
+    with pytest.raises(ValidationError) as err_info:
+        build_global_configuration(invalid_type_config)
+
+    assert "Detailed information:" in str(err_info.value)
+    assert "The following required entries are missing:" not in str(err_info.value)
+
+
+def test_build_global_configuration_omits_details_when_missing_fields() -> None:
+    """Pydantic error is not shown for missing fields."""
+
+    with pytest.raises(ValidationError) as err_info:
+        build_global_configuration({})
+
+    assert "Detailed information:" not in str(err_info.value)
+    assert "The following required entries are missing:" in str(err_info.value)
+
+
+@pytest.mark.parametrize(
+    "missing_fields",
+    [["access", "model"], [], ["masterdata", "access", "model"], ["masterdata"]],
+)
+def test_missing_required_fields_in_config(
+    mock_global_config: dict[str, Any], missing_fields: list[str]
+) -> None:
+    """Utility identifies missing required top-level fields in stable order."""
+
+    for field in missing_fields:
+        del mock_global_config[field]
+
+    result = _missing_required_fields_in_config(mock_global_config)
+    assert result == missing_fields
+
+
+def test_build_global_configuration_includes_workflow_note_inside_ert(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """
+    WF_CREATE_CASE_METADATA note is shown when running inside ERT
+    and all required fields are missing.
+    """
+
+    # make sure the test is running inside ERT context
+    monkeypatch.setenv("_ERT_RUNPATH", "/fmu-case/realization-0/iter-0")
+    assert FMUEnvironment.from_env().fmu_context is not None
+
+    with pytest.raises(ValidationError) as err_info:
+        build_global_configuration({})
+
+    assert "WF_CREATE_CASE_METADATA" in str(err_info.value)
+
+
+def test_build_global_configuration_omits_workflow_note_inside_ert_partial_setup(
+    monkeypatch: MonkeyPatch,
+    mock_global_config: dict[str, Any],
+) -> None:
+    """
+    WF_CREATE_CASE_METADATA note is not shown when running inside ERT
+    and only some required fields are missing.
+    """
+
+    # make sure the test is running inside ERT context
+    monkeypatch.setenv("_ERT_RUNPATH", "/fmu-case/realization-0/iter-0")
+    assert FMUEnvironment.from_env().fmu_context is not None
+
+    # partial setup: some required fields are present, but one is missing
+    del mock_global_config["masterdata"]
+
+    with pytest.raises(ValidationError) as err_info:
+        build_global_configuration(mock_global_config)
+
+    assert "WF_CREATE_CASE_METADATA" not in str(err_info.value)
+
+
+def test_build_global_configuration_omits_workflow_note_outside_ert() -> None:
+    """WF_CREATE_CASE_METADATA note is not shown when outside ERT."""
+
+    # make sure the test is running outside ERT context
+    assert FMUEnvironment.from_env().fmu_context is None
+
+    with pytest.raises(ValidationError) as err_info:
+        build_global_configuration({})
+
+    assert "WF_CREATE_CASE_METADATA" not in str(err_info.value)
 
 
 def test_build_global_configuration_standard_result(

--- a/tests/test_units/test_rms_context.py
+++ b/tests/test_units/test_rms_context.py
@@ -787,7 +787,7 @@ def test_gridproperty_export_with_geometry_lacking_metadata(
         ).export(gridproperty)
 
     # with invalid config the export works but produces no metadata
-    with pytest.warns(UserWarning, match="global configuration was not provided"):
+    with pytest.warns(UserWarning, match="The global configuration is invalid"):
         prop_output = dataio.ExportData(
             config={},
             content="property",

--- a/uv.lock
+++ b/uv.lock
@@ -1406,7 +1406,7 @@ requires-dist = [
     { name = "autodoc-pydantic", marker = "extra == 'docs'", specifier = ">=2.0.0" },
     { name = "coverage", marker = "extra == 'dev'", specifier = ">=4.1" },
     { name = "ert", marker = "extra == 'dev'", specifier = ">=22" },
-    { name = "fmu-datamodels", specifier = "~=0.25.0" },
+    { name = "fmu-datamodels", specifier = "~=0.25.3" },
     { name = "fmu-settings", specifier = ">=0.34.0" },
     { name = "fmu-sumo" },
     { name = "furo", marker = "extra == 'docs'" },


### PR DESCRIPTION
Resolves #1815 
Resolves #1751 

PR to improve the error message when the .fmu or global variables are missing data. 

- A note about the `WF_CREATE_CASE_METADATA` and it's importance regarding `.fmu` is given when running inside ERT.
- Missing fields are listed instead of the user having to interpret it from an pydantic validation message. 
- The validation message from pydantic is omitted if the error is due to a missing field, but included for other messages. 


## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
